### PR TITLE
Added depreciation and future warning decorators; More debug statements

### DIFF
--- a/serpentTools/__init__.py
+++ b/serpentTools/__init__.py
@@ -5,13 +5,14 @@ ROOT_DIR = os.path.dirname(__file__)
 from serpentTools import settings
 
 # List TODOS/feature requests here for now
-# Compatability
+# Compatibility
 # TODO: Python 2 support
 # TODO: Test compatibility with earlier numpy releases
 # Usage/scripting
 # TODO: Update rc with dictionary
 # TODO: Update rc with yaml file into dictionary
 # TODO: Capture materials with underscores for depletion
+# TODO: Find a way to capture some or all of log messages for testing
 
 from ._version import get_versions
 __version__ = get_versions()['version']

--- a/serpentTools/objects/materials.py
+++ b/serpentTools/objects/materials.py
@@ -3,7 +3,7 @@
 import numpy
 from matplotlib import pyplot
 
-
+from serpentTools.settings import messages
 from serpentTools.objects import _NamedObject
 
 
@@ -62,6 +62,7 @@ class DepletedMaterial(_NamedObject):
             List of strings corresponding to the raw data from the file
         """
         newName = self._convertVariableName(variable)
+        messages.debug('Adding {} data to {}'.format(newName, self.name))
         if isinstance(rawData, str):
             scratch = [float(item) for item in rawData.split()]
         else:

--- a/serpentTools/settings/messages.py
+++ b/serpentTools/settings/messages.py
@@ -101,6 +101,7 @@ class __functionHerald__(object):
         decorated.__name__ = f.__name__
         decorated.__doc__ = f.__doc__
         decorated.__dict__.update(f.__dict__)
+        decorated.__repr__ = f.__repr__
         return decorated
 
     def __notify__(self):

--- a/serpentTools/settings/messages.py
+++ b/serpentTools/settings/messages.py
@@ -79,3 +79,35 @@ def updateLevel(level):
     else:
         __logger__.setLevel(level.upper())
         return level
+
+
+def depreciatedWarning(message):
+    DeprecationWarning(message)
+    warning('DEPRECIATED: ' + message)
+
+
+def futureWarning(message):
+    FutureWarning(message)
+    warning('FUTURE: ' + message)
+
+
+def depreciatedFunc(functionName):
+    """Iindicate that a function/method will be depreciated."""
+    def funcWrapper(f):
+        def decorated(*args, **kwargs):
+            depreciatedWarning('Function {} will be depreciated'
+                               .format(functionName))
+            return f(*args, **kwargs)
+        return decorated
+    return funcWrapper
+
+
+def functionWillChange(changeMessage):
+    """Indicate that a function/method will change in the future."""
+    def funcWrapper(f):
+        def decorated(*args, **kwargs):
+            futureWarning(changeMessage)
+            return f(*args, **kwargs)
+        return decorated
+    return funcWrapper
+

--- a/serpentTools/settings/messages.py
+++ b/serpentTools/settings/messages.py
@@ -74,8 +74,8 @@ def updateLevel(level):
     """Set the level of the logger."""
     if level.lower() not in LOG_OPTS:
         __logger__.setLevel('INFO')
-        warning('Logger option {} not in options. Set to warning.')
-        return 'warning'
+        warning('Logger option {} not in options. Set to info.'.format(level))
+        return 'info'
     else:
         __logger__.setLevel(level.upper())
         return level

--- a/serpentTools/settings/messages.py
+++ b/serpentTools/settings/messages.py
@@ -83,31 +83,46 @@ def updateLevel(level):
 
 def depreciatedWarning(message):
     DeprecationWarning(message)
-    warning('DEPRECIATED: ' + message)
+    warning(message)
 
 
 def futureWarning(message):
     FutureWarning(message)
-    warning('FUTURE: ' + message)
+    warning(message)
 
 
-def depreciatedFunc(functionName):
-    """Iindicate that a function/method will be depreciated."""
-    def funcWrapper(f):
+class __functionHerald__(object):
+    """Decorator that raises a message when the decorated function is called."""
+
+    def __call__(self, f):
         def decorated(*args, **kwargs):
-            depreciatedWarning('Function {} will be depreciated'
-                               .format(functionName))
+            self.__notify__()
             return f(*args, **kwargs)
+        decorated.__name__ = f.__name__
+        decorated.__doc__ = f.__doc__
+        decorated.__dict__.update(f.__dict__)
         return decorated
-    return funcWrapper
+
+    def __notify__(self):
+        raise NotImplementedError
 
 
-def functionWillChange(changeMessage):
-    """Indicate that a function/method will change in the future."""
-    def funcWrapper(f):
-        def decorated(*args, **kwargs):
-            futureWarning(changeMessage)
-            return f(*args, **kwargs)
-        return decorated
-    return funcWrapper
+class DepreciatedFunction(__functionHerald__):
+    """Decorator that notifies the user a function will be depreciated."""
+    def __init__(self, functionName, depreciatedVersion):
+        self.functionName = functionName
+        self.depVersion = depreciatedVersion
 
+    def __notify__(self):
+        depreciatedWarning('Function {} will be depreciated as of '
+                           'version {}'
+                           .format(self.functionName, self.depVersion))
+
+
+class ChangedFunction(__functionHerald__):
+    """Decorator that notifies the user a function will be changed."""
+    def __init__(self, message):
+        self.message = message
+
+    def __notify__(self):
+        futureWarning(self.message)

--- a/serpentTools/tests/test_settings.py
+++ b/serpentTools/tests/test_settings.py
@@ -2,6 +2,7 @@
 import unittest
 
 from serpentTools import settings
+from serpentTools.settings.messages import DepreciatedFunction, ChangedFunction
 
 
 class DefaultSettingsTester(unittest.TestCase):
@@ -97,6 +98,34 @@ class RCTester(unittest.TestCase):
             tempRC['xs.variableGroups'] = groupNames
             actual = tempRC.expandVariables()
         self.assertSetEqual(expected, actual)
+
+
+class MessagingTester(unittest.TestCase):
+    """Class to test the messaging framework."""
+
+    def test_futureDecorator(self):
+        """Verify that the future decorator doesn't break"""
+
+        @ChangedFunction('This function will be updated in the future, '
+                         'but will still exist')
+        def demoFuture(x, val=5):
+            return x + val
+
+        self._testSuite(demoFuture)
+
+    def test_depreciatedDecorator(self):
+        """Verify that the depreciated decorator doesn't break things"""
+
+        @DepreciatedFunction('demo function', '1.0')
+        def demoFunction(x, val=5):
+            return x + val
+
+        self._testSuite(demoFunction)
+
+    def _testSuite(self, func):
+        self.assertEqual(7, func(2))
+        self.assertEqual(7, func(2, 5))
+        self.assertEqual(7, func(2, val=5))
 
 
 if __name__ == '__main__':

--- a/serpentTools/tests/test_settings.py
+++ b/serpentTools/tests/test_settings.py
@@ -2,7 +2,7 @@
 import unittest
 
 from serpentTools import settings
-from serpentTools.settings.messages import DepreciatedFunction, ChangedFunction
+from serpentTools.settings.messages import depreciated, willChange
 
 
 class DefaultSettingsTester(unittest.TestCase):
@@ -106,26 +106,23 @@ class MessagingTester(unittest.TestCase):
     def test_futureDecorator(self):
         """Verify that the future decorator doesn't break"""
 
-        @ChangedFunction('This function will be updated in the future, '
-                         'but will still exist')
+        @willChange('This function will be updated in the future, '
+                    'but will still exist')
         def demoFuture(x, val=5):
             return x + val
 
-        self._testSuite(demoFuture)
+        self.assertEqual(7, demoFuture(2))
+        self.assertEqual(7, demoFuture(2, 5))
 
     def test_depreciatedDecorator(self):
         """Verify that the depreciated decorator doesn't break things"""
 
-        @DepreciatedFunction('demo function', '1.0')
+        @depreciated
         def demoFunction(x, val=5):
             return x + val
 
-        self._testSuite(demoFunction)
-
-    def _testSuite(self, func):
-        self.assertEqual(7, func(2))
-        self.assertEqual(7, func(2, 5))
-        self.assertEqual(7, func(2, val=5))
+        self.assertEqual(7, demoFunction(2))
+        self.assertEqual(7, demoFunction(2, 5))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- Changed info messages to debug messages for DepletionReader
- Added more debug statements for adding materials and adding data to those materials
- Added two decorators to notify users of functionality that may be changed or non-existent on the future

Closes #33 

## Decorators
The two new decorators are `depreciated` and `willChange`. These are to decorate functions in the following manner
```
@depreciated
def foo(*args, **kwargs):
    <do some things>
    <return something or not>

foo(arg, kwarg0=True)
# prints the following warning
# WARNING : serpentTools   : Call to depreciated function foo

@willChange('this function will return None in version 1.0)
def bar(*args, **kwargs):
    return True

bar(None)
# prints the following warning
# WARNING : serpentTools   : this function will return None in version 1.0
```

These should be used if a function/method is to be retired (depreciated) in future versions, or if the functionality will change.

## See Also
-  [The decorators they don't tell you about - Chase Stevens](https://github.com/hchasestevens/posts/blob/master/notebooks/the-decorators-they-wont-tell-you-about.ipynb#blob_contributors_box)
-  [Class decorators with arguments- Bruce Eckel](https://www.artima.com/weblogs/viewpost.jsp?thread=240845)
