### PR TITLE
Updated setup.py to use distutils

### DIFF
--- a/docs/about.rst
+++ b/docs/about.rst
@@ -1,6 +1,30 @@
 
 .. include:: ../README.rst
 
+Installation
+------------
+
+The ``serpentTools`` package can be downloaded either as a git repository or
+as a zipped file. Both can be obtained through the ``Clone or download`` option
+at the 
+`serpent-tools GitHub <https://github.com/CORE-GATECH-GROUP/serpent-tools>`_.
+
+Once the repository has been downloaded or extracted from zip, the package 
+can be installed with::
+
+    cd serpentTools
+    python setup.py install
+    python setup.py test
+
+Installing with `setuptools <https://pypi.python.org/pypi/setuptools/38.2.4>`_
+is preferred over the standard ``distutils`` module. ``setuptools`` can be
+installed with ``pip`` as::
+
+    pip install -U setuptools
+
+Installing in this manner ensures that the supporting packages,
+like ``numpy`` are installed and up to date.
+
 License
 -------
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,13 @@
 from os.path import join, dirname
 from os import getenv
-from setuptools import setup
+try:
+    from setuptools import setup
+    HAS_SETUPTOOLS = True
+except ImportError:
+    import warnings
+    from distutils.core import setup
+    warnings.warn('Installing with distutils. Use of setuptools is preferred')
+    HAS_SETUPTOOLS = False
 
 import versioneer
 
@@ -8,7 +15,15 @@ with open('README.rst') as readme:
     longDesc = readme.read()
 
 classifiers = [
+    'Development Status :: 3 - Alpha',
+    'Intended Audience :: Education',
+    'Intended Audience :: Science/Research',
     'License :: OSI Approved :: MIT License',
+    'Natural Language :: English',
+    'Programming Language :: Python',
+    'Programming Language :: Python :: 2.7',
+    'Programming Language :: Python :: 3.5',
+    'Programming Language :: Python :: 3.6'
 ]
 
 installRequires = [
@@ -26,29 +41,39 @@ if not getenv('ONTRAVIS', False):
 
 installVarYamlFrom = join('serpentTools', 'variables.yaml')
 
-pythonRequires = '>=3.5'
+pythonRequires = '>=2.7,!=3.0,!=3.1,!=3.2,!=3.3,!=3.4'
 
 setupArgs = {
     'name': 'serpentTools',
-    'python_requires': pythonRequires,
     'packages': ['serpentTools', 'serpentTools.parsers',
                  'serpentTools.objects'],
     'url': 'https://github.com/CORE-GATECH-GROUP/serpent-tools',
     'description': ('A suite of parsers designed to make interacting with '
                     'SERPENT output files simple, scriptable, and flawless'),
     'long_description': longDesc,
-    'test_suite': 'serpentTools.tests',
     'author': 'Andrew Johnson',
     'author_email': 'ajohnson400@gatech.edu',
     'maintainer': 'Dan Kotlyar',
     'maintainer_email': 'dan.kotlyar@me.gatech.edu',
     'classifiers': classifiers,
-    'install_requires': installRequires,
     'keywords': 'SERPENT file parsers transport',
     'license': 'MIT',
     'version': versioneer.get_version(),
     'cmdclass': versioneer.get_cmdclass(),
     'data_files': [(dirname(installVarYamlFrom), [installVarYamlFrom])]
 }
+if HAS_SETUPTOOLS:
+    setupArgs.update({
+        'python_requires': pythonRequires,
+        'install_requires': installRequires,
+        'test_suite': 'serpentTools.tests'
+    })
 
 setup(**setupArgs)
+
+if not HAS_SETUPTOOLS:
+    warnings.warn(
+            'The following packages are required to use serpentTools version '
+            '{}:\n{}\nPlease ensure they are installed prior to use'
+            .format(versioneer.get_version(), '\n'.join(installRequires)))
+


### PR DESCRIPTION
Using setuptools is preferred because that way packages like numpy are automatically installed and updated. Warnings are raised if distutils is used.

documentation also includes comments on installing the package and preferrence of setuptools