### PR TITLE
Cleanup containers

### DIFF
--- a/serpentTools/__init__.py
+++ b/serpentTools/__init__.py
@@ -4,16 +4,6 @@ ROOT_DIR = os.path.dirname(__file__)
 
 from serpentTools.parsers import read
 from serpentTools import messages
-
-# List TODOS/feature requests here for now
-# Compatibility
-# TODO: Test compatibility with earlier numpy releases
-# Usage/scripting
-# TODO: Update rc with dictionary
-# TODO: Update rc with yaml file into dictionary
-# TODO: Capture materials with underscores for depletion
-# TODO: Find a way to capture some or all of log messages for testing
-
 from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions

--- a/serpentTools/messages.py
+++ b/serpentTools/messages.py
@@ -58,7 +58,7 @@ def info(message):
 
 
 def warning(message):
-    """Log a warning that something that could go wrong or should be avoided."""
+    """Log a warning that something could go wrong or should be avoided."""
     __logger__.warning('%s', message)
 
 

--- a/serpentTools/objects/__init__.py
+++ b/serpentTools/objects/__init__.py
@@ -1,44 +1,24 @@
 """Objects used to support the parsing."""
 
 
-class SupportingObject(object):
-    """
-    Base supporting object.
-
-    Parameters
-    ----------
-    container: Some parser from serpentTools.parsers
-        Container that created this object
-
-    """
-
-    def __init__(self, container):
-        self.filePath = container.filePath
-
-    def __str__(self):
-        return '<{} from {}>'.format(self.__class__.__name__, self.filePath)
-
-    @staticmethod
-    def _convertVariableName(variable):
-        """Converta a SERPENT variable to camelCase."""
-        lowerSplits = [item.lower() for item in variable.split('_')]
-        if len(lowerSplits) == 1:
-            return lowerSplits[0]
-        else:
-            return lowerSplits[0] + ''.join([item.capitalize()
-                                             for item in lowerSplits[1:]])
-
-
-class NamedObject(SupportingObject):
+class NamedObject(object):
     """Class for named objects like materials and detectors."""
 
-    def __init__(self, container, name):
-        SupportingObject.__init__(self, container)
+    def __init__(self, name):
         self.name = name
 
     def __str__(self):
-        return '<{} {} from {}>'.format(self.__class__.__name__,
-                                        self.name, self.filePath)
+        return '<{} {}>'.format(self.__class__.__name__, self.name)
+
+
+def convertVariableName(variable):
+    """Convert a SERPENT variable to camelCase"""
+    lowerSplits = [item.lower() for item in variable.split('_')]
+    if len(lowerSplits) == 1:
+        return lowerSplits[0]
+    else:
+        return lowerSplits[0] + ''.join([item.capitalize()
+                                         for item in lowerSplits[1:]])
 
 
 def splitItems(items):

--- a/serpentTools/objects/materials.py
+++ b/serpentTools/objects/materials.py
@@ -4,7 +4,7 @@ import numpy
 from matplotlib import pyplot
 
 from serpentTools import messages
-from serpentTools.objects import NamedObject
+from serpentTools.objects import NamedObject, convertVariableName
 
 
 class DepletedMaterial(NamedObject):
@@ -26,7 +26,7 @@ class DepletedMaterial(NamedObject):
     names: numpy.array or None
         Names of isotopes
     days: numpy.array or None
-        Days overwhich the material was depleted
+        Days over which the material was depleted
     adens: numpy.array or None
         Atomic density over time for each nuclide
     mdens: numpy.array or None
@@ -37,14 +37,15 @@ class DepletedMaterial(NamedObject):
     """
 
     def __init__(self, parser, name):
-        NamedObject.__init__(self, parser, name)
+        NamedObject.__init__(self, name)
         self.data = {}
         self.zai = parser.metadata.get('zai', None)
         self.names = parser.metadata.get('names', None)
         self.days = parser.metadata.get('days', None)
-        self.__burnup__ = None
-        self.__adens__ = None
-        self.__mdens__ = None
+        self.filePath = parser.filePath
+        self.__burnup = None
+        self.__adens = None
+        self.__mdens = None
 
     def __getitem__(self, item):
         if item not in self.data:
@@ -57,27 +58,27 @@ class DepletedMaterial(NamedObject):
         if 'burnup' not in self.data:
             raise AttributeError('Burnup for material {} has not been loaded'
                                  .format(self.name))
-        if self.__burnup__ is None:
-            self.__burnup__ = self.data['burnup']
-        return self.__burnup__
+        if self.__burnup is None:
+            self.__burnup = self.data['burnup']
+        return self.__burnup
 
     @property
     def adens(self):
         if 'adens' not in self.data:
             raise AttributeError('Atomic densities for material {} have not '
                                  'been loaded'.format(self.name))
-        if self.__adens__ is None:
-            self.__adens__ = self.data['adens']
-        return self.__adens__
+        if self.__adens is None:
+            self.__adens = self.data['adens']
+        return self.__adens
 
     @property
     def mdens(self):
         if 'mdens' not in self.data:
             raise AttributeError('Mass densities for material {} has not been '
                                  'loaded'.format(self.name))
-        if self.__mdens__ is None:
-            self.__mdens__ = self.data['mdens']
-        return self.__mdens__
+        if self.__mdens is None:
+            self.__mdens = self.data['mdens']
+        return self.__mdens
 
     def addData(self, variable, rawData):
         """
@@ -90,7 +91,7 @@ class DepletedMaterial(NamedObject):
         rawData: list
             List of strings corresponding to the raw data from the file
         """
-        newName = self._convertVariableName(variable)
+        newName = convertVariableName(variable)
         messages.debug('Adding {} data to {}'.format(newName, self.name))
         if isinstance(rawData, str):
             scratch = [float(item) for item in rawData.split()]
@@ -148,8 +149,8 @@ class DepletedMaterial(NamedObject):
         if timePoints is not None:
             timeCheck = self._checkTimePoints(xUnits, timePoints)
             if any(timeCheck):
-                raise KeyError('The following times were not present in file {}'
-                               '\n{}'.format(self.filePath,
+                raise KeyError('The following times were not present in file'
+                               '{}\n{}'.format(self.filePath,
                                              ', '.join(timeCheck)))
         if names and self.names is None:
             raise AttributeError(

--- a/serpentTools/parsers/__init__.py
+++ b/serpentTools/parsers/__init__.py
@@ -70,7 +70,8 @@ def inferReader(filePath):
     for reg, reader in six.iteritems(REGEXES):
         match = re.match(reg, filePath)
         if match and match.group() == filePath:
-            info('Inferred reader for {}: {}'.format(filePath, reader.__name__))
+            info('Inferred reader for {}: {}'
+                 .format(filePath, reader.__name__))
             return reader
     raise SerpentToolsException(
         'Failed to infer filetype and thus accurate reader from'
@@ -140,7 +141,8 @@ def read(filePath, reader='infer'):
                     'Reader type {} not supported'.format(reader)
                 )
     else:
-        assert callable(reader), 'Reader {} is not callable'.format(str(reader))
+        assert callable(reader), (
+                'Reader {} is not callable'.format(str(reader)))
         loader = reader
     returnedFromLoader = loader(filePath)
     returnedFromLoader.read()
@@ -202,7 +204,8 @@ def depmtx(fileP):
         if not nMatch:
             raise SerpentToolsException(failMsg + line)
 
-        n0Storage, line, numIso = _parseIsoBlock(f, {}, nMatch, line, nDensRegex)
+        n0Storage, line, numIso = _parseIsoBlock(f, {}, nMatch, line,
+                                                 nDensRegex)
         debug('Found {} isotopes for file {}'.format(numIso, fileP))
         n0 = empty((numIso, 1), dtype=longfloat)
         for indx, v in six.iteritems(n0Storage):

--- a/serpentTools/parsers/branching.py
+++ b/serpentTools/parsers/branching.py
@@ -74,7 +74,8 @@ class BranchingReader(XSReader):
         if branchNames not in self.branches:
             branchState = self._processBranchStateData()
             self.branches[branchNames] = (
-                BranchContainer(self, coefIndx, branchNames, branchState))
+                BranchContainer(self.filePath, coefIndx, branchNames,
+                                branchState))
         else:
             self._advance()
         return self.branches[branchNames], int(totUniv)
@@ -98,7 +99,8 @@ class BranchingReader(XSReader):
         unvID, numVariables = [int(xx) for xx in self._advance()]
         univ = branch.addUniverse(unvID, burnup, burnupIndex)
         for step in range(numVariables):
-            splitList = self._advance(possibleEndOfFile=step == numVariables-1)
+            splitList = self._advance(
+                possibleEndOfFile=step == numVariables - 1)
             varName = splitList[0]
             varValues = [float(xx) for xx in splitList[2:]]
             if self._checkAddVariable(varName):

--- a/serpentTools/parsers/detector.py
+++ b/serpentTools/parsers/detector.py
@@ -69,17 +69,3 @@ class DetectorReader(BaseReader):
         detector.grids[binType] = data
         messages.debug('Added bin data {} to detector {}'
                        .format(binType, detName))
-
-
-if __name__ == '__main__':
-    from os.path import join
-    from matplotlib import pyplot
-    import serpentTools
-
-    det = DetectorReader(join(serpentTools.ROOT_DIR, 'tests', 'ref_det0.m'))
-    det.read()
-    xy = det.detectors['xyFissionCapt']
-    xy.plot(fixed={'reaction': 1, 'ymesh': 2})
-    pyplot.show()
-    xy.plot(fixed={'reaction': 1, 'ymesh': 2}, sigma=1)
-    pyplot.show()

--- a/serpentTools/parsers/detector.py
+++ b/serpentTools/parsers/detector.py
@@ -1,6 +1,5 @@
 """Parser responsible for reading the ``*det<n>.m`` files"""
 
-import six
 import numpy
 
 from serpentTools.engines import KeywordParser
@@ -60,7 +59,7 @@ class DetectorReader(BaseReader):
             data[indx] = [float(xx) for xx in line.split()]
         if detName not in self.detectors:
             # new detector, this data is the tallies
-            detector = Detector(self, detName)
+            detector = Detector(detName)
             detector.addTallyData(data)
             self.detectors[detName] = detector
             messages.debug('Adding detector {}'.format(detName))

--- a/serpentTools/settings.py
+++ b/serpentTools/settings.py
@@ -158,7 +158,7 @@ class DefaultSettingsLoader(dict):
         for name, value in defaultSettings.items():
             if 'options' in value:
                 options = (value['default'] if value['options'] == 'default'
-                else value['options'])
+                           else value['options'])
             else:
                 options = None
             settingsOptions = {'name': name,
@@ -278,8 +278,9 @@ class UserSettingsLoader(dict):
             dictionary
         """
         settings = {}
-        settingsPreffix = ([settingsPreffix] if isinstance(settingsPreffix, str)
-        else settingsPreffix)
+        settingsPreffix = (
+                [settingsPreffix] if isinstance(settingsPreffix, str)
+                else settingsPreffix)
         for setting, value in self.items():
             settingPath = setting.split('.')
             if settingPath[0] in settingsPreffix:
@@ -346,11 +347,11 @@ class UserSettingsLoader(dict):
         """
         messages.debug('Attempting to read from {}'.format(filePath))
         with open(filePath) as yFile:
-            l = yaml.safe_load(yFile)
+            loaded = yaml.safe_load(yFile)
         messages.info('Loading settings onto object with strict:{}'
                       .format(strict))
 
-        for key, value in six.iteritems(l):
+        for key, value in six.iteritems(loaded):
             if isinstance(value, dict):
                 self.__recursiveLoad(value, strict, key)
             else:

--- a/serpentTools/tests/test_container.py
+++ b/serpentTools/tests/test_container.py
@@ -10,7 +10,7 @@ class HomogenizedUniverseTester(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.univ = containers.HomogUniv(DepletionReader(None), 'dummy', 0, 0, 0)
+        cls.univ = containers.HomogUniv('dummy', 0, 0, 0)
         cls.Exp = {}
         cls.Unc = {}
         # Data definition


### PR DESCRIPTION
The SupportingObject class did not extend a lot of additional functionality, and would complicate the integration of objects that may not be connected to parsers, i.e. material objects #12 
This PR removes the SupportingObject. Now, containers either inherit directly from object or from NamedObject.

This PR also closes #81 by

- improved pep8 compliance (mainly line lengths)
- removed TODOs in module-level `__init__`
- Removed `if __name__ == '__main__'` blocks from some detector scripts