### PR TITLE
Pre/post check methods

### DIFF
--- a/serpentTools/objects/readers.py
+++ b/serpentTools/objects/readers.py
@@ -40,7 +40,7 @@ class BaseReader:
             This read function has not been implemented yet
 
         """
-        pass
+        raise NotImplementedError
 
     def _precheck(self):
         """Pre-checking, e.g., make sure Serpent did not

--- a/serpentTools/objects/readers.py
+++ b/serpentTools/objects/readers.py
@@ -1,3 +1,4 @@
+from abc import abstractmethod
 from serpentTools.settings import rc
 
 
@@ -26,6 +27,15 @@ class BaseReader(object):
         return '<{} reading {}>'.format(self.__class__.__name__, self.filePath)
 
     def read(self):
+        """The main method for reading that not only parses data, but also
+        runs pre and post checks.
+        """
+        self._precheck()
+        self._read()
+        self._postcheck()
+
+    @abstractmethod
+    def _read(self):
         """Read the file and store the data.
 
         :warning:
@@ -33,7 +43,22 @@ class BaseReader(object):
             This read function has not been implemented yet
 
         """
-        raise NotImplementedError
+        pass
+
+    @abstractmethod
+    def _precheck(self):
+        """Pre-checking, e.g., make sure Serpent did not
+        exit abnormally, or disk ran out of space while parsing.
+        """
+        pass
+
+    @abstractmethod
+    def _postcheck(self):
+        """Make sure data looks reasonable. Could possibly check for
+        negative cross sections, negative material densitites, etc (which
+        can happen if using the reprocessing interface incorrectly).
+        """
+        pass
 
 
 class MaterialReader(BaseReader):
@@ -42,9 +67,6 @@ class MaterialReader(BaseReader):
     def __init__(self, filePath, readerSettingsLevel):
         BaseReader.__init__(self, filePath, readerSettingsLevel)
         self.materials = {}
-
-    def read(self):
-        raise NotImplementedError
 
 
 class XSReader(BaseReader):
@@ -56,8 +78,6 @@ class XSReader(BaseReader):
         self.settings.pop('variableGroups')
         self.settings.pop('variableExtras')
 
-    def read(self):
-        raise NotImplementedError
 
     def _checkAddVariable(self, variableName):
         """Check if the data for the variable should be stored"""

--- a/serpentTools/objects/readers.py
+++ b/serpentTools/objects/readers.py
@@ -1,8 +1,6 @@
-from abc import abstractmethod
 from serpentTools.settings import rc
 
-
-class BaseReader(object):
+class BaseReader:
     """Parent class from which all parsers will inherit.
 
     Parameters
@@ -34,7 +32,6 @@ class BaseReader(object):
         self._read()
         self._postcheck()
 
-    @abstractmethod
     def _read(self):
         """Read the file and store the data.
 
@@ -45,14 +42,12 @@ class BaseReader(object):
         """
         pass
 
-    @abstractmethod
     def _precheck(self):
         """Pre-checking, e.g., make sure Serpent did not
         exit abnormally, or disk ran out of space while parsing.
         """
         pass
 
-    @abstractmethod
     def _postcheck(self):
         """Make sure data looks reasonable. Could possibly check for
         negative cross sections, negative material densitites, etc (which

--- a/serpentTools/parsers/branching.py
+++ b/serpentTools/parsers/branching.py
@@ -121,7 +121,11 @@ class BranchingReader(XSReader):
         """Currently, just grabs total number of coeff calcs
         """
         with open(self.filePath) as fObj:
-            self._totalBranches = int(fObj.readline().split()[1])
+            try:
+                self._totalBranches = int(fObj.readline().split()[1])
+            except:
+                error("COE output at {} likely malformatted or misnamed".format(
+                    self.filePath))
 
     def _postcheck(self):
         """Make sure Serpent finished printing output.

--- a/serpentTools/parsers/branching.py
+++ b/serpentTools/parsers/branching.py
@@ -69,9 +69,6 @@ class BranchingReader(XSReader):
         if header is None:
             return
         indx, runTot, coefIndx, totCoef, totUniv = header
-        # save total run number if it's not saved:
-        if self._totalBranches == None:
-            self._totalBranches = int(runTot)
         self._whereAmI['runIndx'] = int(indx)
         self._whereAmI['coefIndx'] = int(coefIndx)
         branchNames = tuple(self._advance()[1:])
@@ -121,9 +118,10 @@ class BranchingReader(XSReader):
             yield bID, b
 
     def _precheck(self):
-        """todo: is there a good precheck to do here?
+        """Currently, just grabs total number of coeff calcs
         """
-        pass
+        with open(self.filePath) as fObj:
+            self._totalBranches = int(fObj.readline().split()[1])
 
     def _postcheck(self):
         """Make sure Serpent finished printing output.

--- a/serpentTools/parsers/depletion.py
+++ b/serpentTools/parsers/depletion.py
@@ -47,9 +47,6 @@ class DepletionReader(MaterialReader):
         #  TOT_ADENS --> ('ADENS', )
         #  ING_TOX --> ('ING_TOX', )
 
-        # track how many materials appear in the file
-        self.materialCount = 0
-
     def _makeMaterialRegexs(self):
         """Return the patterns by which to find the requested materials."""
         patterns = self.settings['materials'] or ['.*']
@@ -137,14 +134,15 @@ class DepletionReader(MaterialReader):
     def _precheck(self):
         """do a quick scan to ensure this looks like a material file
         """
+        materialCount = 0
         with open(self.filePath) as fh:
             for line in fh:
                 sline = line.split()
                 if sline == []:
                     continue
                 elif 'MAT' == line.split()[0]:
-                    self.materialCount += 1
-        if self.materialCount == 0:
+                    materialCount += 1
+        if materialCount == 0:
             error("No materials found in {}".format(self.filePath))
 
         if not self.materials:

--- a/serpentTools/parsers/depletion.py
+++ b/serpentTools/parsers/depletion.py
@@ -7,7 +7,7 @@ from serpentTools.engines import KeywordParser
 from serpentTools.objects.readers import MaterialReader
 from serpentTools.objects.materials import DepletedMaterial
 
-from serpentTools import messages
+from serpentTools.messages import warning, info, debug
 
 
 class DepletionReader(MaterialReader):
@@ -52,12 +52,12 @@ class DepletionReader(MaterialReader):
         patterns = self.settings['materials'] or ['.*']
         # match all materials if nothing given
         if any(['_' in pat for pat in patterns]):
-            messages.warning('Materials with underscores are not supported.')
+            warning('Materials with underscores are not supported.')
         return [re.compile(mat) for mat in patterns]
 
-    def read(self):
+    def _read(self):
         """Read through the depletion file and store requested data."""
-        messages.info('Preparing to read {}'.format(self.filePath))
+        info('Preparing to read {}'.format(self.filePath))
         keys = ['MAT', 'TOT'] if self.settings['processTotal'] else ['MAT']
         keys.extend(self.settings['metadataKeys'])
         separators = ['\n', '];', '\r\n']
@@ -72,8 +72,8 @@ class DepletionReader(MaterialReader):
         if 'days' in self.metadata:
             for mKey in self.materials:
                 self.materials[mKey].days = self.metadata['days']
-        messages.info('Done reading depletion file')
-        messages.debug('  found {} materials'.format(len(self.materials)))
+        info('Done reading depletion file')
+        debug('  found {} materials'.format(len(self.materials)))
 
     def _addMetadata(self, chunk):
         options = {'ZAI': 'zai', 'NAMES': 'names', 'DAYS': 'days',
@@ -118,9 +118,9 @@ class DepletionReader(MaterialReader):
                 and variable not in self.settings['materialVariables']):
             return
         if name not in self.materials:
-            messages.debug('Adding material {}...'.format(name))
+            debug('Adding material {}...'.format(name))
             self.materials[name] = DepletedMaterial(self, name)
-            messages.debug('  added')
+            debug('  added')
         if len(chunk) == 1:  # single line values, e.g. volume or burnup
             cleaned = self._cleanSingleLine(chunk)
         else:
@@ -130,3 +130,13 @@ class DepletionReader(MaterialReader):
                     continue
                 cleaned.append(line[:line.index('%')])
         self.materials[name].addData(variable, cleaned)
+
+    def _precheck(self):
+        """todo
+        """
+        pass
+
+    def _postcheck(self):
+        """todo
+        """
+        pass

--- a/serpentTools/parsers/depletion.py
+++ b/serpentTools/parsers/depletion.py
@@ -135,7 +135,7 @@ class DepletionReader(MaterialReader):
         self.materials[name].addData(variable, cleaned)
 
     def _precheck(self):
-        """do a quick scan to see how many materials appear in the file
+        """do a quick scan to ensure this looks like a material file
         """
         with open(self.filePath) as fh:
             for line in fh:
@@ -144,10 +144,16 @@ class DepletionReader(MaterialReader):
                     continue
                 elif 'MAT' == line.split()[0]:
                     self.materialCount += 1
+        if self.materialCount == 0:
+            error("No materials found in {}".format(self.filePath))
+
+        if not self.materials:
+            error("0 materials to grab specified.")
 
     def _postcheck(self):
-        """ensure the parser grabbed the same number of counted materials
+        """ensure the parser grabbed expected materials
         """
-        if len(self.materials) != self.materialCount:
-            error("Did not parse as many materials as counted in file\n"
-                  "{}".format(self.filePath))
+        # checking if it is an instance of DepletedMaterial should
+        # work, since otherwise, self.materials[matname]
+        for mat in self.materials.values():
+            assert isinstance(mat, DepletedMaterial)

--- a/serpentTools/parsers/depletion.py
+++ b/serpentTools/parsers/depletion.py
@@ -7,7 +7,7 @@ from serpentTools.engines import KeywordParser
 from serpentTools.objects.readers import MaterialReader
 from serpentTools.objects.materials import DepletedMaterial
 
-from serpentTools.messages import warning, info, debug
+from serpentTools.messages import warning, info, debug, error
 
 
 class DepletionReader(MaterialReader):
@@ -46,6 +46,9 @@ class DepletionReader(MaterialReader):
         # Captures variables for total block from string::
         #  TOT_ADENS --> ('ADENS', )
         #  ING_TOX --> ('ING_TOX', )
+
+        # track how many materials appear in the file
+        self.materialCount = 0
 
     def _makeMaterialRegexs(self):
         """Return the patterns by which to find the requested materials."""
@@ -132,11 +135,19 @@ class DepletionReader(MaterialReader):
         self.materials[name].addData(variable, cleaned)
 
     def _precheck(self):
-        """todo
+        """do a quick scan to see how many materials appear in the file
         """
-        pass
+        with open(self.filePath) as fh:
+            for line in fh:
+                sline = line.split()
+                if sline == []:
+                    continue
+                elif 'MAT' == line.split()[0]:
+                    self.materialCount += 1
 
     def _postcheck(self):
-        """todo
+        """ensure the parser grabbed the same number of counted materials
         """
-        pass
+        if len(self.materials) != self.materialCount:
+            error("Did not parse as many materials as counted in file\n"
+                  "{}".format(self.filePath))

--- a/serpentTools/parsers/detector.py
+++ b/serpentTools/parsers/detector.py
@@ -31,7 +31,7 @@ class DetectorReader(BaseReader):
         else:
             self._loadAll = False
 
-    def read(self):
+    def _read(self):
         """Read the file and store the detectors."""
         keys = ['DET']
         separators = ['\n', '];']
@@ -69,3 +69,9 @@ class DetectorReader(BaseReader):
         detector.grids[binType] = data
         messages.debug('Added bin data {} to detector {}'
                        .format(binType, detName))
+
+    def _precheck(self):
+        pass
+
+    def _postcheck(self):
+        pass

--- a/serpentTools/parsers/detector.py
+++ b/serpentTools/parsers/detector.py
@@ -82,8 +82,5 @@ class DetectorReader(BaseReader):
                     continue
                 elif 'DET' in sline[0]:
                     self.detCount += 1
-
-    def _postcheck(self):
-        if self.detCount != len(self.detectors):
-            error("Did not parse expected number of detectors in file\n"
-                  "{}".format(self.filePath))
+        if self.detCount == 0:
+            error("No detectors found in {}".format(self.filePath))

--- a/serpentTools/parsers/detector.py
+++ b/serpentTools/parsers/detector.py
@@ -6,6 +6,7 @@ from serpentTools.engines import KeywordParser
 from serpentTools.objects.containers import Detector
 from serpentTools.settings import messages
 from serpentTools.objects.readers import BaseReader
+from serpentTools.messages import error
 
 NUM_COLS = 12
 # number of columns/bins in a single detector line
@@ -30,6 +31,7 @@ class DetectorReader(BaseReader):
             self._loadAll = True
         else:
             self._loadAll = False
+        self.detCount = 0 # how many dets in file?
 
     def _read(self):
         """Read the file and store the detectors."""
@@ -71,7 +73,17 @@ class DetectorReader(BaseReader):
                        .format(binType, detName))
 
     def _precheck(self):
-        pass
+        """ Count how many detectors are in the file
+        """
+        with open(self.filePath) as fh:
+            for line in fh:
+                sline = line.split()
+                if sline == []:
+                    continue
+                elif 'DET' in sline[0]:
+                    self.detCount += 1
 
     def _postcheck(self):
-        pass
+        if self.detCount != len(self.detectors):
+            error("Did not parse expected number of detectors in file\n"
+                  "{}".format(self.filePath))

--- a/serpentTools/parsers/detector.py
+++ b/serpentTools/parsers/detector.py
@@ -31,7 +31,6 @@ class DetectorReader(BaseReader):
             self._loadAll = True
         else:
             self._loadAll = False
-        self.detCount = 0 # how many dets in file?
 
     def _read(self):
         """Read the file and store the detectors."""
@@ -75,12 +74,13 @@ class DetectorReader(BaseReader):
     def _precheck(self):
         """ Count how many detectors are in the file
         """
+        detCount = 0
         with open(self.filePath) as fh:
             for line in fh:
                 sline = line.split()
                 if sline == []:
                     continue
                 elif 'DET' in sline[0]:
-                    self.detCount += 1
-        if self.detCount == 0:
+                    detCount += 1
+        if detCount == 0:
             error("No detectors found in {}".format(self.filePath))


### PR DESCRIPTION
Addresses #86 

This adds abstract methods to the BaseReader, XSReader, and MaterialReader classes for pre and post checks. I used the @abstractmethod from the Python default abc module, since this prevents accidental instantiation of base classes unlike raising NotImplementedError.

For the BranchingReader, the postcheck now determines if Serpent stopped early, and gives a messages.error if so. I tested this locally on some output, and am pretty sure it doesn't need a unit test since it's so simple.