### PR TITLE
Added codecov into travis build

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,6 @@
+# config file for coverage.py
+[run]
+branch = true
+source = serpentTools
+omit = serpentTools/_version.py
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
 
 # install
 install:
-  - pip install jupyter
+  - pip install jupyter codecov coverate
   - python setup.py install
 
 # use xvfb to give the plot functions something to use
@@ -22,5 +22,10 @@ before_script:
 
 # run
 script:
-  - pytest
+  - coverage run setup.py test 
   - ./testNotebooks.sh 
+
+# only if build succeeds
+after-success:
+  - codecov
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
 
 # install
 install:
-  - pip install jupyter codecov coverate
+  - pip install jupyter codecov coverage
   - python setup.py install
 
 # use xvfb to give the plot functions something to use


### PR DESCRIPTION
`.travis.yaml` now includes options for running code coverage.
Added `.coveragerc` to apply testing only to `serpentTools` objects, not third-party packages