### PR TITLE
Default to warning logging level; Quieter operation

### DIFF
--- a/serpentTools/messages.py
+++ b/serpentTools/messages.py
@@ -48,7 +48,7 @@ loggingConfig = {
     },
     'root': {
         'handlers': ['console'],
-        'level': logging.INFO
+        'level': logging.WARNING
     }
 }
 

--- a/serpentTools/objects/readers.py
+++ b/serpentTools/objects/readers.py
@@ -1,4 +1,5 @@
 from serpentTools.settings import rc
+from serpentTools.messages import info
 
 class BaseReader:
     """Parent class from which all parsers will inherit.
@@ -28,8 +29,10 @@ class BaseReader:
         """The main method for reading that not only parses data, but also
         runs pre and post checks.
         """
+        info("Reading {}".format(self.filePath))
         self._precheck()
         self._read()
+        info("  - done")
         self._postcheck()
 
     def _read(self):

--- a/serpentTools/parsers/__init__.py
+++ b/serpentTools/parsers/__init__.py
@@ -1,11 +1,5 @@
 """
 Package dedicated for reading ``SERPENT`` output files
-
-The :py:func:`serpentTools.parsers.read` function uses
-the following string arguments to infer the type of reader
-to be used.
-
-
 """
 from os import path
 import re
@@ -70,8 +64,8 @@ def inferReader(filePath):
     for reg, reader in six.iteritems(REGEXES):
         match = re.match(reg, filePath)
         if match and match.group() == filePath:
-            info('Inferred reader for {}: {}'
-                 .format(filePath, reader.__name__))
+            debug('Inferred reader for {}: {}'
+                  .format(filePath, reader.__name__))
             return reader
     raise SerpentToolsException(
         'Failed to infer filetype and thus accurate reader from'
@@ -190,7 +184,7 @@ def depmtx(fileP):
     failMsg = 'File {} is ill-formed for depmtx reader\nLine: '.format(fileP)
 
     if not HAS_SCIPY:
-        warning('Decay matrix will be returned as full matrix')
+        debug('Decay matrix will be returned as full matrix')
 
     with open(fileP) as f:
         line = f.readline()
@@ -265,3 +259,4 @@ def _parseIsoBlock(stream, storage, match, line, regex):
         line = stream.readline()
         match = re.match(regex, line)
     return storage, line, items
+

--- a/serpentTools/parsers/branching.py
+++ b/serpentTools/parsers/branching.py
@@ -17,6 +17,9 @@ class BranchingReader(XSReader):
     ----------
     filePath: str
         path to the depletion file
+
+    Attributes
+    ----------
     branches: dict
         Dictionary of branch names and their corresponding
         :py:class:`~serpentTools.objects.containers.BranchContainer`
@@ -33,12 +36,10 @@ class BranchingReader(XSReader):
 
     def _read(self):
         """Read the branching file and store the coefficients."""
-        info('Preparing to read {}'.format(self.filePath))
         with open(self.filePath) as fObj:
             self.__fileObj = fObj
             while self.__fileObj is not None:
                 self._processBranchBlock()
-        info('Done reading branching file')
 
     def _advance(self, possibleEndOfFile=False):
         if self.__fileObj is None:
@@ -122,8 +123,7 @@ class BranchingReader(XSReader):
             yield bID, b
 
     def _precheck(self):
-        """Currently, just grabs total number of coeff calcs
-        """
+        """Currently, just grabs total number of coeff calcs."""
         with open(self.filePath) as fObj:
             try:
                 self._totalBranches = int(fObj.readline().split()[1])
@@ -132,10 +132,8 @@ class BranchingReader(XSReader):
                     self.filePath))
 
     def _postcheck(self):
-        """Make sure Serpent finished printing output.
-        """
+        """Make sure Serpent finished printing output."""
 
         if self._totalBranches != self._whereAmI['runIndx']:
-            # maybe this should be an exception?
             error("Serpent appears to have stopped printing coefficient\n"
                     "mode output early for file {}".format(self.filePath))

--- a/serpentTools/parsers/depletion.py
+++ b/serpentTools/parsers/depletion.py
@@ -59,7 +59,6 @@ class DepletionReader(MaterialReader):
 
     def _read(self):
         """Read through the depletion file and store requested data."""
-        info('Preparing to read {}'.format(self.filePath))
         keys = ['MAT', 'TOT'] if self.settings['processTotal'] else ['MAT']
         keys.extend(self.settings['metadataKeys'])
         separators = ['\n', '];', '\r\n']
@@ -74,8 +73,6 @@ class DepletionReader(MaterialReader):
         if 'days' in self.metadata:
             for mKey in self.materials:
                 self.materials[mKey].days = self.metadata['days']
-        info('Done reading depletion file')
-        debug('  found {} materials'.format(len(self.materials)))
 
     def _addMetadata(self, chunk):
         options = {'ZAI': 'zai', 'NAMES': 'names', 'DAYS': 'days',
@@ -122,7 +119,6 @@ class DepletionReader(MaterialReader):
         if name not in self.materials:
             debug('Adding material {}...'.format(name))
             self.materials[name] = DepletedMaterial(name, self.metadata)
-            debug('  added')
         if len(chunk) == 1:  # single line values, e.g. volume or burnup
             cleaned = self._cleanSingleLine(chunk)
         else:
@@ -135,16 +131,14 @@ class DepletionReader(MaterialReader):
 
     def _precheck(self):
         """do a quick scan to ensure this looks like a material file."""
-        materialCount = 0
         with open(self.filePath) as fh:
             for line in fh:
                 sline = line.split()
                 if not sline:
                     continue
                 elif 'MAT' == line.split('_')[0]:
-                    materialCount += 1
-        if materialCount == 0:
-            error("No materials found in {}".format(self.filePath))
+                    return
+        error("No materials found in {}".format(self.filePath))
 
     def _postcheck(self):
         """ensure the parser grabbed expected materials."""
@@ -157,3 +151,5 @@ class DepletionReader(MaterialReader):
                 'Unexpected key {}: {} in materials dictionary'.format(
                     mKey, type(mat))
             )
+        debug('  found {} materials'.format(len(self.materials)))
+

--- a/serpentTools/parsers/detector.py
+++ b/serpentTools/parsers/detector.py
@@ -48,7 +48,6 @@ class DetectorReader(BaseReader):
         """Read the file and store the detectors."""
         keys = ['DET']
         separators = ['\n', '];']
-        info('Preparing to read {}'.format(self.filePath))
         with KeywordParser(self.filePath, keys, separators) as parser:
             for chunk in parser.yieldChunks():
                 detString = chunk.pop(0).split(' ')[0][3:]
@@ -61,7 +60,6 @@ class DetectorReader(BaseReader):
                 else:
                     continue
                 self._addDetector(chunk, detName, binType)
-        info('Done')
 
     def _addDetector(self, chunk, detName, binType):
         if binType is None:
@@ -84,16 +82,16 @@ class DetectorReader(BaseReader):
               .format(binType, detName))
 
     def _precheck(self):
-        """ Count how many detectors are in the file
-        """
-        detCount = 0
+        """ Count how many detectors are in the file."""
         with open(self.filePath) as fh:
             for line in fh:
                 sline = line.split()
                 if not sline:
                     continue
                 elif 'DET' in sline[0]:
-                    detCount += 1
-        if not detCount :
-            error("No detectors found in {}".format(self.filePath))
+                    return
+        error("No detectors found in {}".format(self.filePath))
 
+    def _postcheck(self):
+        if not self.detectors:
+            warning("No detectors stored from file {}".format(self.filePath))

--- a/serpentTools/samplers/__init__.py
+++ b/serpentTools/samplers/__init__.py
@@ -260,3 +260,4 @@ class SampledContainer(object):
 
     def _finalize(self):
         raise NotImplementedError
+

--- a/serpentTools/samplers/depletion.py
+++ b/serpentTools/samplers/depletion.py
@@ -334,3 +334,4 @@ def sigmaLabel(ax, xlabel, ylabel, sigma=None):
     if ylabel:
         ax.set_ylabel(ylabel + confStr)
     return ax
+

--- a/serpentTools/settings.py
+++ b/serpentTools/settings.py
@@ -404,3 +404,4 @@ class UserSettingsLoader(dict):
 
 
 rc = UserSettingsLoader()
+


### PR DESCRIPTION
Closes #104

Default logging level is now WARNING applied to the [logger in messages.py](https://github.com/CORE-GATECH-GROUP/serpent-tools/blob/8dbd66d652179315bdfdeee11e9a3b22a8bbac6d/serpentTools/messages.py#L51). This is really the default, not what is listed in `settings.rc['verbosity']` at launch.

Base reader now makes all logging calls regarding when the files are being read and completed. This provides a single place for changes to be made, i.e. changing the log level to a debug call, and all changes will be inherited by all readers during the public read method.

Infered reader messages and depmtx messages are now debug messages.