### PR TITLE
No more single-entry tuples as branch keys

### DIFF
--- a/docs/welcome/changelog.rst
+++ b/docs/welcome/changelog.rst
@@ -4,6 +4,16 @@
 Changelog
 *********
 
+.. _next:
+
+Next
+====
+
+* :pull:`114` - Standalone branches in the coefficient files are stored
+  and accessed using a single string, rather than a single-entry tuple
+  ``branches['myBranch']`` vs. ``branches[('myBranch', )]``
+
+    
 .. _v0.3.0:
 
 :release-tag:`0.3.0`
@@ -22,10 +32,6 @@ Changelog
 * :pull:`93` - Detector and Depletion Samplers
 * :pull:`96` - Better mesh plotting for detector
 * :bug:`99` - Negative universe burnup with branching reader - :squashed:`100`
-
-Notes
------
-
 * :py:attr:`serpentTools.objects.containers.Detector.indexes` are now zero-indexed
 * The PDF manual is no longer tracked in this repository
 

--- a/serpentTools/messages.py
+++ b/serpentTools/messages.py
@@ -88,9 +88,8 @@ def updateLevel(level):
         __logger__.setLevel('INFO')
         warning('Logger option {} not in options. Set to info.'.format(level))
         return 'info'
-    else:
-        __logger__.setLevel(level.upper())
-        return level
+    __logger__.setLevel(level.upper())
+    return level
 
 
 def deprecated(useInstead):
@@ -101,7 +100,6 @@ def deprecated(useInstead):
         def decorated(*args, **kwargs):
             msg = ('Function {} has been deprecated. Use {} instead'
                    .format(f.__name__, useInstead))
-            warning(msg)
             _updateFilterAlert(msg, DeprecationWarning)
             return f(*args, **kwargs)
 
@@ -116,7 +114,6 @@ def willChange(changeMsg):
     def decorate(f):
         @functools.wraps(f)
         def decoratedFunc(*args, **kwargs):
-            warning(changeMsg)
             _updateFilterAlert(changeMsg, FutureWarning)
             return f(*args, **kwargs)
 

--- a/serpentTools/objects/containers.py
+++ b/serpentTools/objects/containers.py
@@ -203,16 +203,14 @@ class HomogUniv(NamedObject):
         return x, dx
 
     def _lookup(self, variableName, uncertainty):
-        if "inf" in variableName:
+        if 'inf' == variableName[:3]:
             if not uncertainty:
                 return self.infExp
-            else:
-                return self.infUnc
-        elif "b1" in variableName:
+            return self.infUnc
+        elif "b1" ==  variableName[:2]:
             if not uncertainty:
                 return self.b1Exp
-            else:
-                return self.b1Unc
+            return self.b1Unc
         else:
             return self.metadata
 

--- a/serpentTools/parsers/branching.py
+++ b/serpentTools/parsers/branching.py
@@ -77,6 +77,8 @@ class BranchingReader(XSReader):
         self._whereAmI['runIndx'] = int(indx)
         self._whereAmI['coefIndx'] = int(coefIndx)
         branchNames = tuple(self._advance()[1:])
+        if len(branchNames) == 1:
+            branchNames = branchNames[0]
         if branchNames not in self.branches:
             branchState = self._processBranchStateData()
             self.branches[branchNames] = (


### PR DESCRIPTION
Fixes #113

If a branch is found to have only a single name, then the
name of the branch, and key in the branches dictionary, is taken
to be the first entry. The previous implementation would place
these branches under a single entry tuple, which required
extraneous keystrokes for retrieval. Now, the string name of the
branch is the key.

Also fixed a minor bug on the homogenized universe container, where
the b1Kinf data would be stored in the infinite medium dictionaries.