### PR TITLE
Fix Biblatex entry on README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -66,7 +66,7 @@ References
 The Annals of Nuclear Energy article should be cited for all work
 using ``SERPENT``. If you wish to cite this project, please cite as::
 
-    url{@serpentTools
+    @url{serpentTools,
         author = {Andrew Johnson and Dan Kotlyar and Stefano Terlizzi and Gavin Ridley},
         title = {serpentTools: A suite of parsers designed to make interacting with SERPENT outputs simple and flawless},
         url = {https://github.com/CORE-GATECH-GROUP/serpent-tools},


### PR DESCRIPTION
The biblatex entry on the README doesn't work in biblatex. Now it does.
Not many changes here!
