### PR TITLE
Proper x units for SampledDepletedMaterial

### DIFF
--- a/docs/welcome/changelog.rst
+++ b/docs/welcome/changelog.rst
@@ -9,6 +9,8 @@ Changelog
 Next
 ====
 
+* :bug:`119` - SampledDepletedMaterial now respects the value of `xUnits` 
+  - :squashed:`120`
 * :pull:`114` - Standalone branches in the coefficient files are stored
   and accessed using a single string, rather than a single-entry tuple
   ``branches['myBranch']`` vs. ``branches[('myBranch', )]``

--- a/serpentTools/objects/materials.py
+++ b/serpentTools/objects/materials.py
@@ -9,6 +9,7 @@ from serpentTools.objects import NamedObject, convertVariableName
 
 
 class DepletedMaterialBase(NamedObject):
+    PLOT_XLABELS = {'days': "Days", 'burnup': r"Burnup $[MWd/kgU]$"}
     docParams = """name: str
         Name of this material
     metadata: dict
@@ -278,7 +279,8 @@ class DepletedMaterial(DepletedMaterialBase):
         if xUnits not in ('days', 'burnup'):
             raise KeyError("Plot method only uses x-axis data from <days> "
                            "and <burnup>, not {}".format(xUnits))
-        xVals = timePoints or (self.days if xUnits == 'days' else self.burnup)
+        xVals = timePoints if timePoints is not None else (
+            self.days if xUnits == 'days' else self.burnup)
         yVals = self.getValues(xUnits, yUnits, xVals, names)
         ax = ax or pyplot.axes()
         labels = self._formatLabel(labelFmt, names)
@@ -288,7 +290,7 @@ class DepletedMaterial(DepletedMaterialBase):
         # format the plot
         if legend:
             ax.legend()
-        ax.set_xlabel(xlabel or xUnits)
+        ax.set_xlabel(xlabel or self.PLOT_XLABELS[xUnits])
         ax.set_ylabel(ylabel or yUnits)
         if loglog or logx:
             ax.set_xscale('log')

--- a/serpentTools/samplers/depletion.py
+++ b/serpentTools/samplers/depletion.py
@@ -245,8 +245,12 @@ class SampledDepletedMaterial(SampledContainer, DepletedMaterialBase):
         if sigma and yUnits not in self.uncertainties:
             raise KeyError("Uncertainties for {} not stored"
                            .format(yUnits))
+        if xUnits not in ('days', 'burnup'):
+            raise KeyError("Plot method only uses x-axis data from <days> "
+                           "and <burnup>, not {}".format(xUnits))
+        xVals = timePoints if timePoints is not None else (
+            self.days if xUnits == 'days' else self.burnup)
         sigma = int(fabs(sigma))
-        xVals = timePoints or self.days
         colIndices = self._getColIndices(xUnits, timePoints)
         rowIndices = self._getRowIndices(names)
         yVals = self._slice(self.data[yUnits], rowIndices, colIndices)
@@ -268,14 +272,18 @@ class SampledDepletedMaterial(SampledContainer, DepletedMaterialBase):
         # format the plot
         if legend:
             ax.legend()
-        if xlabel or ylabel:
-            ax = sigmaLabel(ax, xlabel, ylabel, sigma)
+        ax = sigmaLabel(ax, xlabel or self.PLOT_XLABELS[xUnits],
+                        ylabel or yUnits, sigma)
+        if loglog or logx:
+            ax.set_xscale('log')
+        if loglog or logy:
+            ax.set_yscale('log')
         return ax
 
     @magicPlotDocDecorator
     def spreadPlot(self, xUnits, yUnits, isotope, timePoints=None, ax=None,
                    xlabel=None, ylabel=None, logx=False, logy=False, 
-                   loglog=True, legend=True):
+                   loglog=False, legend=True):
         """
         Plot the mean quantity and data from all sampled files.
 
@@ -317,7 +325,11 @@ class SampledDepletedMaterial(SampledContainer, DepletedMaterialBase):
             raise SamplerError("Data from all sampled files has been freed "
                                "and cannot be used in this plot method")
         ax = ax or pyplot.axes()
-        xVals = timePoints or self.days
+        if xUnits not in ('days', 'burnup'):
+            raise KeyError("Plot method only uses x-axis data from <days> "
+                           "and <burnup>, not {}".format(xUnits))
+        xVals = timePoints if timePoints is not None else (
+            self.days if xUnits == 'days' else self.burnup)
         rows = self._getRowIndices([isotope])
         cols = self._getColIndices(xUnits, timePoints)
         primaryData = self._slice(self.data[yUnits], rows, cols)[0]
@@ -327,7 +339,7 @@ class SampledDepletedMaterial(SampledContainer, DepletedMaterialBase):
             plotData = self._slice(sampledData[n], rows, cols)[0]
             ax.plot(xVals, plotData, **SPREAD_PLOT_KWARGS)
         ax.plot(xVals, primaryData, label='Mean value')
-        ax = sigmaLabel(ax, xlabel or xUnits, ylabel or yUnits, 0)
+        ax = sigmaLabel(ax, xlabel or self.PLOT_XLABELS[xUnits], ylabel or yUnits)
         if loglog or logx:
             ax.set_xscale('log')
         if loglog or logy:
@@ -339,10 +351,8 @@ class SampledDepletedMaterial(SampledContainer, DepletedMaterialBase):
 
 def sigmaLabel(ax, xlabel, ylabel, sigma=None):
     """Label the axes on a figure with some uncertainty."""
-    confStr = r'$\pm{} \sigma$'.format(sigma) if sigma else ''
-    if xlabel:
-        ax.set_xlabel(xlabel + confStr)
-    if ylabel:
-        ax.set_ylabel(ylabel + confStr)
+    confStr = r'$\pm{} \sigma$'.format(sigma) if sigma is not None else ''
+    ax.set_xlabel(xlabel + confStr)
+    ax.set_ylabel(ylabel + confStr)
     return ax
 


### PR DESCRIPTION
Fixes #119

If the value of timePoints is not given to either plot or spreadPlot for SampledDepletedMaterial, the default x-points are taken according to the value of xUnits passed into the method.

Added some better x-axis formatting for SampledDepletedMaterial and DepletedMaterial containers.