### PR TITLE
Extra warnings and input checking for samplers

### DIFF
--- a/serpentTools/samplers/__init__.py
+++ b/serpentTools/samplers/__init__.py
@@ -31,7 +31,7 @@ def extendFiles(files):
             if not unGlob:
                 warning("No files matched with pattern {}".format(ff))
                 continue
-            for globbed in unGlob(ff):
+            for globbed in unGlob:
                 out.add(globbed)
         else:
             out.add(ff)

--- a/serpentTools/samplers/__init__.py
+++ b/serpentTools/samplers/__init__.py
@@ -27,6 +27,10 @@ def extendFiles(files):
         files = [files]
     for ff in files:
         if '*' in ff:
+            unGlob = glob(ff)
+            if not unGlob:
+                warning("No files matched with pattern {}".format(ff))
+                continue
             for globbed in glob(ff):
                 out.add(globbed)
         else:
@@ -78,6 +82,8 @@ class Sampler(object):
                 "{}".format(parser.__name__))
         self.settings = rc.getReaderSettings('sampler')
         self.files = extendFiles(files)
+        if not self.files:
+            raise SamplerError("No files stored on Sampler.")
         self.__parserCls = parser
         self.parsers = set()
         self.map = {}

--- a/serpentTools/samplers/__init__.py
+++ b/serpentTools/samplers/__init__.py
@@ -31,7 +31,7 @@ def extendFiles(files):
             if not unGlob:
                 warning("No files matched with pattern {}".format(ff))
                 continue
-            for globbed in glob(ff):
+            for globbed in unGlob(ff):
                 out.add(globbed)
         else:
             out.add(ff)


### PR DESCRIPTION
If a globbed argument was passed into a Sampler constructor, then no files would be loaded onto the object. This would not cause any problems during the read process, until now.

Two changes included in this commit. One, during the extendFiles function, if a file glob does not return any files, a warning is raised indicating as much. Second, following this function call, if no files are to be stored on the sampler and to be read, then a proper error is raised.