### PR TITLE
Reshape scatter mats

### DIFF
--- a/docs/defaultSettings.rst
+++ b/docs/defaultSettings.rst
@@ -206,6 +206,19 @@ If true, store the infinite medium cross sections.
   Type: bool
   
 
+.. _xs-reshapeScatter:
+
+---------------------
+``xs.reshapeScatter``
+---------------------
+
+If true, reshape the scattering matrices to square matrices. By default, these matrices are stored as vectors.
+::
+
+  Default: False
+  Type: bool
+  
+
 .. _xs-variableExtras:
 
 ---------------------

--- a/docs/welcome/changelog.rst
+++ b/docs/welcome/changelog.rst
@@ -12,6 +12,9 @@ Next
 * :pull:`131` Updated variable groups between ``2.1.29`` and ``2.1.30`` - include
   poison cross section, kinetic parameters, six factor formula (2.1.30 exclusive),
   and minor differences
+* :pull:`141` - Setting :ref:`xs-reshapeScatter` can be used to reshape scatter
+  matrices on :py:class:`~serpentTools.objects.containers.HomogUniv` 
+  objects to square matrices
 
 .. _vDeprecated:
 

--- a/serpentTools/objects/containers.py
+++ b/serpentTools/objects/containers.py
@@ -1,18 +1,20 @@
-""" Custom-built containers for storing data from serpent outputs
+""" 
+Custom-built containers for storing data from serpent outputs
 
 Contents
 --------
-:py:class:`~serpentTools.objects.containers.HomogUniv`
-:py:class:`~serpentTools.objects.containers.BranchContainer
-:py:class:`~serpentTools.objects.containers.DetectorBase`
-:py:class:`~serpentTools.objects.containers.Detector`
+* :py:class:`~serpentTools.objects.containers.HomogUniv`
+* :py:class:`~serpentTools.objects.containers.BranchContainer
+* :py:class:`~serpentTools.objects.containers.DetectorBase`
+* :py:class:`~serpentTools.objects.containers.Detector`
 
 """
 from collections import OrderedDict
 from itertools import product
 
 from matplotlib import pyplot
-from numpy import array, arange, unique, log, divide, ones_like, hstack
+from numpy import (array, arange, unique, log, divide, ones_like, hstack,
+                   ndarray)
 
 from serpentTools.settings import rc
 from serpentTools.plot import cartMeshPlot, plot, magicPlotDocDecorator
@@ -152,8 +154,7 @@ class HomogUniv(NamedObject):
         variableValue:
             Variable Value
         uncertainty: bool
-            Set to ``True`` in order to retrieve the
-            uncertainty associated to the expected values
+            Set to ``True`` if this data is an uncertainty 
 
         Raises
         ------
@@ -164,6 +165,10 @@ class HomogUniv(NamedObject):
         if not isinstance(uncertainty, bool):
             raise TypeError('The variable uncertainty has type {}, '
                             'should be boolean.'.format(type(uncertainty)))
+        if not isinstance(variableValue, ndarray):
+            debug("Converting {} from {} to array".format(
+                variableName, type(variableValue)))
+            variableValue = array(variableValue)
         ng = self.numGroups
         if self.__reshaped and variableName in SCATTER_MATS:
             if ng is None:
@@ -175,7 +180,7 @@ class HomogUniv(NamedObject):
         incomingGroups = variableValue.shape[0] 
         if ng is None:
             self.numGroups = incomingGroups 
-        elif incomingGroups != ng:
+        elif incomingGroups != ng and variableName not in SCATTER_MATS:
             warning("Variable {} appears to have different group structure. "
                     "Current: {} vs. incoming: {}"
                     .format(variableName, ng, incomingGroups))
@@ -206,7 +211,7 @@ class HomogUniv(NamedObject):
         x:
             Variable Value
         dx:
-            Associated uncertainty
+            Associated uncertainty if ``uncertainty``
 
         Raises
         ------

--- a/serpentTools/parsers/branching.py
+++ b/serpentTools/parsers/branching.py
@@ -134,6 +134,10 @@ class BranchingReader(XSReader):
                 possibleEndOfFile=step == numVariables - 1)
             varName = splitList[0]
             varValues = [float(xx) for xx in splitList[2:]]
+            if not varValues:
+                debug("No data present for variable {}. Skipping"
+                      .format(varName))
+                continue
             if self._checkAddVariable(varName):
                 if self.settings['areUncsPresent']:
                     vals, uncs = splitItems(varValues)

--- a/serpentTools/settings.py
+++ b/serpentTools/settings.py
@@ -260,9 +260,7 @@ class UserSettingsLoader(dict):
         self.__originals = {}
         dict.__init__(self, self._defaultLoader.retrieveDefaults())
 
-    def __setitem__(self, key, value):
-        self._checkStoreOriginal(key)
-        self.setValue(key, value)
+    __setitem__ = setValue
 
     def __enter__(self):
         self.__inside= True
@@ -273,10 +271,6 @@ class UserSettingsLoader(dict):
         for key, originalValue in iteritems(self.__originals):
             self[key] = originalValue
         self.__originals= {}
-
-    def _checkStoreOriginal(self, key):
-        if self.__inside:
-            self.__originals[key] = self[key]
 
     def setValue(self, name, value):
         """Set the value of a specific setting.
@@ -296,6 +290,8 @@ class UserSettingsLoader(dict):
             If the value is not of the correct type
 
         """
+        if self.__inside:
+            self.__originals[name] = self[name]
         if name not in self:
             raise KeyError('Setting {} does not exist'.format(name))
         self._defaultLoader[name].validate(value)

--- a/serpentTools/settings.py
+++ b/serpentTools/settings.py
@@ -260,8 +260,6 @@ class UserSettingsLoader(dict):
         self.__originals = {}
         dict.__init__(self, self._defaultLoader.retrieveDefaults())
 
-    __setitem__ = setValue
-
     def __enter__(self):
         self.__inside= True
         return self
@@ -300,6 +298,8 @@ class UserSettingsLoader(dict):
             value = self._defaultLoader[name].updater(value)
         dict.__setitem__(self, name, value)
         messages.debug('Updated setting {} to {}'.format(name, value))
+
+    __setitem__ = setValue
 
     def getReaderSettings(self, settingsPreffix):
         """Get all module-wide and reader-specific settings.

--- a/serpentTools/settings.py
+++ b/serpentTools/settings.py
@@ -124,6 +124,12 @@ defaultSettings = {
         'description': 'If true, store the critical leakage cross sections.',
         'type': bool
     },
+    'xs.reshapeScatter': {
+        'default': False,
+        'description': 'If true, reshape the scattering matrices to square matrices. '
+                       'By default, these matrices are stored as vectors.',
+       'type': bool
+    },
     'xs.variableGroups': {
         'default': [],
         'description': ('Name of variable groups from variables.yaml to be '

--- a/serpentTools/tests/test_container.py
+++ b/serpentTools/tests/test_container.py
@@ -19,8 +19,8 @@ class HomogenizedUniverseTester(unittest.TestCase):
         vec = arange(5)
         mat = arange(25)
         # Data definition
-        rawData = {'B1_1': vec, 'INF_1': vec, 'INF_S0': mat,
-                  'MACRO_E': vec}
+        rawData = {'B1_1': vec, 'B1_AS_LIST': [0,1,2,3,4],
+                  'INF_1': vec, 'INF_S0': mat, 'MACRO_E': vec}
 
         # Partial dictionaries
         cls.b1Unc = cls.b1Exp = {'b11': vec}


### PR DESCRIPTION
Closes #139 with a new setting `xs.reshapeScatter` that, if `True`, reshapes scattering matrices
on `HomogUniv` objects. This is done solely by the container, so that Readers need not worry about reshaping before calling `HomogUniv.addData`.

Modified the `test_containers.py` to compare reshaped and not reshaped scattering matrices.

Variables to be reshaped are determined by `serpentTools.objects.containers.SCATTER_MATS` set

## To do
- [x] Update changelog to include this change
- [x] Rebuild default settings doc file
