### PR TITLE
Add version at which changes from PR#114 will fully phase in

### DIFF
--- a/docs/welcome/changelog.rst
+++ b/docs/welcome/changelog.rst
@@ -19,6 +19,8 @@ Deprecation
 -----------
 
 * Variable group ``xs-yields`` will be removed. Use ``poisons`` instead
+* Branches of a single name will only be accessible through 
+  ``branches['nom']``, not ``branches[('nom'), ]`` as per :pull:`114`
 
 .. _v0.4.0:
 

--- a/serpentTools/parsers/branching.py
+++ b/serpentTools/parsers/branching.py
@@ -21,13 +21,13 @@ class BranchesWrapper(dict):
         if isinstance(key, tuple) and len(key) == 1 and key[0] in self:
             if not self.__warned:
                 self.__warn(key)
-                return dict.__getitem__(self, key[0]) 
+            return dict.__getitem__(self, key[0]) 
         raise KeyError(key)
 
     @willChange("In the future, access a single item branch name with only "
                 "the string, ['name'] vs. [('name', )]")
     def __warn(self, key):
-        warning("Future versions will not accept '{key}' but will accept "
+        warning("Versions after 0.5.0 will not accept '{key}' but will accept "
                 "'{entry}'".format(key=key, entry=key[0]))
         self.__warned = True
         


### PR DESCRIPTION
PR #114 implemented a work-around where branches of a single name, could be accessed either by `branches[('nom'),]` or `branches['nom']`. These keys are really stored as strings, not one-itemed tuples, but a simple wrapper allows accessing the keys both ways. A warning is raised the first time the
deprecated behavior takes place.

The changelog reflects the fact that version 0.5.0 will no longer support accessing these branches with single-entry tuples.

This is done to assist #138 