### PR TITLE
Add implicit truth methods for HomogUniv objects

### DIFF
--- a/serpentTools/objects/containers.py
+++ b/serpentTools/objects/containers.py
@@ -259,6 +259,17 @@ class HomogUniv(NamedObject):
         else:
             return self.metadata
 
+    def __bool__(self):
+        """Return True if data is stored on the object."""
+        attrs = {"infExp", "infUnc", "b1Exp", "b1Unc", "metadata"}
+        for key in attrs:
+            if getattr(self, key):
+                return True
+        return False
+
+    __nonzero__ = __bool__
+
+    hasData = __bool__
 
 class DetectorBase(NamedObject):
     """

--- a/serpentTools/tests/test_container.py
+++ b/serpentTools/tests/test_container.py
@@ -1,6 +1,7 @@
 """Test the container object. """
 
 import unittest
+from itertools import product
 
 from six import iteritems
 from numpy import array, arange
@@ -135,8 +136,35 @@ def compareDictOfArrays(expected, actualDict, dataType):
 
 del _HomogUnivTestHelper
 
+class UnivTruthTester(unittest.TestCase):
+    """Class that tests the various boolean evaluations for HomogUniv"""
+
+    def setUp(self):
+        """Verify that an empty universe evalutes to False."""
+        self.assertFalse(self.getUniv())
+
+    def test_loadedUnivTrue(self):
+        """Verify that universes with some data evalue to True."""
+        keys = {"INF_TOT", "B1_TOT", "CMM_TRANSP_X"}
+        data = arange(NUM_GROUPS)
+        for uflag, key in product((True, False), keys):
+            univ = self.getUniv()
+            univ.addData(key, data, uflag)
+            self.evalUniv(univ, msg="Key = {}, Uflag={}".format(key, uflag))
+        univ = self.getUniv()
+        univ.addData("MACRO_E", data)
+        self.evalUniv(univ, msg="Key = MACRO_E")
+
+    @staticmethod
+    def getUniv():
+        return HomogUniv('truth', 0, 0, 0)
+
+    def evalUniv(self, univ, msg):
+        """Shortcut for testing the truth of a universe."""
+        self.assertTrue(univ, msg=msg)
+        self.assertTrue(univ.hasData, msg=msg)
+
+
+
 if __name__ == '__main__':
-    from serpentTools import rc
-    with rc:
-        rc['verbosity'] = 'debug'
-        unittest.main()
+    unittest.main()


### PR DESCRIPTION
HomogUniv method hasData returns True is some data is stored
on the instance. The method iterates over inf and b1 dictionaries,
expected and uncertainty, as well as metadata, and returns True
at the first instance of a non-empty dictionary.

This method is also shared with __bool__ and __nonzero__ so that
the universes can be compared implicitly, i.e. `if univ:`, without
having to call `hasData`.