### PR TITLE
[API] Group constant dictionaries for HomogUniv; Criticalities as floats

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,6 +15,9 @@ Next
 * :pull:`141` - Setting :ref:`xs-reshapeScatter` can be used to reshape scatter
   matrices on :py:class:`~serpentTools.objects.containers.HomogUniv` 
   objects to square matrices
+* :pull:`145` - :py:meth:`~serpentTools.objects.containers.HomogUniv.hasData` 
+  added to check if :py:class:`~serpentTools.objects.containers.HomogUniv` 
+  objects have any data stored on them
 
 .. _vDeprecated:
 

--- a/examples/Branching.ipynb
+++ b/examples/Branching.ipynb
@@ -13,7 +13,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# `Branching Reader`\n",
+    "# Branching Reader\n",
     "## Basic Operation"
    ]
   },
@@ -38,8 +38,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Note**\n",
+    "\n",
+    "Without modifying the settings, the [`BranchingReader`](http://serpent-tools.readthedocs.io/en/latest/api/branching.html#serpentTools.parsers.branching.BranchingReader) assumes that all group constant data is presented without the associated uncertainties. See below for examples on the various ways to adjust the UserSettings"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -48,29 +57,10 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "**Note**\n",
-    "\n",
-    "Without modifying the settings, the `BranchingReader` assumes that all group constant data is presented without the associated uncertainties. See below for examples on the various ways to adjust the UserSettings"
-   ]
-  },
-  {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 2,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "INFO    : serpentTools: Inferred reader for demo.coe: BranchingReader\n",
-      "INFO    : serpentTools: Preparing to read demo.coe\n",
-      "INFO    : serpentTools: Done reading branching file\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "r0 = serpentTools.read(branchFile)"
    ]
@@ -79,38 +69,38 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The branches are stored in custom `BranchContainer` objects in the `branches` dictionary"
+    "The branches are stored in custom [`BranchContainer`](http://serpent-tools.readthedocs.io/en/latest/api/containers.html#serpentTools.objects.containers.BranchContainer) objects in the `branches` dictionary"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
        "{('B1000',\n",
-       "  'FT1200'): <serpentTools.objects.containers.BranchContainer at 0x7f2c8d8c9b00>,\n",
+       "  'FT1200'): <serpentTools.objects.containers.BranchContainer at 0x7ff70dcbd898>,\n",
        " ('B1000',\n",
-       "  'FT600'): <serpentTools.objects.containers.BranchContainer at 0x7f2c8cfecfd0>,\n",
+       "  'FT600'): <serpentTools.objects.containers.BranchContainer at 0x7ff70dcd2978>,\n",
        " ('B1000',\n",
-       "  'nom'): <serpentTools.objects.containers.BranchContainer at 0x7f2c8d052b00>,\n",
+       "  'nom'): <serpentTools.objects.containers.BranchContainer at 0x7ff70dc1f780>,\n",
        " ('B750',\n",
-       "  'FT1200'): <serpentTools.objects.containers.BranchContainer at 0x7f2c8d8cc400>,\n",
+       "  'FT1200'): <serpentTools.objects.containers.BranchContainer at 0x7ff70dcb5828>,\n",
        " ('B750',\n",
-       "  'FT600'): <serpentTools.objects.containers.BranchContainer at 0x7f2c8cfe58d0>,\n",
+       "  'FT600'): <serpentTools.objects.containers.BranchContainer at 0x7ff70dcca908>,\n",
        " ('B750',\n",
-       "  'nom'): <serpentTools.objects.containers.BranchContainer at 0x7f2c8d041470>,\n",
+       "  'nom'): <serpentTools.objects.containers.BranchContainer at 0x7ff70dc19780>,\n",
        " ('nom',\n",
-       "  'FT1200'): <serpentTools.objects.containers.BranchContainer at 0x7f2c8cfda208>,\n",
+       "  'FT1200'): <serpentTools.objects.containers.BranchContainer at 0x7ff70dcac7b8>,\n",
        " ('nom',\n",
-       "  'FT600'): <serpentTools.objects.containers.BranchContainer at 0x7f2c8cfdf1d0>,\n",
+       "  'FT600'): <serpentTools.objects.containers.BranchContainer at 0x7ff70dcc7898>,\n",
        " ('nom',\n",
-       "  'nom'): <serpentTools.objects.containers.BranchContainer at 0x7f2c8d03eda0>}"
+       "  'nom'): <serpentTools.objects.containers.BranchContainer at 0x7ff70dc08780>}"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -128,7 +118,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -159,7 +149,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -172,7 +162,7 @@
        " 'VERSION': '2.1.29'}"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -200,12 +190,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `BranchContainer` stores group constant data in `HomogUniv` objects in the `universes` dictionary. "
+    "The [`BranchContainer`](http://serpent-tools.readthedocs.io/en/latest/api/containers.html#serpentTools.objects.containers.BranchContainer) stores group constant data in [`HomogUniv`](http://serpent-tools.readthedocs.io/en/latest/api/containers.html#serpentTools.objects.containers.HomogUniv) objects in the `universes` dictionary. "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -216,14 +206,14 @@
       "(10, 1.0, 1)\n",
       "(20, 1.0, 1)\n",
       "(30, 1.0, 1)\n",
-      "(20, 0.0, 0)\n",
-      "(40, 0.0, 0)\n",
+      "(20, 0, 0)\n",
+      "(40, 0, 0)\n",
       "(20, 10.0, 2)\n",
       "(10, 10.0, 2)\n",
-      "(0, 0.0, 0)\n",
-      "(10, 0.0, 0)\n",
+      "(0, 0, 0)\n",
+      "(10, 0, 0)\n",
       "(0, 10.0, 2)\n",
-      "(30, 0.0, 0)\n",
+      "(30, 0, 0)\n",
       "(40, 10.0, 2)\n",
       "(40, 1.0, 1)\n",
       "(30, 10.0, 2)\n"
@@ -241,12 +231,12 @@
    "source": [
     "The keys here are vectors indicating the universe ID, burnup, and burnup index corresponding to the point in the burnup schedule. `SERPENT` prints negative values of burnup to indicate units of days, which is reflected in the `hasDays` attribute. `hasDays-> True` indicates that the values of burnup, second item in the above tuple, are in terms of days, not MWd/kgU.\n",
     "\n",
-    "These universes can be obtained by indexing this dictionary, or by using the `getUniv` method."
+    "These universes can be obtained by indexing this dictionary, or by using the [`getUniv`](http://serpent-tools.readthedocs.io/en/latest/api/containers.html#serpentTools.objects.containers.BranchContainer.getUniv) method."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -276,12 +266,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Since the coefficient files do not store the day value of burnup, all `HomogUniv` objects created by the `BranchContainers` default to day zero."
+    "Since the coefficient files do not store the day value of burnup, all [`HomogUniv`](http://serpent-tools.readthedocs.io/en/latest/api/containers.html#serpentTools.objects.containers.HomogUniv) objects created by the [`BranchContainer`](http://serpent-tools.readthedocs.io/en/latest/api/containers.html#serpentTools.objects.containers.BranchContainer)  default to day zero."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -294,20 +284,26 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Group constant data is stored in five dictionaries:\n",
+    "Group constant data is spread out across sub-dictionaries:\n",
     "\n",
-    "1. `infExp`: Expected values for infinite medium group constants\n",
-    "1. `infUnc`: Relative uncertainties for infinite medium group constants\n",
-    "1. `b1Exp`: Expected values for leakge-corrected group constants\n",
-    "1. `b1Unc`: Relative uncertainties for leakge-corrected group constants\n",
-    "1. `metaData`: items that do not fit the in the above categories, such as energy group structure, k-infinity, etc.\n",
-    "\n",
-    "For this problem, the coefficient file does not have uncertainties, nor these metadata arguments. For this reason, the `infUnc`, `b1Unc`, and `metaData` dictionaries are emtpy."
+    "1. [`infExp`](http://serpent-tools.readthedocs.io/en/latest/api/containers.html#serpentTools.objects.containers.HomogUniv.infExp): Expected values for infinite medium group constants\n",
+    "1. [`infUnc`](http://serpent-tools.readthedocs.io/en/latest/api/containers.html#serpentTools.objects.containers.HomogUniv.infUnc): Relative uncertainties for infinite medium group constants\n",
+    "1. [`b1Exp`](http://serpent-tools.readthedocs.io/en/latest/api/containers.html#serpentTools.objects.containers.HomogUniv.b1Exp): Expected values for leakge-corrected group constants\n",
+    "1. [`b1Unc`](http://serpent-tools.readthedocs.io/en/latest/api/containers.html#serpentTools.objects.containers.HomogUniv.b1Unc): Relative uncertainties for leakge-corrected group constants\n",
+    "1. [`gc`](http://serpent-tools.readthedocs.io/en/latest/api/containers.html#serpentTools.objects.containers.HomogUniv.gc): Group constant data that does not match the `INF` nor `B1` scheme\n",
+    "1. [`gcUnc`](http://serpent-tools.readthedocs.io/en/latest/api/containers.html#serpentTools.objects.containers.HomogUniv.gcUnc): Relative uncertainties for data in [`gc`](http://serpent-tools.readthedocs.io/en/latest/api/containers.html#serpentTools.objects.containers.HomogUniv.gc)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For this problem, only expected values for infinite and critical spectrum (B1) group constants are returned, so only the `infExp` and `b1Exp` dictionaries contain data"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -315,13 +311,12 @@
       "text/plain": [
        "{'infDiffcoef': array([ 1.83961 ,  0.682022]),\n",
        " 'infFiss': array([ 0.00271604,  0.059773  ]),\n",
-       " 'infRem': array([], dtype=float64),\n",
        " 'infS0': array([ 0.298689  ,  0.00197521,  0.00284247,  0.470054  ]),\n",
        " 'infS1': array([ 0.0847372 ,  0.00047366,  0.00062865,  0.106232  ]),\n",
        " 'infTot': array([ 0.310842,  0.618286])}"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -332,7 +327,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -341,7 +336,7 @@
        "{}"
       ]
      },
-     "execution_count": 27,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -352,7 +347,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -360,13 +355,12 @@
       "text/plain": [
        "{'b1Diffcoef': array([ 1.79892 ,  0.765665]),\n",
        " 'b1Fiss': array([ 0.00278366,  0.0597712 ]),\n",
-       " 'b1Rem': array([], dtype=float64),\n",
        " 'b1S0': array([ 0.301766  ,  0.0021261 ,  0.00283866,  0.470114  ]),\n",
        " 'b1S1': array([ 0.0856397 ,  0.00051071,  0.00062781,  0.106232  ]),\n",
        " 'b1Tot': array([ 0.314521,  0.618361])}"
       ]
      },
-     "execution_count": 28,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -377,7 +371,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -386,25 +380,45 @@
        "{}"
       ]
      },
-     "execution_count": 29,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "univ0.metadata"
+    "univ0.gc"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{}"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "univ0.gcUnc"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Group constants and their associated uncertainties can be obtained using the `HomogUniv.get` method."
+    "Group constants and their associated uncertainties can be obtained using the [`get`](http://serpent-tools.readthedocs.io/en/latest/api/containers.html#serpentTools.objects.containers.HomogUniv.get) method."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -413,7 +427,7 @@
        "array([ 0.00271604,  0.059773  ])"
       ]
      },
-     "execution_count": 30,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -424,7 +438,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -452,22 +466,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "('B1000', 'FT1200') <BranchContainer for B1000, FT1200 from demo.coe>\n",
-      "('B750', 'FT1200') <BranchContainer for B750, FT1200 from demo.coe>\n",
-      "('nom', 'FT1200') <BranchContainer for nom, FT1200 from demo.coe>\n",
-      "('nom', 'FT600') <BranchContainer for nom, FT600 from demo.coe>\n",
       "('B750', 'nom') <BranchContainer for B750, nom from demo.coe>\n",
       "('nom', 'nom') <BranchContainer for nom, nom from demo.coe>\n",
-      "('B1000', 'FT600') <BranchContainer for B1000, FT600 from demo.coe>\n",
+      "('B1000', 'FT1200') <BranchContainer for B1000, FT1200 from demo.coe>\n",
+      "('B1000', 'nom') <BranchContainer for B1000, nom from demo.coe>\n",
+      "('nom', 'FT1200') <BranchContainer for nom, FT1200 from demo.coe>\n",
       "('B750', 'FT600') <BranchContainer for B750, FT600 from demo.coe>\n",
-      "('B1000', 'nom') <BranchContainer for B1000, nom from demo.coe>\n"
+      "('B750', 'FT1200') <BranchContainer for B750, FT1200 from demo.coe>\n",
+      "('B1000', 'FT600') <BranchContainer for B1000, FT600 from demo.coe>\n",
+      "('nom', 'FT600') <BranchContainer for nom, FT600 from demo.coe>\n"
      ]
     }
    ],
@@ -486,74 +500,29 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 33,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "import six\n",
-    "from serpentTools.settings import rc"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 34,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "xs.getInfXS\n",
-      "\t default: True\n",
-      "\t description: If true, store the infinite medium cross sections.\n",
-      "\t type: <class 'bool'>\n",
-      "branching.floatVariables\n",
-      "\t default: []\n",
-      "\t description: Names of state data variables to convert to floats for each branch\n",
-      "\t type: <class 'list'>\n",
-      "xs.variableGroups\n",
-      "\t default: []\n",
-      "\t description: Name of variable groups from variables.yaml to be expanded into SERPENT variable to be stored\n",
-      "\t type: <class 'list'>\n",
-      "xs.variableExtras\n",
-      "\t default: []\n",
-      "\t description: Full SERPENT name of variables to be read\n",
-      "\t type: <class 'list'>\n",
-      "branching.intVariables\n",
-      "\t default: []\n",
-      "\t description: Name of state data variables to convert to integers for each branch\n",
-      "\t type: <class 'list'>\n",
-      "branching.areUncsPresent\n",
-      "\t default: False\n",
-      "\t description: True if the values in the .coe file contain uncertainties\n",
-      "\t type: <class 'bool'>\n",
-      "xs.getB1XS\n",
-      "\t default: True\n",
-      "\t description: If true, store the critical leakage cross sections.\n",
-      "\t type: <class 'bool'>\n"
-     ]
-    }
-   ],
-   "source": [
-    "from serpentTools.settings import rc, defaultSettings\n",
-    "for setting in defaultSettings:\n",
-    "    if 'xs' in setting or 'branching' in setting:\n",
-    "        print(setting)\n",
-    "        for k, v in six.iteritems(defaultSettings[setting]):\n",
-    "            print('\\t', k+':', v)"
+    "* [`branching.areUncsPresent`](http://serpent-tools.readthedocs.io/en/latest/settingsTop.html#branching-areuncspresent)\n",
+    "* [`branching.floatVariables`](http://serpent-tools.readthedocs.io/en/latest/settingsTop.html#branching-floatvariables)\n",
+    "* [`branching.intVariables`](http://serpent-tools.readthedocs.io/en/latest/settingsTop.html#branching-intvariables)\n",
+    "* [`xs.getB1XS`](http://serpent-tools.readthedocs.io/en/latest/settingsTop.html#xs-getb1xs)\n",
+    "* [`xs.getInfXS`](http://serpent-tools.readthedocs.io/en/latest/settingsTop.html#xs-getinfxs)\n",
+    "* [`xs.reshapeScatter`](http://serpent-tools.readthedocs.io/en/latest/settingsTop.html#xs-reshapescatter)\n",
+    "* [`xs.variableExtras`](http://serpent-tools.readthedocs.io/en/latest/settingsTop.html#xs-variableextras)\n",
+    "* [`xs.variableGroups`](http://serpent-tools.readthedocs.io/en/latest/settingsTop.html#xs-variablegroups)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In our example above, the `BOR` and `TFU` variables represented boron concentration and fuel temperature, and can easily be cast into numeric values using the `branching.intVariables` and `brancing.floatVariables` settings. From the previous example, we see that the default action is to store all state data variables as strings."
+    "In our example above, the `BOR` and `TFU` variables represented boron concentration and fuel temperature, and can easily be cast into numeric values using the [`branching.floatVariables`](http://serpent-tools.readthedocs.io/en/latest/settingsTop.html#branching-floatvariables) and [`branching.intVariables`](http://serpent-tools.readthedocs.io/en/latest/settingsTop.html#branching-intvariables) settings. From the previous example, we see that the default action is to store all state data variables as strings."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -564,25 +533,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As demonstrated in the [Settings example](https://github.com/CORE-GATECH-GROUP/serpent-tools/blob/master/examples/Settings.ipynb), use of `xs.variableGroups` and `xs.variableExtras` controls what data is stored on the `HomogUniv` objects. By default, all variables present in the coefficient file are stored."
+    "As demonstrated in the [Settings example](https://github.com/CORE-GATECH-GROUP/serpent-tools/blob/master/examples/Settings.ipynb), use of  [`xs.variableExtras`](http://serpent-tools.readthedocs.io/en/latest/settingsTop.html#xs-variableextras) [`xs.variableGroups`](http://serpent-tools.readthedocs.io/en/latest/settingsTop.html#xs-variablegroups)controls what data is stored on the `HomogUniv` objects. By default, all variables present in the coefficient file are stored."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 18,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "INFO    : serpentTools: Inferred reader for demo.coe: BranchingReader\n",
-      "INFO    : serpentTools: Preparing to read demo.coe\n",
-      "INFO    : serpentTools: Done reading branching file\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
+    "from serpentTools.settings import rc\n",
     "rc['branching.floatVariables'] = ['BOR']\n",
     "rc['branching.intVariables'] = ['TFU']\n",
     "rc['xs.getB1XS'] = False\n",
@@ -592,7 +552,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -601,7 +561,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
@@ -614,7 +574,7 @@
        " 'VERSION': '2.1.29'}"
       ]
      },
-     "execution_count": 38,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -625,7 +585,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -642,7 +602,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
@@ -651,7 +611,7 @@
        "{'infTot': array([ 0.313338,  0.54515 ])}"
       ]
      },
-     "execution_count": 40,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -663,7 +623,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
@@ -672,7 +632,7 @@
        "{}"
       ]
      },
-     "execution_count": 41,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/serpentTools/objects/containers.py
+++ b/serpentTools/objects/containers.py
@@ -283,9 +283,15 @@ class HomogUniv(NamedObject):
 
     def __bool__(self):
         """Return True if data is stored on the object."""
-        attrs = {"infExp", "infUnc", "b1Exp", "b1Unc", "metadata"}
+        attrs = {"infExp", "infUnc", "b1Exp", "b1Unc", "gc", "gcUnc",
+                 "groups", "microGroups"}
         for key in attrs:
-            if getattr(self, key):
+            value = getattr(self, key)
+            if isinstance(value, dict) and value:
+                return True
+            if isinstance(value, ndarray) and value.any():
+                return True
+            if value:
                 return True
         return False
 

--- a/serpentTools/objects/containers.py
+++ b/serpentTools/objects/containers.py
@@ -196,10 +196,6 @@ class HomogUniv(NamedObject):
         incomingGroups = variableValue.shape[0] 
         if ng is None:
             self.numGroups = incomingGroups 
-        elif incomingGroups != ng and variableName not in SCATTER_MATS:
-            warning("Variable {} appears to have different group structure. "
-                    "Current: {} vs. incoming: {}"
-                    .format(variableName, ng, incomingGroups))
 
         variableName = convertVariableName(variableName)
 

--- a/serpentTools/tests/test_container.py
+++ b/serpentTools/tests/test_container.py
@@ -30,7 +30,7 @@ class _HomogUnivTestHelper(unittest.TestCase):
                    'INF_1': vec, 'INF_S0': mat, 'CMM_TRANSP_X': vec}
         attrs = {'MACRO_E': groupStructure}
         # Partial dictionaries
-        self.b1Unc = self.b1Exp = {'b11': vec}
+        self.b1Unc = self.b1Exp = {'b11': vec, 'b1AsList': vec}
         self.infUnc = self.infExp = {'inf1': vec, 'infS0': mat}
         self.gcUnc = self.gc = {'cmmTranspX': vec}
         self.expAttrs = {'groups': groupStructure, 'numGroups': NUM_GROUPS} 

--- a/serpentTools/tests/test_container.py
+++ b/serpentTools/tests/test_container.py
@@ -25,14 +25,19 @@ class _HomogUnivTestHelper(unittest.TestCase):
     def setUp(self):
         self.univ, vec, mat = self.getParams()
         groupStructure = arange(NUM_GROUPS  + 1)
+        testK = vec[0]
         # Data definition
         rawData = {'B1_1': vec, 'B1_AS_LIST': list(vec),
-                   'INF_1': vec, 'INF_S0': mat, 'CMM_TRANSP_X': vec}
+                   'INF_1': vec, 'INF_S0': mat, 'CMM_TRANSP_X': vec,
+                   'INF_KEFF': vec, 'B1_KINF': vec, 'IMP_KEFF': vec,
+                   'INF_KINF': vec}
         attrs = {'MACRO_E': groupStructure}
         # Partial dictionaries
-        self.b1Unc = self.b1Exp = {'b11': vec, 'b1AsList': vec}
-        self.infUnc = self.infExp = {'inf1': vec, 'infS0': mat}
-        self.gcUnc = self.gc = {'cmmTranspX': vec}
+        self.b1Unc = self.b1Exp = {'b11': vec, 'b1AsList': vec, 'b1Kinf': testK}
+        self.infUnc = self.infExp = {
+                'inf1': vec, 'infS0': mat, 'infKeff': testK, 'infKinf': testK,
+                }
+        self.gcUnc = self.gc = {'cmmTranspX': vec, 'impKeff': testK}
         self.expAttrs = {'groups': groupStructure, 'numGroups': NUM_GROUPS} 
         # Use addData
         for key, value in iteritems(attrs):


### PR DESCRIPTION
Metadata dictionary for HomogUniv objects is no more. Instead, the following changes have been made to the underlying structure:

1. Micro and macro group structure, and number of groups, are stored directly on the object, not in metadata dictionaries
1. Non `INF` nor `B1` quantities, such as `CMM_*` or `IMP_KEFF` are stored in two new sub-dictionaries: `gc` and `gcUnc` for group constants and their associated relative uncertainties

HomogUniv now cleans incoming data from `addData` by
1. Converting all incoming data to numpy arrays
1. Returning floats for criticality related values, anything that matches `K[EI][FN]F`
1. Reshaping scattering matrices via #141 

Unit tests were updated accordingly.
Also update the Branching notebook with links and the more recent changes

- [ ] Update branching example rst with changes from branching notebook

Parent PR to #130 - changes here effect unit tests for Results reader
