### PR TITLE
[BUG] HomogUniv store number of groups as ints

### DIFF
--- a/serpentTools/objects/containers.py
+++ b/serpentTools/objects/containers.py
@@ -35,8 +35,8 @@ for xsSpectrum, xsType in product({'INF', 'B1'},
                         for xx in range(SCATTER_ORDERS)})
 
 HOMOG_VAR_TO_ATTR = {
-    'MICRO_E': 'microGroups', 'MICRO_NG': '_numMicroGroups',
-    'MACRO_E': 'groups', 'MACRO_NG': '_numGroups'}
+    'MICRO_E': 'microGroups', 'MICRO_NG': 'numMicroGroups',
+    'MACRO_E': 'groups', 'MACRO_NG': 'numGroups'}
 
 __all__ = ('DET_COLS', 'HomogUniv', 'BranchContainer', 'Detector',
            'DetectorBase', 'SCATTER_MATS', 'SCATTER_ORDERS')
@@ -147,11 +147,21 @@ class HomogUniv(NamedObject):
             self._numGroups = self.groups.size - 1
         return self._numGroups
 
+    @numGroups.setter
+    def numGroups(self, value):
+        value = value if isinstance(value, int) else int(value)
+        self._numGroups = value
+
     @property
     def numMicroGroups(self):
         if self._numMicroGroups is None and self.microGroups is not None:
             self._numMicroGroups = self.microGroups.size - 1
         return self._numMicroGroups 
+
+    @numMicroGroups.setter
+    def numMicroGroups(self, value):
+        value = value if isinstance(value, int) else int(value)
+        self._numMicroGroups = value
 
     def __str__(self):
         extras = []

--- a/serpentTools/tests/test_container.py
+++ b/serpentTools/tests/test_container.py
@@ -4,7 +4,7 @@ import unittest
 from itertools import product
 
 from six import iteritems
-from numpy import array, arange, ndarray
+from numpy import array, arange, ndarray, float64
 from numpy.testing import assert_array_equal
 
 from serpentTools.settings import rc
@@ -171,6 +171,37 @@ class UnivTruthTester(unittest.TestCase):
         self.assertTrue(univ.hasData, msg=msg)
 
 
+class HomogUnivIntGroupsTester(unittest.TestCase):
+    """Class that ensures number of groups is stored as ints."""
+
+    def setUp(self):
+        self.univ = HomogUniv('intGroups', 0, 0, 0)
+        self.numGroups = 2
+        self.numMicroGroups = 4
+
+    def test_univGroupsFromFloats(self):
+        """Vefify integer groups are stored when passed as floats."""
+        self.setAs(float)
+        self._tester()
+
+    def test_univGroupsFromNPFloats(self):
+        """Vefify integer groups are stored when passed as numpy floats."""
+        self.setAs(float64)
+        self._tester()
+
+    def _tester(self):
+        for attr in {'numGroups', 'numMicroGroups'}:
+            actual = getattr(self.univ, attr)
+            msg ='Attribute: {}'.format(attr)
+            self.assertIsInstance(actual, int, msg=msg)
+            expected = getattr(self, attr)
+            self.assertEqual(expected, actual, msg=msg)
+    
+    def setAs(self, func):
+        """Set the number of groups to be as specific type."""
+        for attr in {'numGroups', 'numMicroGroups'}:
+            expected = getattr(self, attr)
+            setattr(self.univ, attr, func(expected))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Closes #152 by storing the `numGroups` and `numMicroGroups` attributes as integers for `HomogUniv` objects. Added tests where those attributes are set as floats and tested against integers.

- [x] PR fits the [project scope](http://serpent-tools.readthedocs.io/en/latest/develop/contributing.html#project-scope)
- [x] Code to be committed is [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) and matches the [code style](http://serpent-tools.readthedocs.io/en/latest/develop/codestyle.html#code-style) of the project
- [x] New and/or changed features are [well documented](http://serpent-tools.readthedocs.io/en/latest/develop/documentation.html#documentation) and have adequate testing