### PR TITLE
[BUG] Reshape scatter matrices using fortran ordering

### DIFF
--- a/serpentTools/objects/containers.py
+++ b/serpentTools/objects/containers.py
@@ -232,7 +232,7 @@ class HomogUniv(NamedObject):
                         "Will not reshape variable {}"
                         .format(name))
             else:
-                value = value.reshape(ng, ng)
+                value = value.reshape(ng, ng, order="F")
         return value
         
     def get(self, variableName, uncertainty=False):

--- a/serpentTools/tests/test_container.py
+++ b/serpentTools/tests/test_container.py
@@ -122,7 +122,7 @@ class ReshapedHomogUnivTester(_HomogUnivTestHelper):
             rc.setValue('xs.reshapeScatter', True)
             univ, vec, mat = getParams()
             self.assertTrue(univ.reshaped)
-        return univ, vec, mat.reshape(NUM_GROUPS, NUM_GROUPS)
+        return univ, vec, mat.reshape(NUM_GROUPS, NUM_GROUPS, order="F")
 
 
 def getParams():


### PR DESCRIPTION
Fixes #155 by reshaping scattering matrices on HomogUniv
objects using order="F" to agree with matlab and
with the documented layout.

Row index corresponds to original energy group, columns
corresponds to destination group
```
[a b c d] -->
[[a, c],
 [b, d]]
```