### PR TITLE
[STY] Custom notebook template for rst files

### DIFF
--- a/docs/develop/documentation.rst
+++ b/docs/develop/documentation.rst
@@ -181,7 +181,10 @@ Converting
 ----------
 
 These Jupyter notebooks can be converted to |rst| files for inclusion
-in the manual with the command |jconvert| .
+in the manual with the command |jconvert|, with::
+
+    $ jupyter nbconvert --to=rst Notebook.ipynb
+
 However, there are some tweaks that should be made so that the documentation
 renders properly and has helpful links to objects in the project.
 
@@ -214,6 +217,12 @@ The above code block should be replaced with::
 
         hello world!
 
+It is recommended to use the template in ``examples/rstTemplate.tpl`` to ease this conversion process.
+This can be passed to with ::
+
+    
+    $ jupyter nbconvert --to=rst --template=rstTemplate.tpl Notebook.ipynb
+
 Upon conversion, move the file into the ``docs/examples`` directory and include the 
 file name in ``docs/examples/index.rst``.
 
@@ -222,7 +231,7 @@ file name in ``docs/examples/index.rst``.
 Images
 ------
 
-Executing |jconvert| will create a directory containing the images
+Executing ``nbconvert`` will create a directory containing the images
 contained in the notebook.
 When moving the |rst| version of the notebook into the ``docs/examples`` folder, make sure
 that all links to images are correct.
@@ -289,6 +298,7 @@ docstrings to automatically document new features.
 This is most simply done by calling ``.. autoclass::`` or ``..autofunction::`` like::
 
     .. autofunction:: serpentTools.plot.plot
+
     .. autoclass:: serpentTools.parsers.results.ResultsReader
 
 For new readers, those should be included in their own file, such as ``docs/api/myNewReader.rst``, 

--- a/docs/examples/Branching.rst
+++ b/docs/examples/Branching.rst
@@ -36,65 +36,76 @@ The simplest way to read these files is using the
     See :ref:`branching-settings` for examples on the various ways to
     control operation
 
-.. code:: 
 
+.. code:: 
+    
     >>> import serpentTools
     >>> branchFile = 'demo.coe'
+
+.. code:: 
+    
     >>> r0 = serpentTools.read(branchFile)
-    INFO    : serpentTools: Inferred reader for demo.coe: BranchingReader
-    INFO    : serpentTools: Preparing to read demo.coe
-    INFO    : serpentTools: Done reading branching file
 
 The branches are stored in custom |branchContainer| objects in the
 :py:attr:`~serpentTools.parsers.branching.BranchingReader.branches`
 dictionary
 
 .. code:: 
-
+    
     >>> r0.branches
-    {('B1000', 'FT1200'): 
-        <serpentTools.objects.containers.BranchContainer at 0x7f2c8d8c9b00>,
-     ('B1000', 'FT600'):
-        <serpentTools.objects.containers.BranchContainer at 0x7f2c8cfecfd0>,
-     ('B1000', 'nom'): 
-        <serpentTools.objects.containers.BranchContainer at 0x7f2c8d052b00>,
-     ('B750', 'FT1200'): 
-        <serpentTools.objects.containers.BranchContainer at 0x7f2c8d8cc400>,
-     ('B750', 'FT600'): 
-        <serpentTools.objects.containers.BranchContainer at 0x7f2c8cfe58d0>,
-     ('B750', 'nom'): 
-        <serpentTools.objects.containers.BranchContainer at 0x7f2c8d041470>,
-     ('nom', 'FT1200'): 
-        <serpentTools.objects.containers.BranchContainer at 0x7f2c8cfda208>,
-     ('nom', 'FT600'): 
-        <serpentTools.objects.containers.BranchContainer at 0x7f2c8cfdf1d0>,
-     ('nom', 'nom'): 
-        <serpentTools.objects.containers.BranchContainer at 0x7f2c8d03eda0>}
+
+
+
+
+.. parsed-literal::
+
+    {('B1000',
+      'FT1200'): <serpentTools.objects.containers.BranchContainer at 0x7fa068b42978>,
+     ('B1000',
+      'FT600'): <serpentTools.objects.containers.BranchContainer at 0x7fa068b58a58>,
+     ('B1000',
+      'nom'): <serpentTools.objects.containers.BranchContainer at 0x7fa068aac860>,
+     ('B750',
+      'FT1200'): <serpentTools.objects.containers.BranchContainer at 0x7fa068b3a908>,
+     ('B750',
+      'FT600'): <serpentTools.objects.containers.BranchContainer at 0x7fa068b509e8>,
+     ('B750',
+      'nom'): <serpentTools.objects.containers.BranchContainer at 0x7fa068a9c860>,
+     ('nom',
+      'FT1200'): <serpentTools.objects.containers.BranchContainer at 0x7fa068b33898>,
+     ('nom',
+      'FT600'): <serpentTools.objects.containers.BranchContainer at 0x7fa068b47978>,
+     ('nom',
+      'nom'): <serpentTools.objects.containers.BranchContainer at 0x7fa068a8b860>}
 
 Here, the keys are tuples of strings indicating what
 perturbations/branch states were applied for each ``SERPENT`` solution.
 Examining a particular case
 
 .. code:: 
-
+    
     >>> b0 = r0.branches['B1000', 'FT600']
     >>> print(b0)
+
+
+.. parsed-literal::
+
     <BranchContainer for B1000, FT600 from demo.coe>
-    
 
-``SERPENT`` allows the user to define variables for each branch through:
-
-::
-
-    var V1_name V1_value
-
-cards. These are stored in the 
+``SERPENT`` allows the user to define variables for each branch through 
+``var V1_name V1_value`` cards. These are stored in the 
 :py:attr:`~serpentTools.objects.containers.BranchContainer.stateData` 
 attribute
 
 .. code:: 
-
+    
     >>> b0.stateData
+
+
+
+
+.. parsed-literal::
+
     {'BOR': '1000',
      'DATE': '17/12/19',
      'TFU': '600',
@@ -115,27 +126,33 @@ Group Constant Data
 
 The |branchContainer| stores group 
 constant data in |homogUniv| objects in the 
-:py:attr:`~serpentTools.parsers.branching.BranchingReader.branches`
+:py:attr:`~serpentTools.parsers.branching.BranchingReader.universes`
 dictionary
 
-.. code:: 
 
-    >>> b0.universes
-    {(0, 0.0, 1): <serpentTools.objects.containers.HomogUniv at 0x2220c781ac8>,
-     (0, 1.0, 2): <serpentTools.objects.containers.HomogUniv at 0x2220c78b5f8>,
-     (0, 10.0, 3): <serpentTools.objects.containers.HomogUniv at 0x2220c791240>,
-     (10, 0.0, 1): <serpentTools.objects.containers.HomogUniv at 0x2220c787a58>,
-     (10, 1.0, 2): <serpentTools.objects.containers.HomogUniv at 0x2220c78b6a0>,
-     (10, 10.0, 3): <serpentTools.objects.containers.HomogUniv at 0x2220c791320>,
-     (20, 0.0, 1): <serpentTools.objects.containers.HomogUniv at 0x2220c787cc0>,
-     (20, 1.0, 2): <serpentTools.objects.containers.HomogUniv at 0x2220c78b908>,
-     (20, 10.0, 3): <serpentTools.objects.containers.HomogUniv at 0x2220c791588>,
-     (30, 0.0, 1): <serpentTools.objects.containers.HomogUniv at 0x2220c78b048>,
-     (30, 1.0, 2): <serpentTools.objects.containers.HomogUniv at 0x2220c78bb70>,
-     (30, 10.0, 3): <serpentTools.objects.containers.HomogUniv at 0x2220c7917f0>,
-     (40, 0.0, 1): <serpentTools.objects.containers.HomogUniv at 0x2220c78b1d0>,
-     (40, 1.0, 2): <serpentTools.objects.containers.HomogUniv at 0x2220c78bdd8>,
-     (40, 10.0, 3): <serpentTools.objects.containers.HomogUniv at 0x2220c791a58>}
+.. code:: 
+    
+    >>> for key in b0.universes:
+    ...     print(key)
+
+
+.. parsed-literal::
+
+    (0, 1.0, 1)
+    (10, 1.0, 1)
+    (20, 1.0, 1)
+    (30, 1.0, 1)
+    (20, 0, 0)
+    (40, 0, 0)
+    (20, 10.0, 2)
+    (10, 10.0, 2)
+    (0, 0, 0)
+    (10, 0, 0)
+    (0, 10.0, 2)
+    (30, 0, 0)
+    (40, 10.0, 2)
+    (40, 1.0, 1)
+    (30, 10.0, 2)
 
 The keys here are vectors indicating the universe ID, burnup, and burnup
 index corresponding to the point in the burnup schedule. ``SERPENT``
@@ -149,23 +166,25 @@ These universes can be obtained by indexing this dictionary, or by using
 the :py:meth:`~serpentTools.objects.containers.BranchContainer.getUniv` method
 
 .. code:: 
-
+    
     >>> univ0 = b0.universes[0, 1, 1]
     >>> print(univ0)
-    <HomogUniv 0: burnup: 1.000 MWd/kgu, step: 1>
     >>> print(univ0.name)
-    0
     >>> print(univ0.bu)
-    1.0
     >>> print(univ0.step)
-    1
     >>> print(univ0.day)
-    None
     >>> print(b0.hasDays)
+
+
+.. parsed-literal::
+
+    <HomogUniv 0: burnup: 1.000 MWd/kgu, step: 1>
+    0
+    1.0
+    1
+    None
     False
-    >>> univ1 = b0.getUniv(0, burnup=1)
-    >>> univ2 = b0.getUniv(0, index=1)
-    >>> assert univ0 is univ1 is univ2
+
 
 Group constant data is spread out across the following sub-dictionaries:
 
@@ -187,37 +206,102 @@ spectrum (b1) group constants are returned, so only the ``infExp`` and
 ``b1Exp`` dictionaries contain data
 
 .. code:: 
-
+    
     >>> univ0.infExp
+
+
+
+
+.. parsed-literal::
+
     {'infDiffcoef': array([ 1.83961 ,  0.682022]),
      'infFiss': array([ 0.00271604,  0.059773  ]),
-     'infRem': array([], dtype=float64),
      'infS0': array([ 0.298689  ,  0.00197521,  0.00284247,  0.470054  ]),
      'infS1': array([ 0.0847372 ,  0.00047366,  0.00062865,  0.106232  ]),
      'infTot': array([ 0.310842,  0.618286])}
+
+.. code:: 
+    
     >>> univ0.infUnc
+
+
+
+
+.. parsed-literal::
+
     {}
+
+
+
+.. code:: 
+    
     >>> univ0.b1Exp
+
+
+
+
+.. parsed-literal::
+
     {'b1Diffcoef': array([ 1.79892 ,  0.765665]),
      'b1Fiss': array([ 0.00278366,  0.0597712 ]),
-     'b1Rem': array([], dtype=float64),
      'b1S0': array([ 0.301766  ,  0.0021261 ,  0.00283866,  0.470114  ]),
      'b1S1': array([ 0.0856397 ,  0.00051071,  0.00062781,  0.106232  ]),
      'b1Tot': array([ 0.314521,  0.618361])}
-    >>> univ.gc 
+
+
+
+.. code:: 
+    
+    >>> univ0.gc
+
+
+
+
+.. parsed-literal::
+
     {}
+
+
+
+.. code:: 
+    
+    >>> univ0.gcUnc
+
+
+
+
+.. parsed-literal::
+
+    {}
+
+
 
 Group constants and their associated uncertainties can be obtained using
 the :py:meth:`~serpentTools.objects.containers.HomogUniv.get` method.
 
 .. code:: 
-
+    
     >>> univ0.get('infFiss')
-    array([ 0.00286484,  0.0577559 ])
+
+
+
+
+.. parsed-literal::
+
+    array([ 0.00271604,  0.059773  ])
+
+
+
+.. code:: 
+    
     >>> try:
-    >>>     univ0.get('infS0', uncertainty=True)
+    ...     univ0.get('infS0', uncertainty=True)
     >>> except KeyError as ke:  # no uncertainties here
-    >>>     print(str(ke))
+    ...     print(str(ke))
+
+
+.. parsed-literal::
+
     'Variable infS0 absent from uncertainty dictionary'
 
 Iteration
@@ -228,25 +312,29 @@ The branching reader has a
 method that works to yield branch names and their associated
 |branchContainer| objects. This can
 be used to efficiently iterate over all the branches presented in the file.
-
 .. code:: 
-
+    
     >>> for names, branch in r0.iterBranches():
-    >>>    print(names, branch)
-    ('nom', 'nom') <BranchContainer for nom, nom from demo.coe>
-    ('B750', 'nom') <BranchContainer for B750, nom from demo.coe>
-    ('B1000', 'nom') <BranchContainer for B1000, nom from demo.coe>
+    ...     print(names, branch)
+
+
+.. parsed-literal::
+
     ('nom', 'FT1200') <BranchContainer for nom, FT1200 from demo.coe>
-    ('B750', 'FT1200') <BranchContainer for B750, FT1200 from demo.coe>
     ('B1000', 'FT1200') <BranchContainer for B1000, FT1200 from demo.coe>
-    ('nom', 'FT600') <BranchContainer for nom, FT600 from demo.coe>
     ('B750', 'FT600') <BranchContainer for B750, FT600 from demo.coe>
+    ('nom', 'nom') <BranchContainer for nom, nom from demo.coe>
+    ('B750', 'FT1200') <BranchContainer for B750, FT1200 from demo.coe>
     ('B1000', 'FT600') <BranchContainer for B1000, FT600 from demo.coe>
+    ('nom', 'FT600') <BranchContainer for nom, FT600 from demo.coe>
+    ('B1000', 'nom') <BranchContainer for B1000, nom from demo.coe>
+    ('B750', 'nom') <BranchContainer for B750, nom from demo.coe>
+
 
 .. _branching-settings:
 
-Settings
---------
+User Control
+------------
 
 The ``SERPENT``
 `set coefpara <http://serpent.vtt.fi/mediawiki/index.php/Input_syntax_manual#set_coefpara>`_
@@ -278,34 +366,67 @@ stored on the |homogUniv|
 objects. By default, all variables present in the coefficient file are stored.
 
 .. code:: 
-
+    
+    >>> from serpentTools.settings import rc
     >>> rc['branching.floatVariables'] = ['BOR']
     >>> rc['branching.intVariables'] = ['TFU']
     >>> rc['xs.getB1XS'] = False
     >>> rc['xs.variableExtras'] = ['INF_TOT', 'INF_SCATT0']
     >>> r1 = serpentTools.read(branchFile)
-    INFO    : serpentTools: Inferred reader for demo.coe: BranchingReader
-    INFO    : serpentTools: Preparing to read demo.coe
-    INFO    : serpentTools: Done reading branching file
+
+.. code:: 
+    
     >>> b1 = r1.branches['B1000', 'FT600']
+
+.. code:: 
+    
     >>> b1.stateData
+
+
+
+
+.. parsed-literal::
+
     {'BOR': 1000.0,
-     'DATE': '17/10/18',
+     'DATE': '17/12/19',
      'TFU': 600,
-     'TIME': '10:26:48',
+     'TIME': '09:48:54',
      'VERSION': '2.1.29'}
+
+
+
+.. code:: 
+    
     >>> assert isinstance(b1.stateData['BOR'], float)
     >>> assert isinstance(b1.stateData['TFU'], int)
 
 Inspecting the data stored on the homogenized universes reveals only the
 variables explicitly requested are present
 
-.. code:: 
 
+.. code:: 
+    
     >>> univ4 = b1.getUniv(0, 0)
     >>> univ4.infExp
+
+
+
+
+.. parsed-literal::
+
     {'infTot': array([ 0.313338,  0.54515 ])}
+
+
+
+.. code:: 
+    
     >>> univ4.b1Exp
+
+
+
+
+.. parsed-literal::
+
     {}
 
 Conclusion

--- a/docs/examples/DepletionReader.rst
+++ b/docs/examples/DepletionReader.rst
@@ -26,39 +26,87 @@ this file, and storing the data inside |depMat| objects.
 Each such object has methods and attributes that should ease analysis.
 
 .. code:: 
-
+    
+    >>> %matplotlib inline
     >>> import six
     >>> import serpentTools
     >>> from serpentTools.settings import rc
+
+.. code:: 
+    
     >>> depFile = 'demo_dep.m'
     >>> dep = serpentTools.read(depFile)
-    INFO    : serpentTools: Inferred reader for demo_dep.m: DepletionReader
-    INFO    : serpentTools: Preparing to read demo_dep.m
-    INFO    : serpentTools: Done reading depletion file
 
 The materials read in from the file are stored in the |materials| 
 dictionary, where the keys represent the name of specific materials, and
 the corresponding values are the depleted material.
 
 .. code:: 
-
+    
     >>> dep.materials
-    {'bglass0': <serpentTools.objects.materials.DepletedMaterial at 0x23905154668>,
-     'fuel0': <serpentTools.objects.materials.DepletedMaterial at 0x2390578eeb8>,
-     'total': <serpentTools.objects.materials.DepletedMaterial at 0x2390579e978>}
+
+
+
+
+.. parsed-literal::
+
+    {'fuel0': <serpentTools.objects.materials.DepletedMaterial at 0x7f8f8dccde80>,
+     'bglass0': <serpentTools.objects.materials.DepletedMaterial at 0x7f8f8f42f518>,
+     'total': <serpentTools.objects.materials.DepletedMaterial at 0x7f8f8dce7940>}
 
 Metadata, such as the isotopic vector and depletion schedule are also
 present inside the reader
 
-.. code:: 
 
+.. code:: 
+    
     >>> dep.metadata.keys()
-    dict_keys(['zai', 'burnup', 'names', 'days'])
+
+
+
+
+.. parsed-literal::
+
+    dict_keys(['zai', 'names', 'burnup', 'days'])
+
+
+
+.. code:: 
+    
     >>> dep.metadata['burnup']
-    array([ 0.  ,  0.02,  0.04,  ...,  1.36,  1.38,  1.4 ,  1.42])
+
+
+
+
+.. parsed-literal::
+
+    array([0.  , 0.02, 0.04, 0.06, 0.08, 0.1 , 0.12, 0.14, 0.16, 0.18, 0.2 ,
+           0.22, 0.24, 0.26, 0.28, 0.3 , 0.32, 0.34, 0.36, 0.38, 0.4 , 0.42,
+           0.44, 0.46, 0.48, 0.5 , 0.52, 0.54, 0.56, 0.58, 0.6 , 0.62, 0.64,
+           0.66, 0.68, 0.7 , 0.72, 0.74, 0.76, 0.78, 0.8 , 0.82, 0.84, 0.86,
+           0.88, 0.9 , 0.92, 0.94, 0.96, 0.98, 1.  , 1.02, 1.04, 1.06, 1.08,
+           1.1 , 1.12, 1.14, 1.16, 1.18, 1.2 , 1.22, 1.24, 1.26, 1.28, 1.3 ,
+           1.32, 1.34, 1.36, 1.38, 1.4 , 1.42])
+
+
+
+.. code:: 
+    
     >>> dep.metadata['names']
-    ['Xe135', 'I135', 'U234', 'U235', 'U236', 'U238', 'Pu238',
-     'Pu239',..., 'lost', 'total']
+
+
+
+
+.. parsed-literal::
+
+    ['Xe135', 'I135', 'U234', 'U235', 'U236', 'U238',
+     'Pu238', 'Pu239', 'Pu240', 'Pu241', 'Pu242', 'Np237',
+     'Am241', 'Am243', 'Cm243', 'Cm244', 'Cm245', 'Cs133',
+     'Nd143', 'Sm147', 'Sm149', 'Sm150', 'Sm151', 'Sm152',
+     'Eu153', 'Gd155', 'Mo95', 'Tc99', 'Ru101', 'Rh103',
+     'Ag109', 'Cd113', 'lost', 'total']
+
+
 
 DepletedMaterial
 ----------------
@@ -68,11 +116,26 @@ As mentioned before, all the material data is stored inside these
 These objects share access to the metadata of the reader as well.
 
 .. code:: 
-
+    
     >>> fuel = dep.materials['fuel0']
-    >>> fuel.burnup
-    array([ 0.  ,  0.02,  0.04,  ...,  1.36,  1.38,  1.4 ,  1.42])
-    >>> fuel.days is dep.metadata['days']
+    >>> print(fuel.burnup)
+    >>> print(fuel.days is dep.metadata['days'])
+
+
+.. parsed-literal::
+
+    [0.         0.00702676 0.0144405  0.0218803  0.0297245  0.0370823
+     0.0447201  0.0513465  0.0590267  0.0671439  0.073392   0.0802637
+     0.0887954  0.0974604  0.104807   0.111528   0.119688   0.128006
+     0.135704   0.143491   0.150545   0.157608   0.165391   0.172872
+     0.180039   0.188011   0.195215   0.202291   0.20963    0.216895
+     0.224651   0.232139   0.23904    0.246076   0.25422    0.262011
+     0.269681   0.276981   0.284588   0.291835   0.299661   0.30727
+     0.314781   0.322364   0.329404   0.336926   0.34438    0.352246
+     0.360913   0.367336   0.37415    0.381556   0.388951   0.396286
+     0.404159   0.412113   0.419194   0.426587   0.43425    0.442316
+     0.449562   0.456538   0.465128   0.472592   0.479882   0.487348
+     0.494634   0.502167   0.508326   0.515086   0.522826   0.530643  ]
     True
 
 All of the variables present in the depletion file for this material are
@@ -80,15 +143,41 @@ present, stored in the |matData| dictionary. A few properties commonly
 used are accessible as attributes as well.
 
 .. code:: 
-
+    
     >>> fuel.data.keys()
-    dict_keys(['a', 'adens', 'burnup', 'gsrc', ..., 'volume'])
-    >>> fuel.adens
-    array([[  0.00000000e+00,   2.43591000e-09,   4.03796000e-09, ...,
-              4.70133000e-09,   4.70023000e-09,   4.88855000e-09],
-           ..., 
-           [  6.88332000e-02,   6.88334000e-02,   6.88336000e-02, ...,
-              6.88455000e-02,   6.88457000e-02,   6.88459000e-02]])
+
+
+
+
+.. parsed-literal::
+
+    dict_keys(['volume', 'burnup', 'adens', 'mdens', 'a', 'h', 'sf', 'gsrc', 'ingTox', 'inhTox'])
+
+
+
+.. code:: 
+    
+    >>> print(fuel.adens)
+    >>> print(fuel.adens is fuel.data['adens'])
+
+
+.. parsed-literal::
+
+    [[0.00000e+00 2.43591e-09 4.03796e-09 ... 4.70133e-09 4.70023e-09
+      4.88855e-09]
+     [0.00000e+00 6.06880e-09 8.11783e-09 ... 8.05991e-09 8.96359e-09
+      9.28554e-09]
+     [4.48538e-06 4.48486e-06 4.48432e-06 ... 4.44726e-06 4.44668e-06
+      4.44611e-06]
+     ...
+     [0.00000e+00 3.03589e-11 7.38022e-11 ... 1.62829e-09 1.63566e-09
+      1.64477e-09]
+     [0.00000e+00 1.15541e-14 2.38378e-14 ... 8.60736e-13 8.73669e-13
+      8.86782e-13]
+     [6.88332e-02 6.88334e-02 6.88336e-02 ... 6.88455e-02 6.88457e-02
+      6.88459e-02]]
+    True
+
 
 Similar to the original file, the rows of the matrix correspond to
 positions in the isotopic vector, and the columns correspond to
@@ -123,16 +212,19 @@ those specific isotopes. Data for every isotope is given if ``names`` is
 not given.
 
 .. code:: 
-
+    
     >>> dayPoints = [0, 5, 10, 30]
     >>> iso = ['Xe135', 'Sm149']
     >>> vals = fuel.getValues('days', 'a', dayPoints, iso)
     >>> print(vals.shape)
-    (2, 4)
     >>> print(vals)
-    [[  0.00000000e+00   3.28067000e+14   3.24606000e+14   3.27144000e+14]
-     [  0.00000000e+00   0.00000000e+00   0.00000000e+00   0.00000000e+00]]
-    
+
+
+.. parsed-literal::
+
+    (2, 4)
+    [[0.00000e+00 3.28067e+14 3.24606e+14 3.27144e+14]
+     [0.00000e+00 0.00000e+00 0.00000e+00 0.00000e+00]]
 
 The |depMat| uses this slicing for the built-in |depMatPlot| method, 
 which takes similar slicing arguments to |getValues|.
@@ -154,17 +246,20 @@ replacements
 | ``'zai'`` | ZZAAAI of the isotope, e.g. 922350   |
 +-----------+--------------------------------------+
 
-.. code::
-
+.. code:: 
+    
     >>> fuel.plot('days', 'adens', dayPoints, iso, 
-    >>>           ylabel='Atomic Density [#/cc]');
+    ...           ylabel='Atomic Density [#/cc]');
+
+
+
 
 .. image:: DepletionReader_files/DepletionReader_22_0.png
 
 .. code:: 
-
+    
     >>> fuel.plot('burnup', 'ingTox', names='Xe135', logy=True,
-    >>>           labelFmt="{iso}");
+    ...                  labelFmt="{iso}");
 
 .. image:: DepletionReader_files/DepletionReader_23_0.png
 
@@ -217,35 +312,41 @@ with ``bglass`` followed by at least one integer.
     equivalent to ``serpentTools.read(depFile)``
 
 .. code:: 
-
+    
     >>> rc['depletion.processTotal'] = False
     >>> rc['depletion.metadataKeys'] = ['BU']
     >>> rc['depletion.materialVariables'] = ['ADENS']
     >>> rc['depletion.materials'] = [r'bglass\d+']
-    >>>
+    >>> 
     >>> bgReader = serpentTools.parsers.DepletionReader(depFile)
     >>> bgReader.read()
-    INFO    : serpentTools: Preparing to read demo_dep.m
-    INFO    : serpentTools: Done reading depletion file
-    >>> bgReader.materials
-    {'bglass0': <serpentTools.objects.materials.DepletedMaterial at 0x239057dcb00>}
+
+.. code:: 
+    
+    >>> bgReader.materials.keys()
+
+
+
+
+.. parsed-literal::
+
+    dict_keys(['bglass0'])
+
+
+
+.. code:: 
+    
     >>> bglass = bgReader.materials['bglass0']
-    >>> bglass.data
-    {'adens': array([[ 0.       ,  0.       ,  0.       , ...,  0.       ,  0.       ,
-              0.       ],
-            [ 0.       ,  0.       ,  0.       , ...,  0.       ,  0.       ,
-              0.       ],
-            [ 0.       ,  0.       ,  0.       , ...,  0.       ,  0.       ,
-              0.       ],
-            ..., 
-            [ 0.       ,  0.       ,  0.       , ...,  0.       ,  0.       ,
-              0.       ],
-            [ 0.       ,  0.       ,  0.       , ...,  0.       ,  0.       ,
-              0.       ],
-            [ 0.0715841,  0.0715843,  0.0715845, ...,  0.0715968,  0.0715969,
-              0.0715971]])}
     >>> bglass.data.keys()
+
+
+
+
+.. parsed-literal::
+
     dict_keys(['adens'])
+
+
 
 Conclusion
 ----------

--- a/docs/examples/Detector.rst
+++ b/docs/examples/Detector.rst
@@ -44,22 +44,30 @@ Here, all energy and spatial grid data are stored,
 including other binning information such as reaction, universe, and
 lattice bins.
 
-.. code::
-
+.. code:: 
+    
+    >>> %matplotlib inline
     >>> from matplotlib import pyplot
     >>> import serpentTools
+
+.. code:: 
+    
     >>> pinFile = 'fuelPin_det0.m'
     >>> bwrFile = 'bwr_det0.m'
     >>> pin = serpentTools.read(pinFile)
     >>> bwr = serpentTools.read(bwrFile)
+
+.. code:: 
+    
     >>> print(pin.detectors)
-    {'nodeFlx': 
-        <serpentTools.objects.containers.Detector object at 0x7fb3ae1db978>}
     >>> print(bwr.detectors)
-    {'spectrum':
-        <serpentTools.objects.containers.Detector object at 0x7fb3ae1db9e8>,
-     'xymesh':
-         <serpentTools.objects.containers.Detector object at 0x7fb3ae1dba20>}
+
+
+.. parsed-literal::
+
+    {'nodeFlx': <serpentTools.objects.containers.Detector object at 0x7f6df2162b70>}
+    {'xymesh': <serpentTools.objects.containers.Detector object at 0x7f6df2162a90>, 
+     'spectrum': <serpentTools.objects.containers.Detector object at 0x7f6df2162b00>}
 
 These detectors were defined for a single fuel pin with 16 axial layers
 and a separate BWR assembly, with a description of the detectors provided in
@@ -90,23 +98,33 @@ the full tally matrix is stored in the
 |detBins| array.
 
 .. code:: 
-
+    
     >>> nodeFlx = pin.detectors['nodeFlx']
     >>> print(nodeFlx.bins.shape)
+    >>> nodeFlx.bins[:3,:].T
+
+
+.. parsed-literal::
+
     (16, 12)
-    >>> nodeFlx.bins[:3, :].T
-    array([[  1.00000000e+00,   2.00000000e+00,   3.00000000e+00],
-           [  1.00000000e+00,   1.00000000e+00,   1.00000000e+00],
-           [  1.00000000e+00,   2.00000000e+00,   3.00000000e+00],
-           [  1.00000000e+00,   1.00000000e+00,   1.00000000e+00],
-           [  1.00000000e+00,   1.00000000e+00,   1.00000000e+00],
-           [  1.00000000e+00,   1.00000000e+00,   1.00000000e+00],
-           [  1.00000000e+00,   1.00000000e+00,   1.00000000e+00],
-           [  1.00000000e+00,   1.00000000e+00,   1.00000000e+00],
-           [  1.00000000e+00,   1.00000000e+00,   1.00000000e+00],
-           [  1.00000000e+00,   1.00000000e+00,   1.00000000e+00],
-           [  2.34759000e-02,   5.75300000e-02,   8.47000000e-02],
-           [  4.53000000e-03,   3.38000000e-03,   2.95000000e-03]])
+
+
+
+
+.. parsed-literal::
+
+    array([[1.00000e+00, 2.00000e+00, 3.00000e+00],
+           [1.00000e+00, 1.00000e+00, 1.00000e+00],
+           [1.00000e+00, 2.00000e+00, 3.00000e+00],
+           [1.00000e+00, 1.00000e+00, 1.00000e+00],
+           [1.00000e+00, 1.00000e+00, 1.00000e+00],
+           [1.00000e+00, 1.00000e+00, 1.00000e+00],
+           [1.00000e+00, 1.00000e+00, 1.00000e+00],
+           [1.00000e+00, 1.00000e+00, 1.00000e+00],
+           [1.00000e+00, 1.00000e+00, 1.00000e+00],
+           [1.00000e+00, 1.00000e+00, 1.00000e+00],
+           [2.34759e-02, 5.75300e-02, 8.47000e-02],
+           [4.53000e-03, 3.38000e-03, 2.95000e-03]])
 
 Here, only three columns, shown as rows for readability, are changing:
 
@@ -119,12 +137,6 @@ Here, only three columns, shown as rows for readability, are changing:
     For SERPENT-1, there would be an additional column 12 that
     contained the scores for each bin
 
-.. code:: 
-
-    >>> nodeFlx.bins[:, 0]
-    array([  1.,   2.,   3.,   4.,   5.,   6.,   7.,   8.,   9.,  10.,  
-            11.,  12.,  13.,  14.,  15.,  16.])
-
 Once each detector is given this binned tally data, the
 :py:meth:`~serpentTools.objects.containers.Detector.reshape`
 method is called to recast the
@@ -135,18 +147,28 @@ since the only variable bin quantity is that of the universe, these
 will all be 1D arrays.
 
 .. code:: 
-
+    
     >>> assert nodeFlx.tallies.shape == (16, )
     >>> assert nodeFlx.errors.shape == (16, )
     >>> nodeFlx.tallies
-    array([ 0.0234759 ,  0.05753   ,  0.0847    ,  0.102034  ,  0.110384  ,
-            0.110174  ,  0.102934  ,  0.0928861 ,  0.0810541 ,  0.067961  ,
-            0.0550446 ,  0.0422486 ,  0.0310226 ,  0.0211475 ,  0.0125272 ,
-            0.00487726])
+
+
+.. parsed-literal::
+
+    array([0.0234759 , 0.05753   , 0.0847    , 0.102034  , 0.110384  ,
+           0.110174  , 0.102934  , 0.0928861 , 0.0810541 , 0.067961  ,
+           0.0550446 , 0.0422486 , 0.0310226 , 0.0211475 , 0.0125272 ,
+           0.00487726])
+
+.. code:: 
+    
     >>> nodeFlx.errors
-    array([ 0.00453,  0.00338,  0.00295,  0.00263,  0.00231,  0.00222,
-            0.00238,  0.00251,  0.00282,  0.00307,  0.00359,  0.00415,
-            0.00511,  0.00687,  0.00809,  0.01002])
+
+.. parsed-literal::
+
+    array([0.00453, 0.00338, 0.00295, 0.00263, 0.00231, 0.00222, 0.00238,
+           0.00251, 0.00282, 0.00307, 0.00359, 0.00415, 0.00511, 0.00687,
+           0.00809, 0.01002])
 
 Bin information is retained through the |detIndx| attribute. This is an 
 :py:class:`~collections.OrderedDict` as the keys are placed according to their column
@@ -159,17 +181,27 @@ provided in the ``DET_COLS`` tuple.
     is accessed with ``array[0]``, rather than ``array[1]``.
 
 .. code:: 
-
+    
     >>> from serpentTools.objects.containers import DET_COLS
     >>> print(DET_COLS)
+    >>> print(DET_COLS.index('cell'))
+
+
+.. parsed-literal::
+
     ('value', 'energy', 'universe', 'cell', 'material', 'lattice', 
      'reaction', 'zmesh', 'ymesh', 'xmesh', 'tally', 'error', 'scores')
-    >>> print(DET_COLS.index('cell'))
     3
+
+
+.. code:: 
+    
     >>> nodeFlx.indexes
+
+.. parsed-literal::
+
     OrderedDict([('universe',
-                  array([  1.,   2.,   3.,   4.,   5.,   6.,   7.,   8.,   
-                           9.,  10.,  11.,  12.,  13.,  14.,  15.,  16.]))])
+                  array([ 0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15]))])
 
 
 Each item in the |detIndx| ordered dictionary corresponds to the
@@ -185,14 +217,16 @@ For detectors that include some grid matrices, such as spatial or energy
 meshes ``DET<name>E``, these arrays are stored in the |detGrids| dictionary
 
 .. code:: 
-
+    
     >>> spectrum = bwr.detectors['spectrum']
     >>> print(spectrum.grids['E'][:5, :])
-    [[  1.00002000e-11   4.13994000e-07   2.07002000e-07]
-     [  4.13994000e-07   5.31579000e-07   4.72786000e-07]
-     [  5.31579000e-07   6.25062000e-07   5.78320000e-07]
-     [  6.25062000e-07   6.82560000e-07   6.53811000e-07]
-     [  6.82560000e-07   8.33681000e-07   7.58121000e-07]]
+ parsed-literal::
+
+    [[1.00002e-11 4.13994e-07 2.07002e-07]
+     [4.13994e-07 5.31579e-07 4.72786e-07]
+     [5.31579e-07 6.25062e-07 5.78320e-07]
+     [6.25062e-07 6.82560e-07 6.53811e-07]
+     [6.82560e-07 8.33681e-07 7.58121e-07]]
 
 Multi-dimensional Detectors
 ---------------------------
@@ -205,10 +239,14 @@ In the following example, the detector has been configured to tally the
 fission and capture rates (two ``dr`` arguments) in an XY mesh.
 
 .. code:: 
-
+    
     >>> xy = bwr.detectors['xymesh']
     >>> for key in xy.indexes:
-    >>>     print(key, xy.indexes[key])
+    ...     print(key, xy.indexes[key])
+
+
+.. parsed-literal::
+
     energy [0 1]
     ymesh [ 0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 17 18 19]
     xmesh [ 0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 17 18 19]
@@ -219,17 +257,19 @@ changing ``ymesh`` values, and the final axis reflects changes in
 ``xmesh``.
 
 .. code:: 
-
+    
     >>> print(xy.bins.shape)
-    (800, 12)
     >>> print(xy.tallies.shape)
-    (2, 20, 20)
     >>> print(xy.bins[:5, 10])
-    [  8.19312000e+17   7.18519000e+17   6.90079000e+17   6.22241000e+17
-       5.97257000e+17]
     >>> print(xy.tallies[0, 0, :5])
-    [  8.19312000e+17   7.18519000e+17   6.90079000e+17   6.22241000e+17
-       5.97257000e+17]
+
+
+.. parsed-literal::
+
+    (800, 12)
+    (2, 20, 20)
+    [8.19312e+17 7.18519e+17 6.90079e+17 6.22241e+17 5.97257e+17]
+    [8.19312e+17 7.18519e+17 6.90079e+17 6.22241e+17 5.97257e+17]
 
 Slicing
 ~~~~~~~
@@ -240,7 +280,7 @@ complicated. This retrieval can be simplified using the |detSlice| method.
 This method takes an argument indicating what bins (keys in |detIndx|)
 to fix at what position.
 
-If we want to retrive the tally data for the fission reaction in the
+If we want to retrieve the tally data for the fission reaction in the
 ``spectrum`` detector, you would instruct the
 |detSlice| method to use column 1 along the axis that corresponds to the reaction bin, 
 as the fission reaction corresponded to reaction tally 2 in the original
@@ -248,28 +288,32 @@ matrix. Since python and numpy arrays are zero indexed, the second
 reaction tally is stored in column 1.
 
 .. code:: 
-
+    
     >>> print(spectrum.indexes['reaction'])
-    [0 1]
     >>> spectrum.slice({'reaction': 1})[:20]
-    array([  3.66341000e+22,   6.53587000e+20,   3.01655000e+20,
-             1.51335000e+20,   3.14546000e+20,   7.45742000e+19,
-             4.73387000e+20,   2.82554000e+20,   9.89379000e+19,
-             9.49670000e+19,   8.98272000e+19,   2.04606000e+20,
-             3.58272000e+19,   1.44708000e+20,   7.25499000e+19,
-             6.31722000e+20,   2.89445000e+20,   2.15484000e+20,
-             3.59303000e+20,   3.15000000e+20])
 
-This method also works for slicing the error and score matrices by using
-``what='errors'`` or ``'scores'``, respectively.
+.. parsed-literal::
+
+    [0 1]
+
+.. parsed-literal::
+
+    array([3.66341e+22, 6.53587e+20, 3.01655e+20, 1.51335e+20, 3.14546e+20,
+           7.45742e+19, 4.73387e+20, 2.82554e+20, 9.89379e+19, 9.49670e+19,
+           8.98272e+19, 2.04606e+20, 3.58272e+19, 1.44708e+20, 7.25499e+19,
+           6.31722e+20, 2.89445e+20, 2.15484e+20, 3.59303e+20, 3.15000e+20])
+
+This method also works for slicing the error, or score, matrix
 
 .. code:: 
-
+    
     >>> spectrum.slice({'reaction': 1}, 'errors')[:20]
-    array([ 0.00692,  0.01136,  0.01679,  0.02262,  0.01537,  0.02915,
-            0.01456,  0.01597,  0.01439,  0.01461,  0.01634,  0.01336,
-            0.01549,  0.01958,  0.02165,  0.0192 ,  0.02048,  0.01715,
-            0.02055,  0.0153 ]) 
+
+.. parsed-literal::
+
+    array([0.00692, 0.01136, 0.01679, 0.02262, 0.01537, 0.02915, 0.01456,
+           0.01597, 0.01439, 0.01461, 0.01634, 0.01336, 0.01549, 0.01958,
+           0.02165, 0.0192 , 0.02048, 0.01715, 0.02055, 0.0153 ])
 
 Plotting Routines
 -----------------
@@ -324,7 +368,7 @@ documentation <https://matplotlib.org/api/_as_gen/matplotlib.pyplot.plot.html>`_
 
     >>> ax = nodeFlx.plot(steps=True, label='steps')
     >>> ax = nodeFlx.plot(sigma=100, ax=ax, c='k', alpha=0.6, 
-    >>>                   marker='x', label='sigma')
+    ...                   marker='x', label='sigma')
 
 
 .. image:: Detector_files/Detector_32_0.png
@@ -337,7 +381,7 @@ as the ``xdim`` argument sets the x-axis to be that specific index.
 .. code:: 
 
     >>> nodeFlx.plot(xdim='universe', what='errors', 
-    >>>              ylabel='Relative tally error [%]')
+    ...              ylabel='Relative tally error [%]')
 
 
 .. image:: Detector_files/Detector_34_0.png
@@ -377,8 +421,8 @@ we must pick an energy group to plot.
 .. code:: 
 
     >>> xy.meshPlot('x', 'y', fixed={'energy': 0}, 
-    >>>             cbarLabel='Mesh-integrated flux $[n/cm^2/s]$',
-    >>>             title="Fast spectrum flux $[>0.625 eV]$");
+    ...             cbarLabel='Mesh-integrated flux $[n/cm^2/s]$',
+    ...             title="Fast spectrum flux $[>0.625 eV]$");
 
 
 .. image:: Detector_files/Detector_36_0.png
@@ -397,10 +441,10 @@ being plotted.
 .. code:: 
 
     >>> ax = spectrum.meshPlot('e', 'reaction', what='errors', 
-    >>>                        ylabel='Reaction type', cmap='PuBu_r',
-    >>>                        cbarLabel="Relative error $[\%]$",
-    >>>                        xlabel='Energy [MeV]', logColor=True,
-    >>>                        logx=True);
+    ...                        ylabel='Reaction type', cmap='PuBu_r',
+    ...                        cbarLabel="Relative error $[\%]$",
+    ...                        xlabel='Energy [MeV]', logColor=True,
+    ...                        logx=True);
     >>> ax.set_yticks([0.5, 1.5]);
     >>> ax.set_yticklabels([r'$\psi$', r'$U-235 \sigma_f$'], rotation=90,
     >>>                    verticalalignment='center');
@@ -415,9 +459,9 @@ from before
 .. code:: 
 
     >>> xy.plot(fixed={'energy': 1, 'xmesh': 1}, 
-    >>>         xlabel='Y position',
-    >>>         ylabel='Thermal flux along x={}'
-    >>>         .format(xy.grids['X'][1, 0]));
+    ...         xlabel='Y position',
+    ...         ylabel='Thermal flux along x={}'
+    ...         .format(xy.grids['X'][1, 0]));
 
 .. image:: Detector_files/Detector_40_0.png
 
@@ -482,8 +526,8 @@ label each individual plot in the order of the bin index.
 .. code:: 
 
     >>> labels = (
-    >>>     'flux',
-    >>>     r'$\sigma_f^{U-235}\psi$')  # render as mathtype
+    ...     'flux',
+    ...     r'$\sigma_f^{U-235}\psi$')  # render as mathtype
     >>> spectrum.plot(labels=labels, loglog=True);
 
 .. image:: Detector_files/Detector_46_0.png

--- a/docs/examples/Detector.rst
+++ b/docs/examples/Detector.rst
@@ -188,9 +188,10 @@ provided in the ``DET_COLS`` tuple.
 
 
 .. parsed-literal::
+ 
 
-    ('value', 'energy', 'universe', 'cell', 'material', 'lattice', 
-     'reaction', 'zmesh', 'ymesh', 'xmesh', 'tally', 'error', 'scores')
+    ('value', 'energy', 'universe', 'cell', 'material', 'lattice', 'reaction',
+    'zmesh', 'ymesh', 'xmesh', 'tally', 'error', 'scores')
     3
 
 
@@ -220,13 +221,17 @@ meshes ``DET<name>E``, these arrays are stored in the |detGrids| dictionary
     
     >>> spectrum = bwr.detectors['spectrum']
     >>> print(spectrum.grids['E'][:5, :])
- parsed-literal::
+
+
+.. parsed-literal::
+ 
 
     [[1.00002e-11 4.13994e-07 2.07002e-07]
      [4.13994e-07 5.31579e-07 4.72786e-07]
-     [5.31579e-07 6.25062e-07 5.78320e-07]
+    [5.31579e-07 6.25062e-07 5.78320e-07]
      [6.25062e-07 6.82560e-07 6.53811e-07]
-     [6.82560e-07 8.33681e-07 7.58121e-07]]
+    [6.82560e-07 8.33681e-07 7.58121e-07]]
+
 
 Multi-dimensional Detectors
 ---------------------------

--- a/docs/examples/ResultsReader.rst
+++ b/docs/examples/ResultsReader.rst
@@ -28,23 +28,22 @@ inside |homogUniv| objects. Each such object has methods and attributes that
 should ease the analyses.
 
 .. code:: 
-
-    import numpy as np
-    import serpentTools
-    from serpentTools.settings import rc
-    rc['serpentVersion'] = '2.1.30'
+    
+    >>> import numpy as np
+    >>> import serpentTools
+    >>> from serpentTools.settings import rc
+    >>> rc['serpentVersion'] = '2.1.30'
 
 .. code:: 
-
-    %time
-    resFile = 'InnerAssembly_res.m'
-    res = serpentTools.read(resFile)
+    
+    >>> %time
+    >>> resFile = 'InnerAssembly_res.m'
+    >>> res = serpentTools.read(resFile)
 
 
 .. parsed-literal::
 
     Wall time: 0 ns
-    
 
 Metadata (``metadata``)
 =======================
@@ -55,9 +54,9 @@ data exist on the reader
 
 .. code:: 
 
-    print(res.metadata['version'])  # Serpent version used for the execution
-    print(res.metadata['decayDataFilePath'])  # Directory path for data libraries
-    print(res.metadata['inputFileName'])  # Directory path for data libraries
+    >>> print(res.metadata['version'])  # Serpent version used for the execution
+    >>> print(res.metadata['decayDataFilePath'])  # Directory path for data libraries
+    >>> print(res.metadata['inputFileName'])  # Directory path for data libraries
 
 
 .. parsed-literal::
@@ -71,55 +70,54 @@ Obtain all the variables in the metadata via ``.keys()``
 
 .. code:: 
 
-    res.metadata.keys()
-
-
-
+    >>> res.metadata.keys()
 
 .. parsed-literal::
-
-    dict_keys(['version', 'compileDate', 'debug', 'title', 'confidentialData', 'inputFileName', 'workingDirectory', 'hostname', 'cpuType', 'cpuMhz', 'startDate', 'completeDate', 'pop', 'cycles', 'skip', 'batchInterval', 'srcNormMode', 'seed', 'ufsMode', 'ufsOrder', 'neutronTransportMode', 'photonTransportMode', 'groupConstantGeneration', 'b1Calculation', 'b1BurnupCorrection', 'implicitReactionRates', 'optimizationMode', 'reconstructMicroxs', 'reconstructMacroxs', 'doubleIndexing', 'mgMajorantMode', 'spectrumCollapse', 'mpiTasks', 'ompThreads', 'mpiReproducibility', 'ompReproducibility', 'ompHistoryProfile', 'shareBufArray', 'shareRes2Array', 'xsDataFilePath', 'decayDataFilePath', 'sfyDataFilePath', 'nfyDataFilePath', 'braDataFilePath'])
+ 
+    dict_keys(['version', 'compileDate', 'debug', 'title', 'confidentialData',
+    'inputFileName', 'workingDirectory', 'hostname', 'cpuType', 'cpuMhz',
+    'startDate', 'completeDate', 'pop', 'cycles', 'skip', 'batchInterval',
+    'srcNormMode', 'seed', 'ufsMode', 'ufsOrder', 'neutronTransportMode',
+    'photonTransportMode', 'groupConstantGeneration', 'b1Calculation',
+    'b1BurnupCorrection', 'implicitReactionRates', 'optimizationMode',
+    'reconstructMicroxs', 'reconstructMacroxs', 'doubleIndexing', 'mgMajorantMode',
+    'spectrumCollapse', 'mpiTasks', 'ompThreads', 'mpiReproducibility',
+    'ompReproducibility', 'ompHistoryProfile', 'shareBufArray', 'shareRes2Array',
+    'xsDataFilePath', 'decayDataFilePath', 'sfyDataFilePath', 'nfyDataFilePath',
+    'braDataFilePath'])
 
 
 
 .. code:: 
-
-    # Grep the value of a certain key, e.g. simulation start date
-    res.metadata['startDate']
-
-
-
+    
+    >>> # Grep the value of a certain key, e.g. simulation start date
+    >>> res.metadata['startDate']
 
 .. parsed-literal::
-
+ 
     'Sat Apr 28 06:09:54 2018'
 
-
-
 .. code:: 
-
-    # statistics used for the execution (histories, inactive and active cycles)
-    print(res.metadata['pop'], res.metadata['skip']  , res.metadata['cycles'])
-
-
-.. parsed-literal::
-
-    [ 5000.] [ 10.] [ 50.]
     
+    >>> # statistics used for the execution (histories, inactive and active cycles)
+    >>> print(res.metadata['pop'], res.metadata['skip']  , res.metadata['cycles'])
+
+.. parsed-literal::
+ 
+    [ 5000.] [ 10.] [ 50.]
 
 .. code:: 
-
-    # Obtain the version defined in the settings
-    print('User defined version: {}'.format(rc['serpentVersion']))
-    # Obtain the version actually used in the execution
-    print('Used version: {}'.format(res.metadata['version']))
+    
+    >>> # Obtain the version defined in the settings
+    >>> print('User defined version: {}'.format(rc['serpentVersion']))
+    >>> # Obtain the version actually used in the execution
+    >>> print('Used version: {}'.format(res.metadata['version']))
 
 
 .. parsed-literal::
-
+ 
     User defined version: 2.1.30
     Used version: Serpent 2.1.30
-    
 
 Results Data (``resdata``)
 ==========================
@@ -131,25 +129,20 @@ include values and uncertainities (e.g. criticality) and some just the
 values (e.g. CPU resources).
 
 .. code:: 
-
-    # All the variables can be obtained by using 'resdata.keys()'
-    AllVariables = res.resdata.keys() # contains all the variable as a dict_keys
-    # The example below shows only the first five variables in the resdata dictionary
-    list(AllVariables)[0:5]
-
-
-
+    
+    >>> # All the variables can be obtained by using 'resdata.keys()'
+    >>> AllVariables = res.resdata.keys() # contains all the variable as a dict_keys
+    >>> # The example below shows only the first five variables in the resdata dictionary
+    >>> list(AllVariables)[0:5]
 
 .. parsed-literal::
-
+ 
     ['minMacroxs', 'dtThresh', 'stFrac', 'dtFrac', 'dtEff']
 
-
-
 .. code:: 
-
-    # Time-dependent variables, such as k-eff, are stored in 'resdata'
-    print(res.resdata['absKeff'])  # Values (1st col.) + std (2nd col.) 
+    
+    >>> # Time-dependent variables, such as k-eff, are stored in 'resdata'
+    >>> print(res.resdata['absKeff'])  # Values (1st col.) + std (2nd col.) 
 
 
 .. parsed-literal::
@@ -164,8 +157,8 @@ values (e.g. CPU resources).
 
 .. code:: 
 
-    # Obtain only the values for 'absKeff'
-    res.resdata['absKeff'][:,0]
+    >>> # Obtain only the values for 'absKeff'
+    >>> res.resdata['absKeff'][:,0]
 
 
 
@@ -178,8 +171,8 @@ values (e.g. CPU resources).
 
 .. code:: 
 
-    # Obtain only the uncertainties for 'absKeff'
-    res.resdata['absKeff'][:,1]
+    >>> # Obtain only the uncertainties for 'absKeff'
+    >>> res.resdata['absKeff'][:,1]
 
 
 
@@ -192,10 +185,10 @@ values (e.g. CPU resources).
 
 .. code:: 
 
-    # Burnup data is not written by default, a burnup mode is defined within the input file
-    # Extract burnup related quantities
-    print(res.resdata['burnup']) # burnup intervals (MWd/kg) 
-    print(res.resdata['burnDays']) # time points (days)
+    >>> # Burnup data is not written by default, a burnup mode is defined within the input file
+    >>> # Extract burnup related quantities
+    >>> print(res.resdata['burnup']) # burnup intervals (MWd/kg) 
+    >>> print(res.resdata['burnDays']) # time points (days)
 
 
 .. parsed-literal::
@@ -216,8 +209,8 @@ values (e.g. CPU resources).
 
 .. code:: 
 
-    # Some variables are stored with no uncertainties
-    print(res.resdata['totCpuTime']) # total CPU time,  
+    >>> # Some variables are stored with no uncertainties
+    >>> print(res.resdata['totCpuTime']) # total CPU time,  
 
 
 .. parsed-literal::
@@ -237,12 +230,12 @@ Basic 1-D plotting capabilities are not yet avaialble in the parser.
 
 .. code:: 
 
-    %matplotlib inline
-    import matplotlib.pyplot as plt
-    xdata = res.resdata['burnDays'][:] # obtain the time in (days)
-    ydata = res.resdata['absKeff'][:,0] # obtain the k-eff (values only)
-    plt.plot(xdata, ydata)
-    plt.xlabel('Time, days'), plt.ylabel('k-eff')               
+    >>> %matplotlib inline
+    >>> import matplotlib.pyplot as plt
+    >>> xdata = res.resdata['burnDays'][:] # obtain the time in (days)
+    >>> ydata = res.resdata['absKeff'][:,0] # obtain the k-eff (values only)
+    >>> plt.plot(xdata, ydata)
+    >>> plt.xlabel('Time, days'), plt.ylabel('k-eff')               
 
 
 
@@ -272,23 +265,28 @@ Universe data is stored for each state point, i.e.
 
 .. code:: 
 
-    # The different states are obtained by:
-    res.universes.keys()
-    # The next cell presents the various unique states ('univ',burnup, burnupIdx, time)
-
-
-
+    >>> # The different states are obtained by:
+    >>> res.universes.keys()
+    >>> # The next cell presents the various unique states ('univ',burnup, burnupIdx, time)
 
 .. parsed-literal::
-
-    dict_keys([('3101', 0.0, 1, 0.0), ('3102', 0.0, 1, 0.0), ('0', 0.0, 1, 0.0), ('3101', 0.10000000000000001, 2, 1.20048), ('3102', 0.10000000000000001, 2, 1.20048), ('0', 0.10000000000000001, 2, 1.20048), ('3101', 1.0, 3, 12.004799999999999), ('3102', 1.0, 3, 12.004799999999999), ('0', 1.0, 3, 12.004799999999999), ('3101', 2.0, 4, 24.009599999999999), ('3102', 2.0, 4, 24.009599999999999), ('0', 2.0, 4, 24.009599999999999), ('3101', 3.0, 5, 36.014400000000002), ('3102', 3.0, 5, 36.014400000000002), ('0', 3.0, 5, 36.014400000000002), ('3101', 4.0, 6, 48.019199999999998), ('3102', 4.0, 6, 48.019199999999998), ('0', 4.0, 6, 48.019199999999998)])
+ 
+    dict_keys([('3101', 0.0, 1, 0.0), ('3102', 0.0, 1, 0.0), ('0', 0.0, 1, 0.0),
+    ('3101', 0.10000000000000001, 2, 1.20048), ('3102', 0.10000000000000001, 2,
+    1.20048), ('0', 0.10000000000000001, 2, 1.20048), ('3101', 1.0, 3,
+    12.004799999999999), ('3102', 1.0, 3, 12.004799999999999), ('0', 1.0, 3,
+    12.004799999999999), ('3101', 2.0, 4, 24.009599999999999), ('3102', 2.0, 4,
+    24.009599999999999), ('0', 2.0, 4, 24.009599999999999), ('3101', 3.0, 5,
+    36.014400000000002), ('3102', 3.0, 5, 36.014400000000002), ('0', 3.0, 5,
+    36.014400000000002), ('3101', 4.0, 6, 48.019199999999998), ('3102', 4.0, 6,
+    48.019199999999998), ('0', 4.0, 6, 48.019199999999998)])
 
 
 
 .. code:: 
 
-    # Let's use the following unique state
-    print(res.universes[('3102', 0.0, 1, 0.0)])
+    >>> # Let's use the following unique state
+    >>> print(res.universes[('3102', 0.0, 1, 0.0)])
 
 
 .. parsed-literal::
@@ -296,7 +294,7 @@ Universe data is stored for each state point, i.e.
     <HomogUniv 3102: burnup: 0.000 MWd/kgu, step: 1, 0.000 days>
     
 
-Each state contains the same data fields, which can be obatined by using
+Each state contains the same data fields, which can be obtained by using
 a specific state point:
 
 ``.infExp``: infinite values, e.g. ``INF_ABS``,
@@ -336,79 +334,102 @@ one time parameter is given, the hierarchy of search is: index (highest
 priority), burnup, time (lowest priority)
 
 .. code:: 
-
-    # Examples to use various time entries
-    univ3101 = res.getUniv('3101', index=4) # obtain the results for universe=3101 and index=4 
-    univ3102 = res.getUniv('3102', burnup=0.1) # obtain the results for universe=3102 and index=0.1 MWd/kgU
-    univ0 = res.getUniv('0', timeDays=24.0096) # obtain the results for universe=0 and index=24.0096 days
+    
+    >>> # Examples to use various time entries
+    >>> univ3101 = res.getUniv('3101', index=4) # obtain the results for universe=3101 and index=4 
+    >>> univ3102 = res.getUniv('3102', burnup=0.1) # obtain the results for universe=3102 and index=0.1 MWd/kgU
+    >>> univ0 = res.getUniv('0', timeDays=24.0096) # obtain the results for universe=0 and index=24.0096 days
 
 .. code:: 
-
-    # The full states are printed below
-    print(univ3101)
-    print(univ3102)
-    print(univ0)
+    
+    >>> # The full states are printed below
+    >>> print(univ3101)
+    >>> print(univ3102)
+    >>> print(univ0)
 
 
 .. parsed-literal::
-
+ 
     <HomogUniv 3101: burnup: 2.000 MWd/kgu, step: 4, 24.010 days>
-    <HomogUniv 3102: burnup: 0.100 MWd/kgu, step: 2, 1.200 days>
-    <HomogUniv 0: burnup: 2.000 MWd/kgu, step: 4, 24.010 days>
-    
+    <HomogUniv 3102:
+    burnup: 0.100 MWd/kgu, step: 2, 1.200 days>
+    <HomogUniv 0: burnup: 2.000
+    MWd/kgu, step: 4, 24.010 days>
 
 .. code:: 
-
-    # obtain the results for universe=0 and index=1 (burnup and timeDays are inserted but not used)
-    univ0 = res.getUniv('0', burnup=0.0, index=1, timeDays=0.0)  
-    print(univ0)
+    
+    >>> # obtain the results for universe=0 and index=1 (burnup and timeDays are inserted but not used)
+    >>> univ0 = res.getUniv('0', burnup=0.0, index=1, timeDays=0.0)  
+    >>> print(univ0)
 
 
 .. parsed-literal::
-
+ 
     <HomogUniv 0: burnup: 0.000 MWd/kgu, step: 1, 0.000 days>
+
+.. code:: 
     
+    >>> # The parser reads all the variables by default
+    >>> # Each field is a dictionary, with variables as keys and corresponding values.
+    >>> univ0.infExp.keys() # obtain all the variables stored in 'infExp' field
+
+.. parsed-literal::
+ 
+    dict_keys(['infMicroFlx', 'infKinf', 'infFlx', 'infFissFlx', 'infTot',
+    'infCapt', 'infAbs', 'infFiss', 'infNsf', 'infNubar', 'infKappa', 'infInvv',
+    'infScatt0', 'infScatt1', 'infScatt2', 'infScatt3', 'infScatt4', 'infScatt5',
+    'infScatt6', 'infScatt7', 'infScattp0', 'infScattp1', 'infScattp2',
+    'infScattp3', 'infScattp4', 'infScattp5', 'infScattp6', 'infScattp7',
+    'infTranspxs', 'infDiffcoef', 'infRabsxs', 'infRemxs', 'infI135Yield',
+    'infXe135Yield', 'infPm147Yield', 'infPm148Yield', 'infPm148mYield',
+    'infPm149Yield', 'infSm149Yield', 'infI135MicroAbs', 'infXe135MicroAbs',
+    'infPm147MicroAbs', 'infPm148MicroAbs', 'infPm148mMicroAbs',
+    'infPm149MicroAbs', 'infSm149MicroAbs', 'infXe135MacroAbs', 'infSm149MacroAbs',
+    'infChit', 'infChip', 'infChid', 'infS0', 'infS1', 'infS2', 'infS3', 'infS4',
+    'infS5', 'infS6', 'infS7', 'infSp0', 'infSp1', 'infSp2', 'infSp3', 'infSp4',
+    'infSp5', 'infSp6', 'infSp7'])
+
 
 .. code:: 
-
-    # The parser reads all the variables by default
-    # Each field is a dictionary, with variables as keys and corresponding values.
-    univ0.infExp.keys() # obtain all the variables stored in 'infExp' field
-
-
+    
+    >>> # The values are all energy dependent 
+    >>> univ0.infExp['infAbs'] # obtain the infinite macroscopic xs for ('0', 0.0, 1, 0.0)
 
 
 .. parsed-literal::
-
-    dict_keys(['infMicroFlx', 'infKinf', 'infFlx', 'infFissFlx', 'infTot', 'infCapt', 'infAbs', 'infFiss', 'infNsf', 'infNubar', 'infKappa', 'infInvv', 'infScatt0', 'infScatt1', 'infScatt2', 'infScatt3', 'infScatt4', 'infScatt5', 'infScatt6', 'infScatt7', 'infScattp0', 'infScattp1', 'infScattp2', 'infScattp3', 'infScattp4', 'infScattp5', 'infScattp6', 'infScattp7', 'infTranspxs', 'infDiffcoef', 'infRabsxs', 'infRemxs', 'infI135Yield', 'infXe135Yield', 'infPm147Yield', 'infPm148Yield', 'infPm148mYield', 'infPm149Yield', 'infSm149Yield', 'infI135MicroAbs', 'infXe135MicroAbs', 'infPm147MicroAbs', 'infPm148MicroAbs', 'infPm148mMicroAbs', 'infPm149MicroAbs', 'infSm149MicroAbs', 'infXe135MacroAbs', 'infSm149MacroAbs', 'infChit', 'infChip', 'infChid', 'infS0', 'infS1', 'infS2', 'infS3', 'infS4', 'infS5', 'infS6', 'infS7', 'infSp0', 'infSp1', 'infSp2', 'infSp3', 'infSp4', 'infSp5', 'infSp6', 'infSp7'])
-
-
-
-.. code:: 
-
-    # The values are all energy dependent 
-    univ0.infExp['infAbs'] # obtain the infinite macroscopic xs for ('0', 0.0, 1, 0.0)
-
-
-
-
-.. parsed-literal::
-
+ 
     array([ 0.0170306 ,  0.0124957 ,  0.00777066,  0.00773255,  0.00699608,
-            0.00410746,  0.00334604,  0.00296948,  0.0030725 ,  0.00335412,
-            0.00403133,  0.00506587,  0.00651475,  0.00737292,  0.00907442,
-            0.0113446 ,  0.0125896 ,  0.0164987 ,  0.0181642 ,  0.0266464 ,
-            0.0292439 ,  0.0315338 ,  0.0463069 ,  0.0807952 ])
+    0.00410746,  0.00334604,  0.00296948,  0.0030725 ,  0.00335412,
+    0.00403133,  0.00506587,  0.00651475,  0.00737292,  0.00907442,
+    0.0113446 ,  0.0125896 ,  0.0164987 ,  0.0181642 ,  0.0266464 ,
+    0.0292439 ,  0.0315338 ,  0.0463069 ,  0.0807952 ])
 
+.. code:: 
+    
+    >>> # Obtain the infinite flux for ('0', 0.0, 1, 0.0)
+    >>> univ0.infExp['infFlx']
+
+.. parsed-literal::
+ 
+    array([  1.10460000e+15,   1.72386000e+16,   7.78465000e+16,
+    1.70307000e+17,   2.85783000e+17,   4.61226000e+17,
+             8.04999000e+17,
+    1.17536000e+18,   1.17488000e+18,
+             1.26626000e+18,   1.03476000e+18,
+    7.58885000e+17,
+             4.95687000e+17,   5.85369000e+17,   2.81921000e+17,
+    1.16665000e+17,   8.06833000e+16,   2.26450000e+16,
+             6.51541000e+16,
+    2.79929000e+16,   8.87468000e+15,
+             1.70822000e+15,   8.87055000e+14,
+    6.22266000e+13])
 
 
 .. code:: 
-
-    # Obtain the infinite flux for ('0', 0.0, 1, 0.0)
-    univ0.infExp['infFlx']
-
-
-
+    
+    >>> # Uncertainties can be obtained in a similar was by using the 'infUnc' field. 
+    >>> # The variables will be identical to those defined in 'infExp'
+    >>> univ0.infUnc['infFlx'] # obtain the relative uncertainty
 
 .. parsed-literal::
 
@@ -421,16 +442,11 @@ priority), burnup, time (lowest priority)
              6.51541000e+16,   2.79929000e+16,   8.87468000e+15,
              1.70822000e+15,   8.87055000e+14,   6.22266000e+13])
 
-
-
 .. code:: 
-
-    # Uncertainties can be obtained in a similar was by using the 'infUnc' field. 
-    # The variables will be identical to those defined in 'infExp'
-    univ0.infUnc['infFlx'] # obtain the relative uncertainty
-
-
-
+    
+    >>> # Uncertainties can be obtained in a similar was by using the 'infUnc' field. 
+    >>> # The variables will be identical to those defined in 'infExp'
+    >>> univ0.infUnc['infFlx'] # obtain the relative uncertainty
 
 .. parsed-literal::
 
@@ -449,27 +465,30 @@ If this card is not enabled by the user, the ``B1_`` variables will all
 be zeros.
 
 .. code:: 
-
-    # The parser reads all the variables by default
-    # Each field is a dictionary, with variables as keys and corresponding values.
-    univ0.b1Exp.keys() # obtain all the variables stored in 'b1Exp' field
-
-
-
+    
+    >>> # The parser reads all the variables by default
+    >>> # Each field is a dictionary, with variables as keys and corresponding values.
+    >>> univ0.b1Exp.keys() # obtain all the variables stored in 'b1Exp' field
 
 .. parsed-literal::
-
-    dict_keys(['b1MicroFlx', 'b1Kinf', 'b1Keff', 'b1B2', 'b1Err', 'b1Flx', 'b1FissFlx', 'b1Tot', 'b1Capt', 'b1Abs', 'b1Fiss', 'b1Nsf', 'b1Nubar', 'b1Kappa', 'b1Invv', 'b1Scatt0', 'b1Scatt1', 'b1Scatt2', 'b1Scatt3', 'b1Scatt4', 'b1Scatt5', 'b1Scatt6', 'b1Scatt7', 'b1Scattp0', 'b1Scattp1', 'b1Scattp2', 'b1Scattp3', 'b1Scattp4', 'b1Scattp5', 'b1Scattp6', 'b1Scattp7', 'b1Transpxs', 'b1Diffcoef', 'b1Rabsxs', 'b1Remxs', 'b1I135Yield', 'b1Xe135Yield', 'b1Pm147Yield', 'b1Pm148Yield', 'b1Pm148mYield', 'b1Pm149Yield', 'b1Sm149Yield', 'b1I135MicroAbs', 'b1Xe135MicroAbs', 'b1Pm147MicroAbs', 'b1Pm148MicroAbs', 'b1Pm148mMicroAbs', 'b1Pm149MicroAbs', 'b1Sm149MicroAbs', 'b1Xe135MacroAbs', 'b1Sm149MacroAbs', 'b1Chit', 'b1Chip', 'b1Chid', 'b1S0', 'b1S1', 'b1S2', 'b1S3', 'b1S4', 'b1S5', 'b1S6', 'b1S7', 'b1Sp0', 'b1Sp1', 'b1Sp2', 'b1Sp3', 'b1Sp4', 'b1Sp5', 'b1Sp6', 'b1Sp7'])
-
-
+ 
+    dict_keys(['b1MicroFlx', 'b1Kinf', 'b1Keff', 'b1B2', 'b1Err', 'b1Flx',
+    'b1FissFlx', 'b1Tot', 'b1Capt', 'b1Abs', 'b1Fiss', 'b1Nsf', 'b1Nubar',
+    'b1Kappa', 'b1Invv', 'b1Scatt0', 'b1Scatt1', 'b1Scatt2', 'b1Scatt3',
+    'b1Scatt4', 'b1Scatt5', 'b1Scatt6', 'b1Scatt7', 'b1Scattp0', 'b1Scattp1',
+    'b1Scattp2', 'b1Scattp3', 'b1Scattp4', 'b1Scattp5', 'b1Scattp6', 'b1Scattp7',
+    'b1Transpxs', 'b1Diffcoef', 'b1Rabsxs', 'b1Remxs', 'b1I135Yield',
+    'b1Xe135Yield', 'b1Pm147Yield', 'b1Pm148Yield', 'b1Pm148mYield',
+    'b1Pm149Yield', 'b1Sm149Yield', 'b1I135MicroAbs', 'b1Xe135MicroAbs',
+    'b1Pm147MicroAbs', 'b1Pm148MicroAbs', 'b1Pm148mMicroAbs', 'b1Pm149MicroAbs',
+    'b1Sm149MicroAbs', 'b1Xe135MacroAbs', 'b1Sm149MacroAbs', 'b1Chit', 'b1Chip',
+    'b1Chid', 'b1S0', 'b1S1', 'b1S2', 'b1S3', 'b1S4', 'b1S5', 'b1S6', 'b1S7',
+    'b1Sp0', 'b1Sp1', 'b1Sp2', 'b1Sp3', 'b1Sp4', 'b1Sp5', 'b1Sp6', 'b1Sp7'])
 
 .. code:: 
-
-    # Obtain the b1 fluxes for ('3101', 0.0, 1, 0.0)
-    univ3101.b1Exp['b1Flx']
-
-
-
+    
+    >>> # Obtain the b1 fluxes for ('3101', 0.0, 1, 0.0)
+    >>> univ3101.b1Exp['b1Flx']
 
 .. parsed-literal::
 
@@ -482,15 +501,10 @@ be zeros.
              3.51299000e+16,   1.46504000e+16,   4.38516000e+15,
              7.96971000e+14,   3.54233000e+14,   2.11013000e+13])
 
-
-
 .. code:: 
-
-    # Obtain the b1 fluxes for ('3101', 0.0, 1, 0.0)
-    univ3101.b1Exp['b1Abs']
-
-
-
+    
+    >>> # Obtain the b1 fluxes for ('3101', 0.0, 1, 0.0)
+    >>> univ3101.b1Exp['b1Abs']
 
 .. parsed-literal::
 
@@ -500,33 +514,25 @@ be zeros.
             0.011397  ,  0.0125957 ,  0.0167696 ,  0.0184019 ,  0.0274004 ,
             0.0286808 ,  0.0318976 ,  0.0522545 ,  0.0763042 ])
 
-
-
 Data that does not contain the prefix ``INF_`` or ``B1_`` is stored
 under the ``gc`` and ``gcUnc`` fields.
 
 Criticality, kinetic, and other variables are stored under this field.
 
 .. code:: 
-
-    univ3101.gc.keys() # obtain all the variables stored in 'gc' field
-
-
-
+    
+    >>> univ3101.gc.keys() # obtain all the variables stored in 'gc' field
 
 .. parsed-literal::
-
-    dict_keys(['cmmTranspxs', 'cmmTranspxsX', 'cmmTranspxsY', 'cmmTranspxsZ', 'cmmDiffcoef', 'cmmDiffcoefX', 'cmmDiffcoefY', 'cmmDiffcoefZ', 'betaEff', 'lambda'])
-
-
+ 
+    dict_keys(['cmmTranspxs', 'cmmTranspxsX', 'cmmTranspxsY', 'cmmTranspxsZ',
+    'cmmDiffcoef', 'cmmDiffcoefX', 'cmmDiffcoefY', 'cmmDiffcoefZ', 'betaEff',
+    'lambda'])
 
 .. code:: 
-
-    # The data included in the 'gc' field contains only the values (no uncertainties)
-    univ3101.gc['betaEff'] # obtain beta-effective
-
-
-
+    
+    >>> # The data included in the 'gc' field contains only the values (no uncertainties)
+    >>> univ3101.gc['betaEff'] # obtain beta-effective
 
 .. parsed-literal::
 
@@ -534,18 +540,13 @@ Criticality, kinetic, and other variables are stored under this field.
              5.62858000e-04,   1.04108000e-03,   5.67326000e-04,
              1.22822000e-04])
 
-
-
 ``Macro`` and ``Micro`` energy group structures are stored directly in
 the universe.
 
 .. code:: 
 
-    # Obtain the macro energy structure in MeV
-    univ3101.groups
-
-
-
+    >>> # Obtain the macro energy structure in MeV
+    >>> univ3101.groups
 
 .. parsed-literal::
 
@@ -559,15 +560,10 @@ the universe.
              4.54000000e-04,   3.12030000e-04,   1.48940000e-04,
              0.00000000e+00])
 
-
-
 .. code:: 
 
-    # Obtain the micro energy structure in MeV
-    univ3101.microGroups[:5:] # print only the five first values
-
-
-
+    >>> # Obtain the micro energy structure in MeV
+    >>> univ3101.microGroups[:5:] # print only the five first values
 
 .. parsed-literal::
 
@@ -580,48 +576,43 @@ Plotting universes
 ------------------
 
 .. code:: 
-
-    # obtain the energy grid in descending order (high to low energy)
-    xdata = univ3101.groups[1:] 
-    # obtain the inifinite abs. xs
-    ydataInf = univ3101.infExp['infAbs']
-    ydataB1 = univ3101.b1Exp['b1Abs']
+    
+    >>> # obtain the energy grid in descending order (high to low energy)
+    >>> xdata = univ3101.groups[1:] 
+    >>> # obtain the inifinite abs. xs
+    >>> ydataInf = univ3101.infExp['infAbs']
+    >>> ydataB1 = univ3101.b1Exp['b1Abs']
 
 .. code:: 
-
-    plt.plot(xdata, ydataInf,'r', label='INF')
-    plt.plot(xdata, ydataB1,'*g', label='B1')
-    plt.legend()
-    plt.xlabel('Energy, MeV'), plt.ylabel('Macroscopic absorption cross section, cm$^{-1}$')  
-
-
-
+    
+    >>> plt.plot(xdata, ydataInf,'r', label='INF')
+    >>> plt.plot(xdata, ydataB1,'*g', label='B1')
+    >>> plt.legend()
+    >>> plt.xlabel('Energy, MeV'), plt.ylabel('Macroscopic absorption cross section, cm$^{-1}$')  
 
 .. parsed-literal::
-
+ 
     (<matplotlib.text.Text at 0x1e4ca0c8a20>,
-     <matplotlib.text.Text at 0x1e4ca334cf8>)
-
-
-
+     <matplotlib.text.Text at
+    0x1e4ca334cf8>)
 
 .. image:: images/ResultsReader_51_1.png
 
 
 .. code:: 
 
-    # obtain the energy grid in descending order (high to low energy)
-    xdata = univ3101.groups[1:] 
-    # obtain the inifinite fiss. xs
-    ydata3101 = univ3101.infExp['infFiss'] # for universe 3101 and index=2
-    ydata3102 = univ3102.infExp['infFiss'] # for universe 3102 and index=4
+    >>> # obtain the energy grid in descending order (high to low energy)
+    >>> xdata = univ3101.groups[1:] 
+    >>> # obtain the inifinite fiss. xs
+    >>> ydata3101 = univ3101.infExp['infFiss'] # for universe 3101 and index=2
+    >>> ydata3102 = univ3102.infExp['infFiss'] # for universe 3102 and index=4
 
 .. code:: 
 
-    plt.plot(xdata, ydata3101,'r', label='universe 3101')
-    plt.plot(xdata, ydata3102,'*g', label='universe 3102')
-    plt.legend()
-    plt.xlabel('Energy, MeV'), plt.ylabel('Macroscopic fission cross section, cm$^{-1}$')  
+    >>> plt.plot(xdata, ydata3101,'r', label='universe 3101')
+    >>> plt.plot(xdata, ydata3102,'*g', label='universe 3102')
+    >>> plt.legend()
+    >>> plt.xlabel('Energy, MeV'), plt.ylabel('Macroscopic fission cross section, cm$^{-1}$')  
 
 
 
@@ -648,115 +639,109 @@ http://serpent-tools.readthedocs.io/en/latest/settingsTop.html
 
 .. code:: 
 
-    # Setting are all defined in 'rc'
-    from serpentTools.settings import rc
+    >>> # Setting are all defined in 'rc'
+    >>> from serpentTools.settings import rc
 
 .. code:: 
 
-    # Obtain the user defined keys
-    rc.keys()
+    >>> # Obtain the user defined keys
+    >>> rc.keys()
 
 
 
 
 .. parsed-literal::
-
-    dict_keys(['branching.areUncsPresent', 'branching.intVariables', 'branching.floatVariables', 'depletion.metadataKeys', 'depletion.materialVariables', 'depletion.materials', 'depletion.processTotal', 'detector.names', 'verbosity', 'sampler.allExist', 'sampler.freeAll', 'sampler.raiseErrors', 'sampler.skipPrecheck', 'serpentVersion', 'xs.getInfXS', 'xs.getB1XS', 'xs.reshapeScatter', 'xs.variableGroups', 'xs.variableExtras'])
+ 
+    dict_keys(['branching.areUncsPresent', 'branching.intVariables',
+    'branching.floatVariables', 'depletion.metadataKeys',
+    'depletion.materialVariables', 'depletion.materials', 'depletion.processTotal',
+    'detector.names', 'verbosity', 'sampler.allExist', 'sampler.freeAll',
+    'sampler.raiseErrors', 'sampler.skipPrecheck', 'serpentVersion', 'xs.getInfXS',
+    'xs.getB1XS', 'xs.reshapeScatter', 'xs.variableGroups', 'xs.variableExtras'])
 
 
 
 The user can modify the settings and only then use |resReader|
 
 .. code:: 
-
-    # Change the serpent version to 2.1.30
-    versionOriginal = rc['serpentVersion']
-    print('The version defined by default is {}'.format(versionOriginal)) # print the original version
-    rc['serpentVersion'] = '2.1.30'
-    print('The version set by the user is {}'.format(rc['serpentVersion'] )) # print the modified version
+    
+    >>> # Change the serpent version to 2.1.30
+    >>> versionOriginal = rc['serpentVersion']
+    >>> print('The version defined by default is {}'.format(versionOriginal)) # print the original version
+    >>> rc['serpentVersion'] = '2.1.30'
+    >>> print('The version set by the user is {}'.format(rc['serpentVersion'] )) # print the modified version
 
 
 .. parsed-literal::
-
+ 
     The version defined by default is 2.1.30
     The version set by the user is 2.1.30
+
+.. code:: 
     
+    >>> # Explicitly state which groups of variables should be stored
+    >>> # The variables for these groups are defined according to the .yaml file
+    >>> rc['xs.variableGroups'] = ['versions', 'xs', 'eig', 'burnup-coeff']
 
 .. code:: 
-
-    # Explicitly state which groups of variables should be stored
-    # The variables for these groups are defined according to the .yaml file
-    rc['xs.variableGroups'] = ['versions', 'xs', 'eig', 'burnup-coeff']
-
-.. code:: 
-
-    # The user can state which cross-sections to store
-    rc['xs.getInfXS'] = True # Obtain the infinite xs
-    rc['xs.getB1XS'] = False # Do not store the leakage corrected xs
+    
+    >>> # The user can state which cross-sections to store
+    >>> rc['xs.getInfXS'] = True # Obtain the infinite xs
+    >>> rc['xs.getB1XS'] = False # Do not store the leakage corrected xs
 
 .. code:: 
-
-    # Read the file again with the updated settings
-    resFilt = serpentTools.read(resFile)
+    
+    >>> # Read the file again with the updated settings
+    >>> resFilt = serpentTools.read(resFile)
 
 .. code:: 
-
-    # Print all the stored variables in metadata
-    resFilt.metadata.keys()
-
-
-
+    
+    >>> # Print all the stored variables in metadata
+    >>> resFilt.metadata.keys()
 
 .. parsed-literal::
-
-    dict_keys(['version', 'compileDate', 'debug', 'title', 'confidentialData', 'inputFileName', 'workingDirectory', 'hostname', 'cpuType', 'cpuMhz', 'startDate', 'completeDate'])
-
-
+ 
+    dict_keys(['version', 'compileDate', 'debug', 'title', 'confidentialData',
+    'inputFileName', 'workingDirectory', 'hostname', 'cpuType', 'cpuMhz',
+    'startDate', 'completeDate'])
 
 .. code:: 
-
-    # All the variables can be obtained by using 'resdata.keys()'
-    resFilt.resdata.keys() # contains all the variable as a dict_keys
-
-
-
+    
+    >>> # All the variables can be obtained by using 'resdata.keys()'
+    >>> resFilt.resdata.keys() # contains all the variable as a dict_keys
 
 .. parsed-literal::
-
-    dict_keys(['burnMaterials', 'burnMode', 'burnStep', 'burnup', 'burnDays', 'nubar', 'anaKeff', 'impKeff', 'colKeff', 'absKeff', 'absKinf', 'geomAlbedo'])
-
-
-
-.. code:: 
-
-    # obtain the results for universe=0 and index=1 (burnup and timeDays are inserted but not used)
-    univ0Filt = resFilt.getUniv('0', burnup=0.0, index=1, timeDays=0.0)  
+ 
+    dict_keys(['burnMaterials', 'burnMode', 'burnStep', 'burnup', 'burnDays',
+    'nubar', 'anaKeff', 'impKeff', 'colKeff', 'absKeff', 'absKinf', 'geomAlbedo'])
 
 .. code:: 
+    
+    >>> # obtain the results for universe=0 and index=1 (burnup and timeDays are inserted but not used)
+    >>> univ0Filt = resFilt.getUniv('0', burnup=0.0, index=1, timeDays=0.0)  
 
-    # Obtain all the variables stored in 'infExp' field
-    univ0Filt.infExp.keys() 
-
-
-
+.. code:: 
+    
+    >>> # Obtain all the variables stored in 'infExp' field
+    >>> univ0Filt.infExp.keys() 
 
 .. parsed-literal::
-
-    dict_keys(['infCapt', 'infAbs', 'infFiss', 'infNsf', 'infNubar', 'infKappa', 'infInvv', 'infScatt0', 'infScatt1', 'infScatt2', 'infScatt3', 'infScatt4', 'infScatt5', 'infScatt6', 'infScatt7', 'infTranspxs', 'infDiffcoef', 'infRabsxs', 'infRemxs', 'infChit', 'infChip', 'infChid', 'infS0', 'infS1', 'infS2', 'infS3', 'infS4', 'infS5', 'infS6', 'infS7'])
-
-
+ 
+    dict_keys(['infCapt', 'infAbs', 'infFiss', 'infNsf', 'infNubar', 'infKappa',
+    'infInvv', 'infScatt0', 'infScatt1', 'infScatt2', 'infScatt3', 'infScatt4',
+    'infScatt5', 'infScatt6', 'infScatt7', 'infTranspxs', 'infDiffcoef',
+    'infRabsxs', 'infRemxs', 'infChit', 'infChip', 'infChid', 'infS0', 'infS1',
+    'infS2', 'infS3', 'infS4', 'infS5', 'infS6', 'infS7'])
 
 .. code:: 
-
-    # Obtain all the variables stored in 'gc' field
-    univ0Filt.gc.keys() 
-
-
-
+    
+    >>> # Obtain all the variables stored in 'gc' field
+    >>> univ0Filt.gc.keys() 
 
 .. parsed-literal::
-
+ 
     dict_keys([])
+
 
 Conclusion
 ----------

--- a/docs/examples/Sensitivity.rst
+++ b/docs/examples/Sensitivity.rst
@@ -25,22 +25,21 @@ all the arrays and perturbation parameters contained therein. A basic
 plot method is also contained on the reader.
 
 .. code:: 
-
-    %matplotlib inline
-    from matplotlib import pyplot
-    import serpentTools
+    
+    >>> %matplotlib inline
+    >>> from matplotlib import pyplot
+    >>> import serpentTools
 
 .. code:: 
-
-    %time
-    sens = serpentTools.read('flattop_sens.m')
-
-
+    
+    >>> %time
+    >>> sens = serpentTools.read('flattop_sens.m')
 
 .. parsed-literal::
+ 
 
-    CPU times: user 2 µs, sys: 0 ns, total: 2 µs
-    Wall time: 3.81 µs
+    CPU times: user 4 µs, sys: 0 ns, total: 4 µs
+    Wall time: 7.87 µs
 
 
 The arrays that are stored in |sens| and |eneSens| 
@@ -56,29 +55,26 @@ These arrays are quite large, so only their shapes will be shown in this
 notebook.
 
 .. code:: 
-
-    print(sens.sensitivities.keys(), sens.energyIntegratedSens.keys())
-
+    
+    >>> print(sens.sensitivities.keys(), sens.energyIntegratedSens.keys())
 
 .. parsed-literal::
+ 
 
     dict_keys(['keff']) dict_keys(['keff'])
 
-
 .. code:: 
-
-    print(sens.sensitivities['keff'].shape)
-
+    
+    >>> print(sens.sensitivities['keff'].shape)
 
 .. parsed-literal::
+ 
 
     (1, 2, 7, 175, 2)
 
-
 .. code:: 
-
-    print(sens.energyIntegratedSens['keff'].shape)
-
+    
+    >>> print(sens.energyIntegratedSens['keff'].shape)
 
 .. parsed-literal::
 
@@ -90,46 +86,38 @@ The energy grid structure and lethargy widths are stored on the reader, as
 :py:attr:`~serpentTools.parsers.sensitivity.SensitivityReader.lethargyWidths`.
 
 .. code:: 
-
-    print(sens.energies.shape)
-
+    
+    >>> print(sens.energies.shape)
 
 .. parsed-literal::
 
     (176,)
 
-
 .. code:: 
-
-    print(sens.energies[:10])
-
+    
+    >>> print(sens.energies[:10])
 
 .. parsed-literal::
 
     [1.00001e-11 1.00001e-07 4.13994e-07 5.31579e-07 6.82560e-07 8.76425e-07
-     1.12300e-06 1.44000e-06 1.85539e-06 2.38237e-06]
-
+    1.12300e-06 1.44000e-06 1.85539e-06 2.38237e-06]
 
 .. code:: 
-
-    print(sens.lethargyWidths.shape)
-
+    
+    >>> print(sens.lethargyWidths.shape)
 
 .. parsed-literal::
 
     (175,)
 
-
 .. code:: 
-
-    print(sens.lethargyWidths[:10])
-
+    
+    >>> print(sens.lethargyWidths[:10])
 
 .. parsed-literal::
 
     [9.21034  1.42067  0.25     0.249999 0.250001 0.247908 0.248639 0.253452
-     0.250001 0.249999]
-
+    0.250001 0.249999]
 
 Ordered dictionaries 
 :py:attr:`~serpentTools.parsers.sensitivity.SensitivityReader.materials`,
@@ -143,34 +131,29 @@ dictionaries has the exact same structure as if the arrays were loaded
 into ``MATLAB``/``Octave``, but with zero-indexing.
 
 .. code:: 
-
-    print(sens.materials)
-
+    
+    >>> print(sens.materials)
 
 .. parsed-literal::
 
     OrderedDict([('total', 0)])
 
-
 .. code:: 
-
-    print(sens.zais)
-
+    
+    >>> print(sens.zais)
 
 .. parsed-literal::
 
     OrderedDict([('total', 0), (922380, 1)])
 
-
 .. code:: 
-
-    print(sens.perts)
-
+    
+    >>> print(sens.perts)
 
 .. parsed-literal::
 
-    OrderedDict([('total xs', 0), ('ela scatt xs', 1), ('sab scatt xs', 2), ('inl scatt xs', 3), ('capture xs', 4), ('fission xs', 5), ('nxn xs', 6)])
-
+    OrderedDict([('total xs', 0), ('ela scatt xs', 1), ('sab scatt xs', 2), ('inl
+    scatt xs', 3), ('capture xs', 4), ('fission xs', 5), ('nxn xs', 6)])
 
 Plotting
 --------
@@ -187,7 +170,7 @@ sensitivities.
 
 .. code:: 
 
-    sens.plot('keff');
+    >>> sens.plot('keff');
 
 
 
@@ -217,11 +200,9 @@ label used for each plot. The following replacements will be made:
 
 .. code:: 
 
-    ax = sens.plot('keff', 922380, mat='total', sigma=0,
-                                labelFmt="{r}: {z} {p}")
-    ax.set_xlim(1E4);  # set the lower limit to be closer to what we care about
-
-
+    >>> ax = sens.plot('keff', 922380, mat='total', sigma=0,
+    ...                labelFmt="{r}: {z} {p}")
+    >>> ax.set_xlim(1E4);  # set the lower limit to be closer to what we care about
 
 .. image:: Sensitivity_files/Sensitivity_22_0.png
 
@@ -232,9 +213,10 @@ the legend outside the plot.
 
 .. code:: 
 
-    sens.plot('keff', zai='total', pert='total xs', labelFmt="{z} -  {p}", legend='right', 
-                       normalize=False)
-    pyplot.xlim(1E4, 1E8);
+    >>> ax = sens.plot('keff', 922380, mat='total', sigma=0,
+    ...                labelFmt="{r}: {z} {p}", legend='right')
+    >>> ax.set_xlim(1E4);  # set the lower limit to be closer to what we care about
+
 
 
 
@@ -242,9 +224,9 @@ the legend outside the plot.
 
 .. code:: 
 
-    sens.plot('keff', zai='total', pert=['total xs', 'fission xs'], labelFmt="{z} -  {p}", 
-                       legend='above', ncol=2, normalize=False)
-    pyplot.xlim(1E4, 1E8);
+    >>> sens.plot('keff', zai='total', pert=['total xs', 'fission xs'], labelFmt="{z} -  {p}", 
+    ...           legend='above', ncol=2, normalize=False)
+    >>> pyplot.xlim(1E4, 1E8);
 
 
 

--- a/docs/examples/Settings.rst
+++ b/docs/examples/Settings.rst
@@ -12,53 +12,105 @@ data contained in each of the various output files. However, the
 over what data is obtained through the
 `rc <https://unix.stackexchange.com/questions/3467/what-does-rc-in-bashrc-stand-for>`_
 class. 
-The full list of default settings can be found in :ref:`defaultSettings`.
+
+All the settings are given in :ref:`default-settings` 
+showing their default values and possible options.
 
 Basic Usage
-===========
-
-The |rc| class acts as a dictionary, and updating a value is
-as simple as
+-----------
 
 .. code:: 
-
-    >> rc['verbosity'] = 'debug'
-    DEBUG   : serpentTools: Updated setting verbosity to debug
     
+    >>> import serpentTools
+    >>> from serpentTools.settings import rc
 
-The |rc| object automatically checks to make sure the value is of the
+The |rc| object can be used like a dictionary, polling all possible settings
+with the ``.keys`` method.
+.. code:: 
+    
+    >>> rc.keys()
+
+
+.. parsed-literal::
+ 
+
+    dict_keys(['depletion.processTotal', 'verbosity', 'xs.getInfXS',
+    'branching.intVariables', 'branching.areUncsPresent', 'serpentVersion',
+    'sampler.raiseErrors', 'xs.getB1XS', 'xs.variableGroups', 'xs.variableExtras',
+    'depletion.materialVariables', 'depletion.metadataKeys', 'sampler.freeAll',
+    'sampler.allExist', 'depletion.materials', 'sampler.skipPrecheck',
+    'xs.reshapeScatter', 'branching.floatVariables', 'detector.names'])
+
+Settings such as :ref:`depletion-materials` are specific for the
+:py:class:`~serpentTools.parsers.depletion.DepletionReader`, 
+while settings that are led with ``xs`` are sent to
+the :py:class:`~serpentTools.parsers.results.ResultsReader` and 
+:py:class:`~serpentTools.parsers.branching.BranchingReader` as well as their specific
+settings.
+Updating a setting is similar to setting a value in a dictionary
+
+.. code:: 
+    
+    >>> rc['verbosity'] = 'debug'
+
+
+.. parsed-literal::
+ 
+
+    DEBUG   : serpentTools: Updated setting verbosity to debug
+
+
+The ``rc`` object automatically checks to make sure the value is of the
 correct type, and is an allowable option, if given.
 
 .. code:: 
-
+    
     >>> try:
     ...     rc['depletion.metadataKeys'] = False
-    ... except TypeError as te:
+    >>> except TypeError as te:
     ...     print(te)
-    Setting depletion.metadataKeys should be of type 
-    <class 'list'>, not <class 'bool'>
+
+
+.. parsed-literal::
+ 
+
+    Setting depletion.metadataKeys should be of type <class 'list'>, not <class
+    'bool'>
+
+
+.. code:: 
+    
     >>> try:
     ...     rc['serpentVersion'] = '1.2.3'
-    ... except KeyError as ke:
+    >>> except KeyError as ke:
     ...     print(ke)
-    "Setting serpentVersion is
-    1.2.3
-    and not one of the allowed options:
-    ['2.1.29']"
 
-The |rc| object can also be used inside a context manager to revert
+
+.. parsed-literal::
+ 
+
+    'Setting serpentVersion is 1.2.3 and not one of the allowed options: 2.1.29,
+    2.1.30'
+
+
+The ``rc`` module can also be used inside a context manager to revert
 changes.
 
 .. code:: 
-
+    
     >>> with rc:
     ...     rc['depletion.metadataKeys'] = ['ZAI', 'BU']
-    >>>
+    ...     
     >>> rc['depletion.metadataKeys']
     >>> rc['verbosity'] = 'info'
+
+
+.. parsed-literal::
+ 
+
     DEBUG   : serpentTools: Updated setting depletion.metadataKeys to ['ZAI', 'BU']
-    DEBUG   : serpentTools: Updated setting depletion.metadataKeys to ['ZAI', 'NAMES', 'DAYS', 'BU']
-    ['ZAI', 'NAMES', 'DAYS', 'BU']
+    DEBUG   : serpentTools: Updated setting depletion.metadataKeys to ['ZAI',
+    'NAMES', 'DAYS', 'BU']
 
 .. _group-const-variables:
 
@@ -73,32 +125,43 @@ extracted from the results and coefficient files.
 2. :ref:`xs-variableGroups`: Select keywords that represent blocks of
    common variables
 
-These variable groups are stored in 
-`variables.yaml <https://github.com/CORE-GATECH-GROUP/serpent-tools/blob/develop/serpentTools/variables.yaml>`_
+These variable groups are described in :ref:`varialble-groups` 
 and rely upon the ``SERPENT`` version to properly expand the groups.
 
-.. code:: 
 
+.. code:: 
+    
     >>> rc['serpentVersion']
+
+.. parsed-literal::
+ 
+
     '2.1.29'
+
+.. code:: 
+    
     >>> rc['xs.variableGroups'] = ['kinetics', 'xs', 'diffusion']
     >>> rc['xs.variableExtras'] = ['XS_DATA_FILE_PATH']
     >>> varSet = rc.expandVariables()
     >>> print(sorted(varSet))
-    ['ABS', 'ADJ_IFP_ANA_BETA_EFF', 'ADJ_IFP_ANA_LAMBDA', 'ADJ_IFP_GEN_TIME',
-     'ADJ_IFP_IMP_BETA_EFF', 'ADJ_IFP_IMP_LAMBDA', 'ADJ_IFP_LIFETIME',
-     'ADJ_IFP_ROSSI_ALPHA', 'ADJ_INV_SPD', 'ADJ_MEULEKAMP_BETA_EFF',
-     'ADJ_MEULEKAMP_LAMBDA', 'ADJ_NAUCHI_BETA_EFF', 'ADJ_NAUCHI_GEN_TIME',
-     'ADJ_NAUCHI_LAMBDA', 'ADJ_NAUCHI_LIFETIME', 'ADJ_PERT_BETA_EFF',
-     'ADJ_PERT_GEN_TIME', 'ADJ_PERT_LIFETIME', 'ADJ_PERT_ROSSI_ALPHA', 'CAPT',
-     'CHID', 'CHIP', 'CHIT', 'CMM_DIFFCOEF', 'CMM_DIFFCOEF_X', 'CMM_DIFFCOEF_Y',
-     'CMM_DIFFCOEF_Z', 'CMM_TRANSPXS', 'CMM_TRANSPXS_X', 'CMM_TRANSPXS_Y',
-     'CMM_TRANSPXS_Z', 'DIFFCOEF', 'FISS', 'FWD_ANA_BETA_ZERO',
-     'FWD_ANA_LAMBDA', 'INVV', 'KAPPA', 'NSF', 'NUBAR', 'RABSXS', 'REMXS',
-     'S0', 'S1', 'S2', 'S3', 'S4', 'S5', 'S6', 'S7', 'SCATT0', 'SCATT1',
-     'SCATT2', 'SCATT3', 'SCATT4', 'SCATT5', 'SCATT6', 'SCATT7', 'TOT',
-     'TRANSPXS', 'XS_DATA_FILE_PATH']
 
+
+.. parsed-literal::
+ 
+
+    ['ABS', 'ADJ_IFP_ANA_BETA_EFF', 'ADJ_IFP_ANA_LAMBDA', 'ADJ_IFP_GEN_TIME',
+    'ADJ_IFP_IMP_BETA_EFF', 'ADJ_IFP_IMP_LAMBDA', 'ADJ_IFP_LIFETIME',
+    'ADJ_IFP_ROSSI_ALPHA', 'ADJ_INV_SPD', 'ADJ_MEULEKAMP_BETA_EFF',
+    'ADJ_MEULEKAMP_LAMBDA', 'ADJ_NAUCHI_BETA_EFF', 'ADJ_NAUCHI_GEN_TIME',
+    'ADJ_NAUCHI_LAMBDA', 'ADJ_NAUCHI_LIFETIME', 'ADJ_PERT_BETA_EFF',
+    'ADJ_PERT_GEN_TIME', 'ADJ_PERT_LIFETIME', 'ADJ_PERT_ROSSI_ALPHA', 'BETA_EFF',
+    'CAPT', 'CHID', 'CHIP', 'CHIT', 'CMM_DIFFCOEF', 'CMM_DIFFCOEF_X',
+    'CMM_DIFFCOEF_Y', 'CMM_DIFFCOEF_Z', 'CMM_TRANSPXS', 'CMM_TRANSPXS_X',
+    'CMM_TRANSPXS_Y', 'CMM_TRANSPXS_Z', 'DIFFCOEF', 'FISS', 'FWD_ANA_BETA_ZERO',
+    'FWD_ANA_LAMBDA', 'INVV', 'KAPPA', 'LAMBDA', 'NSF', 'NUBAR', 'RABSXS', 'REMXS',
+    'S0', 'S1', 'S2', 'S3', 'S4', 'S5', 'S6', 'S7', 'SCATT0', 'SCATT1', 'SCATT2',
+    'SCATT3', 'SCATT4', 'SCATT5', 'SCATT6', 'SCATT7', 'TOT', 'TRANSPXS',
+    'XS_DATA_FILE_PATH']
 
 However, one might see that the full group constant cross sections are
 not present in this set
@@ -133,15 +196,59 @@ desired setting value as the values.
 The loader also attempts to expand nested settings, like reader-specific
 settings, that may be lumped in a second level.
 
-.. code:: yaml
+::
 
     verbosity: warning
     xs.getInfXS: False
+
+However, the loader can also expand a nested dictionary structure, as
+
+::
+
     branching:
-        areUncsPresent: False
-        floatVariables: [Fhi, Blo]
+      areUncsPresent: False
+      floatVariables: [Fhi, Blo]
     depletion:
-        materials: [fuel*]
-        materialVariables:
-            [ADENS, MDENS, VOLUME]
+      materials: [fuel*]
+      materialVariables:
+        [ADENS, MDENS, VOLUME]
+
+.. code:: 
+    
+    >>> %cat myConfig.yaml
+
+
+.. parsed-literal::
+ 
+
+    xs.getInfXS: False
+    xs.getB1XS: True
+    xs.variableGroups: [gc-meta, kinetics,
+    xs]
+    branching:
+      areUncsPresent: False
+      floatVariables: [Fhi, Blo]
+    depletion:
+      materials: [fuel*]
+      metadataKeys: [NAMES, BU]
+    materialVariables:
+        [ADENS, MDENS, VOLUME]
+    serpentVersion: 2.1.29
+
+
+.. code:: 
+    
+    >>> myConf = 'myConfig.yaml'
+    >>> rc.loadYaml(myConf)
+    >>> rc['branching.areUncsPresent']
+
+.. parsed-literal::
+ 
+
+    INFO    : serpentTools: Done
+
+.. parsed-literal::
+ 
+
+    False
 

--- a/docs/examples/XSPlot.rst
+++ b/docs/examples/XSPlot.rst
@@ -17,14 +17,13 @@ as documented on the Serpent wiki. ``serpentTools`` can then read the
 output, figuring out its filetype automatically as with other readers.
 Let’s plot some data used in the ``serpentTools`` regression suite.
 
-.. code::
 
-    import serpentTools
-    %matplotlib inline
+.. code:: 
     
-    xsreader = serpentTools.read('../serpentTools/tests/plut_xs0.m')
-
-
+    >>> import serpentTools
+    >>> %matplotlib inline
+    >>> 
+    >>> xsreader = serpentTools.read('../serpentTools/tests/plut_xs0.m')
 
 This file contains some cross sections from a Serpent case containing a
 chunk of plutonium metal reflected by beryllium. Let’s see what cross
@@ -32,16 +31,12 @@ sections are available from the file:
 
 .. code::
 
-    xsreader.xsections.keys()
-
-
-
+    >>> xsreader.xsections.keys()
 
 .. parsed-literal::
-
-    dict_keys(['i4009_03c', 'i7014_03c', 'i8016_03c', 'i94239_03c', 'mbe', 'mfissile'])
-
-
+ 
+    dict_keys(['i4009_03c', 'i7014_03c', 'i8016_03c', 'i94239_03c', 'mbe',
+    'mfissile'])
 
 Notice that the important part of the reader is the |xsections|
 attribute, which contains a dictionary of named |xsdata| objects. Entries
@@ -54,7 +49,7 @@ Plotting the entries is very easy, check this out:
 
 .. code::
 
-    xsreader.xsections['i4009_03c'].plot(legend='right');
+    >>> xsreader.xsections['i4009_03c'].plot(legend='right');
 
 
 
@@ -67,7 +62,7 @@ available, and plot only a few:
 
 .. code::
 
-    xsreader.xsections['i4009_03c'].showMT()
+    >>> xsreader.xsections['i4009_03c'].showMT()
 
 
 .. parsed-literal::
@@ -87,9 +82,7 @@ available, and plot only a few:
 
 .. code::
 
-    fig2 = xsreader.xsections['i4009_03c'].plot(mts=[2, 16], title='Less busy!')
-
-
+    >>> xsreader.xsections['i4009_03c'].plot(mts=[2, 16], title='Less busy!');
 
 .. image:: images/XSPlot_files/XSPlot_11_0.png
 
@@ -100,7 +93,7 @@ meaning without requiring your reference back to the wiki.
 
 .. code::
 
-    xsreader.xsections['mfissile'].showMT()
+    >>> xsreader.xsections['mfissile'].showMT()
 
 
 .. parsed-literal::
@@ -113,10 +106,6 @@ meaning without requiring your reference back to the wiki.
     -6   Macro total fission
     -7   Macro total fission neutron production
     -16  Macro total scattering neutron production
-
-
-Note that any extra arguments passed to the plot method get passed on to
-matplotlib’s plotting, and not figure instantiations.
 
 .. code:: 
 

--- a/docs/examples/XSPlot.rst
+++ b/docs/examples/XSPlot.rst
@@ -109,7 +109,7 @@ meaning without requiring your reference back to the wiki.
 
 .. code:: 
 
-    xsreader.xsections['mfissile'].plot(mts=[-3, -6, -16], loglog=True)
+    >>> xsreader.xsections['mfissile'].plot(mts=[-3, -6, -16], loglog=True)
 
 
 .. image:: images/XSPlot_files/XSPlot_15_1.png
@@ -128,7 +128,7 @@ obtain pretty tables.
 
 .. code::
 
-    xsreader.xsections['mfissile'].xsdata
+    >>> xsreader.xsections['mfissile'].xsdata
 
 
 
@@ -160,10 +160,7 @@ obtain pretty tables.
 
 .. code::
 
-    xsreader.xsections['mfissile'].tabulate()
-
-
-
+    >>> xsreader.xsections['mfissile'].tabulate()
 
 .. raw:: html
 

--- a/examples/Settings.ipynb
+++ b/examples/Settings.ipynb
@@ -13,7 +13,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The [`serpentTools`](https://github.com/CORE-GATECH-GROUP/serpent-tools) package is designed to, without intervention, be able to store all the data contained in each of the various output files. However, the `serpentTools.settings` module grants great flexibility to the user over what data is obtained through the [`rc`](https://unix.stackexchange.com/questions/3467/what-does-rc-in-bashrc-stand-for) class. This notebook will provide as an intro into using this class."
+    "The [`serpentTools`](https://github.com/CORE-GATECH-GROUP/serpent-tools) package is designed to, without intervention, be able to store all the data contained in each of the various output files. However, the `serpentTools.settings` module grants great flexibility to the user over what data is obtained through the [`rc`](https://unix.stackexchange.com/questions/3467/what-does-rc-in-bashrc-stand-for) class. This notebook will provide as an intro into using this class.\n",
+    "\n",
+    "All the settings are given in [Default Settings](http://serpent-tools.readthedocs.io/en/latest/settingsTop.html#default-settings), showing their default values and possible options."
    ]
   },
   {
@@ -27,100 +29,37 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "INFO    : serpentTools: Using version 1.0b0+34.gce072dd.dirty\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import serpentTools\n",
-    "from serpentTools.settings import rc, defaultSettings"
+    "from serpentTools.settings import rc"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Below are the default values for each setting available"
+    "The `rc` object can be used like a dictionary, polling all possible settings with the ``keys`` method."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "branching.areUncsPresent\n",
-      "\t default - False\n",
-      "\t description - True if the values in the .coe file contain uncertainties\n",
-      "\t type - <class 'bool'>\n",
-      "branching.floatVariables\n",
-      "\t default - []\n",
-      "\t type - <class 'list'>\n",
-      "\t description - Names of state data variables to convert to floats for each branch\n",
-      "branching.intVariables\n",
-      "\t default - []\n",
-      "\t type - <class 'list'>\n",
-      "\t description - Name of state data variables to convert to integers for each branch\n",
-      "depletion.materialVariables\n",
-      "\t default - []\n",
-      "\t type - <class 'list'>\n",
-      "\t description - Names of variables to store. Empty list -> all variables.\n",
-      "depletion.materials\n",
-      "\t default - []\n",
-      "\t type - <class 'list'>\n",
-      "\t description - Names of materials to store. Empty list -> all materials.\n",
-      "depletion.metadataKeys\n",
-      "\t options - default\n",
-      "\t default - ['ZAI', 'NAMES', 'DAYS', 'BU']\n",
-      "\t type - <class 'list'>\n",
-      "\t description - Non-material data to store, i.e. zai, isotope names, burnup schedule, etc.\n",
-      "depletion.processTotal\n",
-      "\t default - True\n",
-      "\t type - <class 'bool'>\n",
-      "\t description - Option to store the depletion data from the TOT block\n",
-      "serpentVersion\n",
-      "\t options - ['2.1.29']\n",
-      "\t default - 2.1.29\n",
-      "\t type - <class 'str'>\n",
-      "\t description - Version of SERPENT\n",
-      "verbosity\n",
-      "\t options - ['critical', 'error', 'warning', 'info', 'debug']\n",
-      "\t default - info\n",
-      "\t updater - <function updateLevel at 0x7f32b2e87048>\n",
-      "\t description - Set the level of errors to be shown.\n",
-      "\t type - <class 'str'>\n",
-      "xs.getB1XS\n",
-      "\t default - True\n",
-      "\t type - <class 'bool'>\n",
-      "\t description - If true, store the critical leakage cross sections.\n",
-      "xs.getInfXS\n",
-      "\t default - True\n",
-      "\t type - <class 'bool'>\n",
-      "\t description - If true, store the infinite medium cross sections.\n",
-      "xs.variableExtras\n",
-      "\t default - []\n",
-      "\t type - <class 'list'>\n",
-      "\t description - Full SERPENT name of variables to be read\n",
-      "xs.variableGroups\n",
-      "\t default - []\n",
-      "\t type - <class 'list'>\n",
-      "\t description - Name of variable groups from variables.yaml to be expanded into SERPENT variable to be stored\n"
-     ]
+     "data": {
+      "text/plain": [
+       "dict_keys(['depletion.processTotal', 'verbosity', 'xs.getInfXS', 'branching.intVariables', 'branching.areUncsPresent', 'serpentVersion', 'sampler.raiseErrors', 'xs.getB1XS', 'xs.variableGroups', 'xs.variableExtras', 'depletion.materialVariables', 'depletion.metadataKeys', 'sampler.freeAll', 'sampler.allExist', 'depletion.materials', 'sampler.skipPrecheck', 'xs.reshapeScatter', 'branching.floatVariables', 'detector.names'])"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
-    "for setting in sorted(defaultSettings.keys()):\n",
-    "    print(setting)\n",
-    "    for key in defaultSettings[setting]:\n",
-    "        print('\\t', key, '-', defaultSettings[setting][key])"
+    "rc.keys()"
    ]
   },
   {
@@ -183,7 +122,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "'Setting serpentVersion is 1.2.3 and not one of the allowed options: 2.1.29'\n"
+      "'Setting serpentVersion is 1.2.3 and not one of the allowed options: 2.1.29, 2.1.30'\n"
      ]
     }
    ],
@@ -239,7 +178,7 @@
     "1. `xs.variableExtras`: Full `SERPENT_STYLE` variable names, i.e. `INF_TOT`, `FISSION_PRODUCT_DECAY_HEAT`\n",
     "1. `xs.variableGroups`: Select keywords that represent blocks of common variables\n",
     "\n",
-    "These variable groups are stored in `serpentTools/variables.yaml` and rely upon the `SERPENT` version to properly expand the groups."
+    "These variable groups are described in [Variable Groups](http://serpent-tools.readthedocs.io/en/latest/variableGroupsTop.html#variable-groups) and rely upon the `SERPENT` version to properly expand the groups."
    ]
   },
   {
@@ -271,7 +210,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "['ABS', 'ADJ_IFP_ANA_BETA_EFF', 'ADJ_IFP_ANA_LAMBDA', 'ADJ_IFP_GEN_TIME', 'ADJ_IFP_IMP_BETA_EFF', 'ADJ_IFP_IMP_LAMBDA', 'ADJ_IFP_LIFETIME', 'ADJ_IFP_ROSSI_ALPHA', 'ADJ_INV_SPD', 'ADJ_MEULEKAMP_BETA_EFF', 'ADJ_MEULEKAMP_LAMBDA', 'ADJ_NAUCHI_BETA_EFF', 'ADJ_NAUCHI_GEN_TIME', 'ADJ_NAUCHI_LAMBDA', 'ADJ_NAUCHI_LIFETIME', 'ADJ_PERT_BETA_EFF', 'ADJ_PERT_GEN_TIME', 'ADJ_PERT_LIFETIME', 'ADJ_PERT_ROSSI_ALPHA', 'CAPT', 'CHID', 'CHIP', 'CHIT', 'CMM_DIFFCOEF', 'CMM_DIFFCOEF_X', 'CMM_DIFFCOEF_Y', 'CMM_DIFFCOEF_Z', 'CMM_TRANSPXS', 'CMM_TRANSPXS_X', 'CMM_TRANSPXS_Y', 'CMM_TRANSPXS_Z', 'DIFFCOEF', 'FISS', 'FWD_ANA_BETA_ZERO', 'FWD_ANA_LAMBDA', 'INVV', 'KAPPA', 'NSF', 'NUBAR', 'RABSXS', 'REMXS', 'S0', 'S1', 'S2', 'S3', 'S4', 'S5', 'S6', 'S7', 'SCATT0', 'SCATT1', 'SCATT2', 'SCATT3', 'SCATT4', 'SCATT5', 'SCATT6', 'SCATT7', 'TOT', 'TRANSPXS', 'XS_DATA_FILE_PATH']\n"
+      "['ABS', 'ADJ_IFP_ANA_BETA_EFF', 'ADJ_IFP_ANA_LAMBDA', 'ADJ_IFP_GEN_TIME', 'ADJ_IFP_IMP_BETA_EFF', 'ADJ_IFP_IMP_LAMBDA', 'ADJ_IFP_LIFETIME', 'ADJ_IFP_ROSSI_ALPHA', 'ADJ_INV_SPD', 'ADJ_MEULEKAMP_BETA_EFF', 'ADJ_MEULEKAMP_LAMBDA', 'ADJ_NAUCHI_BETA_EFF', 'ADJ_NAUCHI_GEN_TIME', 'ADJ_NAUCHI_LAMBDA', 'ADJ_NAUCHI_LIFETIME', 'ADJ_PERT_BETA_EFF', 'ADJ_PERT_GEN_TIME', 'ADJ_PERT_LIFETIME', 'ADJ_PERT_ROSSI_ALPHA', 'BETA_EFF', 'CAPT', 'CHID', 'CHIP', 'CHIT', 'CMM_DIFFCOEF', 'CMM_DIFFCOEF_X', 'CMM_DIFFCOEF_Y', 'CMM_DIFFCOEF_Z', 'CMM_TRANSPXS', 'CMM_TRANSPXS_X', 'CMM_TRANSPXS_Y', 'CMM_TRANSPXS_Z', 'DIFFCOEF', 'FISS', 'FWD_ANA_BETA_ZERO', 'FWD_ANA_LAMBDA', 'INVV', 'KAPPA', 'LAMBDA', 'NSF', 'NUBAR', 'RABSXS', 'REMXS', 'S0', 'S1', 'S2', 'S3', 'S4', 'S5', 'S6', 'S7', 'SCATT0', 'SCATT1', 'SCATT2', 'SCATT3', 'SCATT4', 'SCATT5', 'SCATT6', 'SCATT7', 'TOT', 'TRANSPXS', 'XS_DATA_FILE_PATH']\n"
      ]
     }
    ],
@@ -309,7 +248,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "See the `BrancingReader` example for more information on using these settings to control scraped data."
+    "See the [`BrancingReader`](http://serpent-tools.readthedocs.io/en/latest/examples/Branching.html#settings) or [`ResultsReader`](http://serpent-tools.readthedocs.io/en/latest/examples/ResultsReader.html#user-defined-settings) examples for more information on using these settings to control scraped data."
    ]
   },
   {
@@ -317,7 +256,7 @@
    "metadata": {},
    "source": [
     "## Configuration files\n",
-    "As of version 0.1.2, the `rc` object allows for settings to be updated from a yaml configuration file using the `loadYaml` method. The file contains setting names as keys with the desired variables as values, as\n",
+    "The `rc` object allows for settings to be updated from a yaml configuration file using the `loadYaml` method. The file contains setting names as keys with the desired variables as values, as\n",
     "```\n",
     "verbosity: warning\n",
     "xs.getInfXS: False\n",
@@ -336,16 +275,51 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "xs.getInfXS: False\r\n",
+      "xs.getB1XS: True\r\n",
+      "xs.variableGroups: [gc-meta, kinetics, xs]\r\n",
+      "branching:\r\n",
+      "  areUncsPresent: False\r\n",
+      "  floatVariables: [Fhi, Blo]\r\n",
+      "depletion:\r\n",
+      "  materials: [fuel*]\r\n",
+      "  metadataKeys: [NAMES, BU]\r\n",
+      "  materialVariables:\r\n",
+      "    [ADENS, MDENS, VOLUME]\r\n",
+      "serpentVersion: 2.1.29\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "%cat myConfig.yaml"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO    : serpentTools: Done\n"
+     ]
+    },
     {
      "data": {
       "text/plain": [
        "False"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/examples/rstTemplate.tpl
+++ b/examples/rstTemplate.tpl
@@ -1,0 +1,17 @@
+
+{% extends 'rst.tpl' %}
+
+{# update code block #}
+{% block input scoped-%}
+{%- if cell.source.strip() -%}
+.. code:: 
+    
+{% for line in cell.source.split('\n') %}
+{%- if line[0] == ' ' -%}
+{{ ("... " + line) |indent}}
+{%- else -%}
+{{ (">>> " + line) |indent}}
+{%- endif %}
+{% endfor -%}
+{%- endif -%}
+{%- endblock input -%}

--- a/examples/rstTemplate.tpl
+++ b/examples/rstTemplate.tpl
@@ -6,7 +6,7 @@
 {%- if cell.source.strip() -%}
 .. code:: 
     
-{% for line in cell.source.split('\n') %}
+{% for line in cell.source.split('\n') -%}
 {%- if line[0] == ' ' -%}
 {{ ("... " + line) |indent}}
 {%- else -%}
@@ -15,3 +15,23 @@
 {% endfor -%}
 {%- endif -%}
 {%- endblock input -%}
+    
+{% block stream %}
+.. parsed-literal::
+ 
+{{ renderOutput(output.text) }}
+{% endblock stream %}
+    
+{% block data_text scoped %}
+.. parsed-literal::
+ 
+{{ renderOutput(output.data['text/plain']) }}
+{% endblock data_text %}
+    
+{% macro renderOutput(values) -%}
+{% if "array" in values -%}
+{{ values | indent }}
+{% else %}
+{{ values | wordwrap | indent }}
+{% endif %}
+{%- endmacro %}


### PR DESCRIPTION
This PR includes a new template that can be used with the `nbconvert` command with `jupyter nbconvert --to=rst --template=rstTemplate.tpl <file>` to

1. Automatically remove the `ipython3` lines that cause code-rendering to fail
1. Wrap long non-array lines to 79 characters over multiple lines
1. Create a common and consistent way to render code across readers

Code blocks are converted to
```
.. code::

    >>> for line in lines:
    ....     print(line)
```
to show good line-continuation
- [x] PR fits the [project scope](http://serpent-tools.readthedocs.io/en/latest/develop/contributing.html#project-scope)
- [x] Code to be committed is [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) and matches the [code style](http://serpent-tools.readthedocs.io/en/latest/develop/codestyle.html#code-style) of the project
- [x] New and/or changed features are [well documented](http://serpent-tools.readthedocs.io/en/latest/develop/documentation.html#documentation) 

This helps reduce the amount of code that has to be re-written each time a notebook is converted to `rst`.

Applied these changes to our examples, and updated our settings example to point to our default settings and variable groups in documentation