### PR TITLE
[DOC] Include git-based version in conf.py

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,6 +19,10 @@
 #
 import os
 import sys
+
+sys.path.append(os.path.abspath('.'))
+from _version import get_versions
+
 from unittest.mock import MagicMock
 
 ON_RTD = os.environ.get('READTHEDOCS', None) == 'True'
@@ -51,11 +55,10 @@ master_doc = 'index'
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 
-version = '0.5.0'
-release = '0.5.0'
-# Comment the following lines for version releases
-#release += '.dev'
+release = get_versions()['version']
+version = release[:release.find('+')]
 
+del get_versions
 
 # General information about the project.
 project = 'serpentTools'


### PR DESCRIPTION
Closes #172 by importing `get_version` from
`_version.py` into `docs/conf.py`.

Append the current directory of the `conf.py` file
to `sys.path` so we can import the versioneer script
and get our git-based release and version identifiers.

This gives us better information on the exact build,
and is one less thing to worry about when we do releases.