### PR TITLE
[ENH] Add BaseObject and basic compare method

### DIFF
--- a/serpentTools/messages.py
+++ b/serpentTools/messages.py
@@ -27,6 +27,14 @@ class MismatchedContainersError(SamplerError):
     """Attempting to sample from dissimilar containers"""
     pass
 
+class ComparisonError(SerpentToolsException):
+    """Base exception for errors raised while comparing objects."""
+    pass
+
+class MissingDataError(ComparisonError):
+    """One object is missing data contained on the other."""
+    pass
+
 
 LOG_OPTS = ['critical', 'error', 'warning', 'info', 'debug']
 

--- a/serpentTools/objects/__init__.py
+++ b/serpentTools/objects/__init__.py
@@ -1,7 +1,57 @@
 """Objects used to support the parsing."""
 
+class BaseObject(object):
+    """Most basic class shared by all other classes."""
 
-class NamedObject(object):
+    def compare(self, other, rtol=0., atol=0., sigma=3, strictMissing=True):
+        """
+        Compare the results of this reader to another.
+
+        Parameters
+        ----------
+        other:
+            Other reader instance against which to compare.
+            Must be a similar class as this one.
+        rtol: float
+            Relative tolerance for arrays. 
+        atol: float
+            Absolute tolerance for arrays
+        sigma: int
+            Size of confidence interval to apply to 
+            potentially random values
+        strictMissing: bool
+            If ``True``, raise Exceptions for missing data
+
+        Returns
+        -------
+        bool:
+            ``True`` if the readers are in agreement with
+            each other according to the parameters specified
+
+        Raises
+        ------
+        TypeError
+            If ``other`` is not of the same class as this class
+            nor a subclass of this class
+        :py:class:`~serpentTools.messages.MissingDataError`
+            If data is missing from ``other`` and ``strictMissing``
+        """
+        if not (isinstance(other, self.__class__) or 
+                issubclass(other.__class__, self.__class__)):
+            oName = other.__class__.__name__
+            name = self.__class__.__name__
+            raise TypeError(
+                    "Cannot compare against {} - not instance nor subclass "
+                    "of {}".format(oName, name))
+
+            return self._compare(other, rtol, atol, sigma, strictMissing)
+
+    def _compare(self, other, rtol, atol, sigma, strictMissing):
+        """Actual comparison method for similar classes."""
+        raise NotImplementedError
+
+
+class NamedObject(BaseObject):
     """Class for named objects like materials and detectors."""
 
     def __init__(self, name):

--- a/serpentTools/objects/containers.py
+++ b/serpentTools/objects/containers.py
@@ -21,7 +21,7 @@ from numpy import (array, arange, unique, log, divide, ones_like, hstack,
 from serpentTools.settings import rc
 from serpentTools.plot import (cartMeshPlot, plot, magicPlotDocDecorator,
                                formatPlot)
-from serpentTools.objects import NamedObject
+from serpentTools.objects import NamedObject, BaseObject
 from serpentTools.utils import convertVariableName
 from serpentTools.messages import warning, SerpentToolsException, debug, info
 
@@ -911,7 +911,7 @@ class Detector(DetectorBase):
         return shape
 
 
-class BranchContainer(object):
+class BranchContainer(BaseObject):
     """
     Class that stores data for a single branch.
 

--- a/serpentTools/objects/readers.py
+++ b/serpentTools/objects/readers.py
@@ -1,7 +1,8 @@
 from serpentTools.settings import rc
 from serpentTools.messages import info
+from serpentTools.objects import BaseObject
 
-class BaseReader:
+class BaseReader(BaseObject):
     """Parent class from which all parsers will inherit.
 
     Parameters


### PR DESCRIPTION
First step in the process of closing #150 by creating a `BaseObject` class with a `compare` method.
All readers and containers in this repo inherit from this object.
The `compare` method accepts:
1. Another object to be compared against this object via `x.compare(y)`
1. Relative and absolute tolerances, default to 0
1. Parameter sigma controlling the number of confidence intervals to apply to random values. Defaults to 3
1. A `strictMissing` argument used if one object is missing data found on the other. Defaults to `True`

The base `compare` method performs a check to make sure the object being compared is of the same instance or is a subclass thereof. If the objects are different in this regard, an error is raised. Otherwise, the method proceeds to the `_compare` methods that should be present and specific for each reader.

Also included two new exception classes.
1.  `ComparisonError` which is the base class for all exceptions raised specific to this comparison approach
1. `MissingDataError` which will be raised if `strictMissing` and one object is missing data found on the other.

It will be the task of separate issues and PRs to implement the specific comparison methods. This merely lays the ground work for this endeavor. 