### PR TITLE
[BUG] Point to importable directory in conf.py

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,7 +20,7 @@
 import os
 import sys
 
-sys.path.append(os.path.abspath('.'))
+sys.path.append(os.path.abspath('../serpentTools/'))
 from _version import get_versions
 
 from unittest.mock import MagicMock


### PR DESCRIPTION
conf.py now appends the serpentTools root directory via `../serpentTools`
to obtain a version of _version.py that we already track.

Previous PR #173 did not have a `_version.py` file in the `docs` directory because I forgot to tell git to track and push one. This change does the same thing as #173, but uses a `_version.py` file we 
already have to get the version information.