### PR TITLE
[DOC] Apply notices about non-cartesian mesh detectors

### DIFF
--- a/docs/examples/Detector.rst
+++ b/docs/examples/Detector.rst
@@ -544,6 +544,14 @@ label each individual plot in the order of the bin index.
 
 .. image:: Detector_files/Detector_47_0.png
 
+.. _ex-det-lims:
+
+Limitations
+-----------
+
+The |detectorReader| is unable to read files with hexagonal or curvilinear detectors.
+This issue is being tracked on GitHub as :issue:`184`.
+
 Conclusion
 ----------
 

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -65,6 +65,7 @@ Detector/ Tally File
 * Example - notebook: :ex-notebook:`Detector`
 * Example - manual: :ref:`detector-example`
 * Sampler - :class:`serpentTools.samplers.detector.DetectorSampler`
+* Limitations: Unable to read files with non-Cartesian meshes - :issue:`184`
 
 .. _ov-sensitivity:
 

--- a/examples/Detector.ipynb
+++ b/examples/Detector.ipynb
@@ -759,7 +759,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Conclusion"
+    "## Limitations\n\nThe `DetectorReader` is currently unable to read files containing hexagonal or curvilinear detectors. This issue is being tracked on GitHub as Issue [184](https://github.com/CORE-GATECH-GROUP/serpent-tools/issues/184)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Conclusion"
    ]
   },
   {


### PR DESCRIPTION
This PR applies notices in our detector examples regarding #184. The following notice is applied in our examples:

----------------------------
## Limitations
The `DetectorReader` is unable to read files with hexagonal or curvilinear detectors. This issue is being tracked on GitHub as Issue #184

----------------------------

In all places, links to the issue are provided so interested parties can view or partake in the discussion.