### PR TITLE
[TST]  Extend compareDictOfArrays - formatting

### DIFF
--- a/serpentTools/tests/__init__.py
+++ b/serpentTools/tests/__init__.py
@@ -1,7 +1,7 @@
 """
 Module for testing the ``serpentTools`` package
 """
-from os import path 
+from os import path
 from unittest import TestCase
 
 from numpy import stack
@@ -42,7 +42,8 @@ def computeMeansErrors(*arrays):
     workMat = stack(arrays)
     return workMat.mean(axis=0), workMat.std(axis=0)
 
-def compareDictOfArrays(expected, actual, fmtMsg=None, rtol=0, atol=0, 
+
+def compareDictOfArrays(expected, actual, fmtMsg=None, rtol=0, atol=0,
                         testCase=None):
     """
     Compare a dictionary of arrays.
@@ -54,8 +55,8 @@ def compareDictOfArrays(expected, actual, fmtMsg=None, rtol=0, atol=0,
     actual: dict
         Dictionary of actual data.
     fmtMsg: str
-        Message to be passed as the error message. Formatted with 
-        ``.format(key=key)``, where ``key`` is the specific key 
+        Message to be passed as the error message. Formatted with
+        ``.format(key=key)``, where ``key`` is the specific key
         where the arrays were too different.
     rtol: float
         Relative tolerance for arrays
@@ -67,7 +68,7 @@ def compareDictOfArrays(expected, actual, fmtMsg=None, rtol=0, atol=0,
     Raises
     ------
     AssertionError:
-        If the keys in both dictionaries differ, or if any 
+        If the keys in both dictionaries differ, or if any
         one array in ``actual`` is too different from it's counterpart
         in ``expected``.
     """
@@ -91,5 +92,5 @@ def compareDictOfArrays(expected, actual, fmtMsg=None, rtol=0, atol=0,
     for key, value in iteritems(expected):
         actualValue = actual[key]
         assert_allclose(value, actualValue, rtol=rtol, atol=atol,
-                err_msg=fmtMsg.format(key=key))
+                        err_msg=fmtMsg.format(key=key))
 

--- a/serpentTools/tests/__init__.py
+++ b/serpentTools/tests/__init__.py
@@ -1,10 +1,11 @@
 """
 Module for testing the ``serpentTools`` package
 """
-from os import path
+from os import path 
+from unittest import TestCase
 
 from numpy import stack
-from numpy.testing import assert_array_equal
+from numpy.testing import assert_allclose
 from six import iteritems
 
 from serpentTools import ROOT_DIR
@@ -41,10 +42,54 @@ def computeMeansErrors(*arrays):
     workMat = stack(arrays)
     return workMat.mean(axis=0), workMat.std(axis=0)
 
-def compareDictOfArrays(expected, actualDict, dataType):
+def compareDictOfArrays(expected, actual, fmtMsg=None, rtol=0, atol=0, 
+                        testCase=None):
+    """
+    Compare a dictionary of arrays.
+
+    Parameters
+    ----------
+    expected: dict
+        Dictionary of expected data
+    actual: dict
+        Dictionary of actual data.
+    fmtMsg: str
+        Message to be passed as the error message. Formatted with 
+        ``.format(key=key)``, where ``key`` is the specific key 
+        where the arrays were too different.
+    rtol: float
+        Relative tolerance for arrays
+    atol: float
+        Absolute tolerance for arrays
+    testCase: None or :class:`unittest.TestCase`
+        If given, use the ``testCase.assertSetEqual`` to compare keys
+
+    Raises
+    ------
+    AssertionError:
+        If the keys in both dictionaries differ, or if any 
+        one array in ``actual`` is too different from it's counterpart
+        in ``expected``.
+    """
+    fmtMsg = fmtMsg or "Key: {key}"
+    eKeys = set(expected.keys())
+    aKeys = set(actual.keys())
+    if isinstance(testCase, TestCase):
+        testCase.assertSetEqual(eKeys, aKeys)
+    else:
+        in1Not2 = eKeys.difference(aKeys)
+        in2Not1 = aKeys.difference(eKeys)
+        errMsg = ''
+        if any(in1Not2):
+            errMsg += ('Keys in expected not actual: {}\n'
+                       .format(', '.join(in1Not2)))
+        if any(in2Not1):
+            errMsg += ('Keys in actual not expected: {}\n'
+                       .format(', '.join(in2Not1)))
+        if errMsg:
+            raise AssertionError(errMsg)
     for key, value in iteritems(expected):
-        actual = actualDict[key]
-        assert_array_equal(value, actual, 
-                err_msg="Error in {} dictionary: key={}"
-                .format(dataType, key))
+        actualValue = actual[key]
+        assert_allclose(value, actualValue, rtol=rtol, atol=atol,
+                err_msg=fmtMsg.format(key=key))
 

--- a/serpentTools/tests/test_container.py
+++ b/serpentTools/tests/test_container.py
@@ -4,12 +4,10 @@ import unittest
 from itertools import product
 
 from six import iteritems
-from numpy import array, arange, ndarray, float64
+from numpy import arange, ndarray, float64
 from numpy.testing import assert_array_equal
 
-from serpentTools.settings import rc
 from serpentTools.objects.containers import HomogUniv
-from serpentTools.parsers import DepletionReader
 from serpentTools.tests import compareDictOfArrays
 
 NUM_GROUPS = 5
@@ -17,15 +15,15 @@ NUM_GROUPS = 5
 
 class _HomogUnivTestHelper(unittest.TestCase):
     """Class that runs the tests for the two sub-classes
-    
+
     Subclasses will differ in how the ``mat`` data
-    is arranged. For one case, the ``mat`` will be a 
+    is arranged. For one case, the ``mat`` will be a
     2D matrix.
     """
 
     def setUp(self):
         self.univ, vec, mat = self.getParams()
-        groupStructure = arange(NUM_GROUPS  + 1)
+        groupStructure = arange(NUM_GROUPS + 1)
         testK = vec[0]
         # Data definition
         rawData = {'B1_1': vec, 'B1_AS_LIST': list(vec),
@@ -39,7 +37,7 @@ class _HomogUnivTestHelper(unittest.TestCase):
                 'inf1': vec, 'infS0': mat, 'infKeff': testK, 'infKinf': testK,
                 }
         self.gcUnc = self.gc = {'cmmTranspX': vec, 'impKeff': testK}
-        self.expAttrs = {'groups': groupStructure, 'numGroups': NUM_GROUPS} 
+        self.expAttrs = {'groups': groupStructure, 'numGroups': NUM_GROUPS}
         # Use addData
         for key, value in iteritems(attrs):
             self.univ.addData(key, value)
@@ -53,8 +51,8 @@ class _HomogUnivTestHelper(unittest.TestCase):
         # Comparison
         for kk in self.univ.b1Exp:
             d[kk] = self.univ.get(kk, False)
-        compareDictOfArrays(self.b1Exp, d, 'b1 values')
-        
+        compareDictOfArrays(self.b1Exp, d, 'Error in b1 values at {key}')
+
     def test_getB1Unc(self):
         """ Get Expected vales and associated uncertainties from B1 dictionary
         """
@@ -62,7 +60,7 @@ class _HomogUnivTestHelper(unittest.TestCase):
         # Comparison
         for kk in self.univ.b1Exp:
             d[kk] = self.univ.get(kk, True)[1]
-        compareDictOfArrays(self.b1Unc, d, 'b1 uncertainties')
+        compareDictOfArrays(self.b1Unc, d, 'Error in b1 uncertainties at {key}')
 
     def test_getInfExp(self):
         """ Get Expected vales from Inf dictionary"""
@@ -70,7 +68,8 @@ class _HomogUnivTestHelper(unittest.TestCase):
         # Comparison
         for kk in self.univ.infExp:
             d[kk] = self.univ.get(kk, False)
-        compareDictOfArrays(self.infExp, d, 'infinite values')
+        compareDictOfArrays(self.infExp, d,
+                            'Error in infinite values at {key}')
 
     def test_getInfUnc(self):
         """ Get Expected vales and associated uncertainties from Inf dictionary
@@ -79,7 +78,8 @@ class _HomogUnivTestHelper(unittest.TestCase):
         # Comparison
         for kk in self.univ.infUnc:
             d[kk] = self.univ.get(kk, True)[1]
-        compareDictOfArrays(self.infUnc, d, 'infinite uncertainties')
+        compareDictOfArrays(self.infUnc, d,
+                            'Error in infinite uncertainties at {key}')
 
     def test_attributes(self):
         """ Get metaData from corresponding dictionary"""
@@ -101,7 +101,7 @@ class _HomogUnivTestHelper(unittest.TestCase):
             expected[key] = value
             uncertainties[key] = unc
         compareDictOfArrays(self.infExp, expected, 'infinite values')
-        compareDictOfArrays(self.infUnc, uncertainties, 
+        compareDictOfArrays(self.infUnc, uncertainties,
                             'infinite uncertainties')
 
 
@@ -135,6 +135,7 @@ def getParams():
 
 
 del _HomogUnivTestHelper
+
 
 class UnivTruthTester(unittest.TestCase):
     """Class that tests the various boolean evaluations for HomogUniv"""
@@ -190,7 +191,7 @@ class HomogUnivIntGroupsTester(unittest.TestCase):
             self.assertIsInstance(actual, int, msg=msg)
             expected = getattr(self, attr)
             self.assertEqual(expected, actual, msg=msg)
-    
+
     def setAs(self, func):
         """Set the number of groups to be as specific type."""
         for attr in {'numGroups', 'numMicroGroups'}:

--- a/serpentTools/tests/test_sensivity.py
+++ b/serpentTools/tests/test_sensivity.py
@@ -108,7 +108,7 @@ class SensitivityTester(unittest.TestCase):
           [  2.17649000e-03,   5.30000000e-01]]]]])
          }
         compareDictOfArrays(expected, self.reader.sensitivities, 
-                            'sensitivities')
+                            'Error in sensitivities at {key}', testCase=self)
 
     def test_integratedSensitivities(self):
         """Verify the energy integrated sensitivities are correct."""


### PR DESCRIPTION
The helper function serpentTools.tests.compareDictOfArrays
now accepts a few more arguments to make it a good catch-all
for comparing dictionaries of arrays. The arguments are:

    - expected: dictionary of expected arrays
    - actual: dictionary of actual arrays
    - fmtMsg: string that can be formatted with {key}=key,
      where key for an array that is too different from
      that in expected
    - rtol / atol : relative and absolute tolerances to
      apply to arrays
    - testCase: None or unittest.TestCase - used to compare keys
      of dictionaries

This was updated for the sensitivity and container tests.