### PR TITLE
[REL] Release 0.5.1

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,10 +6,10 @@
 Changelog
 *********
 
-.. _vNext:
+.. _v0.5.0:
 
-Next
-====
+:release-tag:`0.5.1`
+====================
 
 * :pull:`180` - Add capability to pass isotope ``zzaaai`` for 
   :py:meth:`~serpentTools.objects.materials.DepletedMaterial.getValues` 
@@ -21,6 +21,13 @@ Next
 
 * :pull:`189` - Support for reading detectors with hexagonal, cylindrical, and 
   spherical meshes.
+
+API Changes
+-----------
+
+* ``zzaaai`` data is stored on 
+  :attr:`~serpentTools.objects.materials.DepletedMaterial.zai` as a list
+  of integers, not strings
 
 .. _v0.5.0:
 

--- a/docs/contributors.rst
+++ b/docs/contributors.rst
@@ -10,4 +10,5 @@ Here are all the wonderful people that helped make this project happen
 * `Dr. Dan Kotlyar <https://github.com/CORE-GATECH>`_
 * `Stefano Terlizzi <https://github.com/sallustius>`_
 * `Gavin Ridley <https://github.com/gridley>`_
+* `Paul Romano <https://github.com/paulromano>`_
         

--- a/serpentTools/objects/detectors.py
+++ b/serpentTools/objects/detectors.py
@@ -130,6 +130,8 @@ class CartesianDetector(Detector):
     __doc__ = """
     Class that stores detector data containing cartesian meshing.
 
+    .. versionadded:: 0.5.1
+
     Parameters
     ----------
     {params:s}
@@ -161,6 +163,8 @@ class HexagonalDetector(Detector):
             3. Flat face perpendicular to y-axis"""
     __doc__ = """
     Class that stores detecto data containing a hexagonal meshing.
+
+    .. versionadded:: 0.5.1
 
     Parameters
     ----------
@@ -218,6 +222,8 @@ class CylindricalDetector(Detector):
     __doc__ = """
     Class that stores detector data containing a cylindrical mesh.
 
+    .. versionadded:: 0.5.1
+
     Parameters
     ----------
     {params:s}
@@ -265,6 +271,8 @@ class CylindricalDetector(Detector):
 class SphericalDetector(Detector):
     __doc__ = """
     Class that stores detector data containing a spherical mesh.
+
+    .. versionadded:: 0.5.1
 
     Paramters
     ---------

--- a/serpentTools/objects/materials.py
+++ b/serpentTools/objects/materials.py
@@ -18,6 +18,11 @@ class DepletedMaterialBase(NamedObject):
         dictionary that stores all variable data
     zai: list
         Isotopic ZZAAA identifiers, e.g. 93325
+
+        .. versionchanged:: 0.5.1
+
+            Now a list of integers, not strings
+
     names: list
         Names of isotopes, e.g. U235
     days: :py:class:`numpy.ndarray`
@@ -125,6 +130,8 @@ class DepletedMaterialBase(NamedObject):
             If given, return y values corresponding to isotopes with
             these ``ZZAAAI`` as would be present in ``self.zai``. Otherwise,
             return values for all isotopes.
+
+            .. versionadded:: 0.5.1
 
         Returns
         -------
@@ -280,6 +287,9 @@ class DepletedMaterial(DepletedMaterialBase):
         zai: int or list or None
             If given, plot values corresponding to these 
             isotope ``ZZAAAI`` values. Otherwise, plot for all isotopes
+
+            .. versionadded:: 0.5.1
+
         {ax}
         {legend}
         {xlabel} Otherwise, use ``xUnits``

--- a/serpentTools/parsers/depletion.py
+++ b/serpentTools/parsers/depletion.py
@@ -43,6 +43,9 @@ class DepPlotMixin(object):
         zai: int or list or None
             If given, plot values corresponding to these 
             isotope ``ZZAAAI`` values. Otherwise, plot for all isotopes
+
+            .. versionadded:: 0.5.1
+
         materials: None or list
             Selection of materials from ``self.materials`` to plot.
             If None, plot all materials, potentially including ``tot``


### PR DESCRIPTION
Added versionadded directives to new detector subclasses.
Added versionchanged directives to the depleted material
zai attribute, indicating that it is a list of integers,
not strings.

Changelog
=========

* Add capability to pass isotope ``zzaaai`` for DepletedMaterial.getValues
  and associated plot routines
* Import all readers and samplers from the main package
```
    >>> from serpentTools import ResultsReader
    >>> from serpentTools import DetectorSampler
```
* Support for reading detectors with hexagonal, cylindrical, and
  spherical meshes.

API Changes
-----------

* ``zzaaai`` data is stored on DepletedMaterial.zai as a list
  of integers, not strings