### PR TITLE
[DOC] Incorporate Zenodo badge and citation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,6 +10,10 @@ serpent-tools
     :target: http://serpent-tools.readthedocs.io/en/latest/?badge=latest
     :alt: Documentation Status
 
+.. image:: https://zenodo.org/badge/102786755.svg
+   :target: https://zenodo.org/badge/latestdoi/102786755
+   :alt: Zenodo DOI 10.5281/zenodo.1301036
+
 A suite of parsers designed to make interacting with
 ``SERPENT`` [1]_ output files simple and flawless.
 
@@ -56,12 +60,10 @@ References
 The Annals of Nuclear Energy article should be cited for all work
 using ``SERPENT``. If you wish to cite this project, please cite as::
 
-    @url{serpentTools,
-        author = {Andrew Johnson and Dan Kotlyar and Stefano Terlizzi and Gavin Ridley},
-        title = {serpentTools: A suite of parsers designed to make interacting with SERPENT outputs simple and flawless},
-        url = {https://github.com/CORE-GATECH-GROUP/serpent-tools},
-        year = {2017}
-    }
+    Andrew Johnson, Dan Kotlyar, Gavin Ridley, Stefano Terlizzi, & Paul Romano.
+    (2018, June 29). "`serpent-tools: A collection of parsing tools and
+    data containers to make interacting with SERPENT outputs easy, intuitive, and flawless.
+    <https://doi.org/10.5281/zenodo.1301036>`_,".
 
 .. [1] Leppanen, J. et al. (2015) "The Serpent Monte Carlo code: Status,
     development and applications in 2013." Ann. Nucl. Energy, `82 (2015) 142-150

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,6 +15,10 @@ Welcome to serpentTools's documentation!
     .. image:: https://readthedocs.org/projects/serpent-tools/badge/?version=latest
         :target: http://serpent-tools.readthedocs.io/en/latest/?badge=latest
         :alt: Documentation Status
+
+    .. image:: https://zenodo.org/badge/102786755.svg
+       :target: https://zenodo.org/badge/latestdoi/102786755
+       :alt: Zenodo DOI 10.5281/zenodo.1301036
   
 A suite of parsers designed to make interacting with
 ``SERPENT`` [1]_ output files simple and flawless. 
@@ -22,17 +26,18 @@ A suite of parsers designed to make interacting with
 The ``SERPENT`` Monte Carlo code
 is developed by VTT Technical Research Centre of Finland, Ltd.
 More information, including distribution and licensing of ``SERPENT`` can be
-found at `<montecarlo.vtt.fi>`_
+found at `<http://montecarlo.vtt.fi>`_
 
 The Annals of Nuclear Energy article should be cited for all work
-using ``SERPENT``. If you wish to cite this project, please cite as::
+using ``SERPENT``. 
 
-    @url{serpentTools,
-        author = {Andrew Johnson and Dan Kotlyar and Stefano Terlizzi and Gavin Ridley},
-        title = {serpentTools: A suite of parsers designed to make interacting with SERPENT outputs simple and flawless},
-        url = {https://github.com/CORE-GATECH-GROUP/serpent-tools},
-        year = {2017}
-    }
+.. admonition:: Preferred citation for attribution
+    :class: tip
+
+    Andrew Johnson, Dan Kotlyar, Gavin Ridley, Stefano Terlizzi, & Paul Romano.
+    (2018, June 29). "`serpent-tools: A collection of parsing tools and
+    data containers to make interacting with SERPENT outputs easy, intuitive, and flawless.
+    <https://doi.org/10.5281/zenodo.1301036>`_,".
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
Badge and citation added to `README.rst` and `docs/index.rst`.

The project-wide citation is listed as:

    Andrew Johnson, Dan Kotlyar, Gavin Ridley, Stefano Terlizzi, & Paul Romano.
    (2018, June 29). "`serpent-tools: A collection of parsing tools and
    data containers to make interacting with SERPENT outputs easy, intuitive, and flawless.
    <https://doi.org/10.5281/zenodo.1301036>`_,".

This specific DOI *should* always point to the latest release via Zenodo.

You can view how the README will render here: https://github.com/CORE-GATECH-GROUP/serpent-tools/blob/cac8c7e0a2f77804d6a3128112c582f0b5a05db7/README.rst