### PR TITLE
[ENH] Improved axis labeling for detector plots

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -23,6 +23,7 @@ Next
 * :pull:`205` - Access materials from :class:`serpentTools.readers.depletion.DepletionReader`
   and :class:`serpentTools.samplers.depletion.DepletionSampler` using key-like
   indexing, e.g. ``reader[matName] == reader.material[matName]``
+* :pull:`213` - Better default x-axis labels for simple detector plots
 
 .. _vNext-api:
 

--- a/serpentTools/objects/base.py
+++ b/serpentTools/objects/base.py
@@ -211,7 +211,7 @@ class DetectorBase(NamedObject):
         if ylabel is None:
             ylabel = 'Tally data'
             ylabel += ' normalized per unit lethargy' if normalize else ''
-            ylabel += r' $\pm${}\sigma$'.format(sigma) if sigma else ''
+            ylabel += r' $\pm{}\sigma$'.format(sigma) if sigma else ''
 
         ax = formatPlot(ax, loglog=loglog, logx=logx, ncol=ncol,
                         xlabel=xlabel or "Energy [MeV]", ylabel=ylabel,

--- a/serpentTools/objects/base.py
+++ b/serpentTools/objects/base.py
@@ -11,6 +11,7 @@ from matplotlib.pyplot import axes
 from serpentTools.messages import debug, warning, SerpentToolsException
 from serpentTools.plot import (
     plot, magicPlotDocDecorator, formatPlot, cartMeshPlot,
+    DETECTOR_PLOT_LABELS,
 )
 
 
@@ -402,12 +403,13 @@ class DetectorBase(NamedObject):
         return None
 
     def _getPlotXData(self, qty, ydata):
-        fallback = arange(len(ydata)), 'Bin Index'
+        fallbackX = arange(len(ydata))
+        xlabel = DETECTOR_PLOT_LABELS.get(qty, 'Bin Index')
         if qty is None:
-            return fallback
+            return fallbackX, xlabel
         xdata = self._inGridsAs(qty)
         if xdata is not None:
-            return xdata[:, 0], qty
+            return xdata[:, 0], xlabel
         if qty in self.indexes:
-            return self.indexes[qty], qty
-        return fallback
+            return self.indexes[qty], xlabel
+        return fallbackX, xlabel

--- a/serpentTools/plot.py
+++ b/serpentTools/plot.py
@@ -115,7 +115,23 @@ DEPLETION_PLOT_LABELS = {
     'burnup': 'Burnup $[MWd/kgU]$',
 }
 
+DETECTOR_PLOT_LABELS = {
+    'energy': 'Energy [MeV]',
+    'xmesh': 'X Position [cm]',
+    'ymesh': 'Y Position [cm]',
+    'zmesh': 'Z Position [cm]',
+}
 
+_DET_LABEL_INDEXES = {
+    'reaction', 'material', 'cell', 'universe', 'lattice',
+}
+# bins that increment by integer indices and reflect discrete quantities,
+# unlike energy inidices
+
+for key in _DET_LABEL_INDEXES:
+    DETECTOR_PLOT_LABELS[key] = key.capitalize() + " Index"
+
+del _DET_LABEL_INDEXES
 def magicPlotDocDecorator(f):
     """
     Decorator that replaces a lot magic strings used in plot functions.


### PR DESCRIPTION

Make sure you have read over the developer guide to ease
the review process. These include:
The following mapping is used for determining the default x label:
    - energy: Energy [MeV]
    - reaction: Reaction Index
    - material: Material Index
    - cell: Cell Index
    - lattice: Lattice Index
    - universe: Universe Index

For x/y/zmesh arguments, the default x-axis label is "{X|Y|Z} Position [cm]"

Removed a rogue `$` in our spectrum plot default y-label that messed up the LaTeX rendering. Now it looks much better

- [x] PR fits the [project scope](http://serpent-tools.readthedocs.io/en/latest/develop/contributing.html#project-scope)
- [x] Code to be committed is [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) and matches the [code style](http://serpent-tools.readthedocs.io/en/latest/develop/codestyle.html#code-style) of the project
- [x] New and/or changed features are [well documented](http://serpent-tools.readthedocs.io/en/latest/develop/documentation.html#documentation) and have adequate testing

## TODO
- [x] Add this PR to changelog