### PR TITLE
[DOC] Add notice about detector energy grid structure

### DIFF
--- a/docs/api/detectors.rst
+++ b/docs/api/detectors.rst
@@ -4,5 +4,12 @@
 Detectors
 ---------
 
+.. note::
+
+    Energy grids stored in ``grids`` are in order of increasing
+    energy, exactly as they appear in the output file. The three
+    columns of this array correspond to lower bound, upper bound,
+    and mid-point of that energy group
+
 .. automodule:: serpentTools.objects.detectors
 

--- a/serpentTools/objects/detectors.py
+++ b/serpentTools/objects/detectors.py
@@ -10,8 +10,9 @@ The detectors contained in this module are tasked with storing such
 data and proving easy access to the data, as well as the underlying
 bins used to define the detector.
 
-Detectors
----------
+Detector Types
+--------------
+
 * :class:`~serpentTools.objects.detectors.Detector`
 * :class:`~serpentTools.objects.detectors.CartesianDetector`
 * :class:`~serpentTools.objects.detectors.HexagonalDetector`


### PR DESCRIPTION
Closes #105 

Add a note in docs/api/detectors.rst about the structure of the energy grid: order of energy groups and the contents of the columns