### PR TITLE
[API/TST] Better x/y labels for sensitivity plots; Test sensitivity plot

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,6 +12,8 @@ Next
 ====
 
 * :pull:`221` - Expanded ``utils`` module to better assist developers
+* :pull:`229` - :meth:`serpentTools.parsers.sensitivity.SensitivityReader.plot`
+  now respects the option to not set x nor y labels.
 
 .. _v0.5.2:
 

--- a/serpentTools/parsers/sensitivity.py
+++ b/serpentTools/parsers/sensitivity.py
@@ -332,13 +332,13 @@ class SensitivityReader(BaseReader):
             ax.errorbar(energies, yVals, yErrs, label=label,
                         drawstyle='steps-post')
 
-        xlabel = xlabel or 'Energy [eV]'
-        ylabel = ylabel or (
+        xlabel = 'Energy [eV]' if xlabel is None else xlabel
+        ylabel = ylabel if ylabel is not None else (
             'Sensitivity {} {}'.format(
                 'per unit lethargy' if normalize else '',
                 r'$\pm{}\sigma$'.format(sigma) if sigma else ''))
         ax = formatPlot(ax, loglog=loglog, logx=logx, logy=logy, ncol=ncol,
-                        legend=legend, xlabel=xlabel, ylabel=ylabel)
+                        legend=legend, xlabel=xlabel, ylabel=ylabel.strip())
         return ax
 
     def _getCleanedPertOpt(self, key, value):

--- a/serpentTools/parsers/sensitivity.py
+++ b/serpentTools/parsers/sensitivity.py
@@ -235,7 +235,7 @@ class SensitivityReader(BaseReader):
 
     @magicPlotDocDecorator
     def plot(self, resp, zai=None, pert=None, mat=None, sigma=3,
-             normalize=True, ax=None, labelFmt=None, titleFmt=None,
+             normalize=True, ax=None, labelFmt=None,
              title=None, logx=True, logy=False, loglog=False, xlabel=None,
              ylabel=None, legend=True, ncol=1):
         """

--- a/serpentTools/parsers/sensitivity.py
+++ b/serpentTools/parsers/sensitivity.py
@@ -344,11 +344,11 @@ class SensitivityReader(BaseReader):
     def _getCleanedPertOpt(self, key, value):
         """Return a set of all or some of the requested perturbations."""
         assert hasattr(self, key), key
-        opts = set(getattr(self, key).keys())
+        opts = getattr(self, key).keys()
         if value is None:
-            return opts
+            return list(opts)
         requested = set([value, ]) if isinstance(value, str) else set(value)
-        missing = {str(xx) for xx in requested.difference(opts)}
+        missing = {str(xx) for xx in requested.difference(set(opts))}
         if missing:
             raise KeyError("Could not find the following perturbations: "
                            "{}".format(', '.join(missing)))

--- a/serpentTools/tests/utils.py
+++ b/serpentTools/tests/utils.py
@@ -2,6 +2,7 @@
 Utilities to make testing easier
 """
 
+from functools import wraps
 from unittest import TestCase
 from logging import NOTSET
 
@@ -163,3 +164,20 @@ class TestCaseWithLogCapture(TestCase, LoggerMixin):
         failMsg = "Found {} match for {} under {} but should not have"
         self.assertFalse(self.msgInLogs(level, msg, partial),
                          msg=failMsg.format(matchType, msg, level))
+
+
+def plotTest(f):
+    """Decorator that clears up existing plots prior to test."""
+    from matplotlib.pyplot import close, figure
+    @wraps(f)
+    def wrappedTest(*args, **kwargs):
+        close('all')
+        figure()
+        return f(*args, **kwargs)
+    return wrappedTest
+
+
+def getLegendTexts(ax):
+    """Return all texts for items in legend."""
+    lgd = ax.legend()
+    return [item.get_text() for item in lgd.get_texts()]

--- a/serpentTools/tests/utils.py
+++ b/serpentTools/tests/utils.py
@@ -169,6 +169,7 @@ class TestCaseWithLogCapture(TestCase, LoggerMixin):
 def plotTest(f):
     """Decorator that clears up existing plots prior to test."""
     from matplotlib.pyplot import close, figure
+
     @wraps(f)
     def wrappedTest(*args, **kwargs):
         close('all')


### PR DESCRIPTION
Previously there was not way to not set the x/y labels for a sensitivity plot. If the passed value did not evaluate to True, then the default was used. This mainly occurred during subplotting routines. Now, passing an argument that does not evaluate to True will not trigger the default x/y label, and result in not setting the label.

Also added some testing for the sensitivity plotter. Mainly for label formatting and x/y axis label setting.

- [x] PR fits the [project scope](http://serpent-tools.readthedocs.io/en/latest/develop/contributing.html#project-scope)
- [x] Code to be committed is [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) and matches the [code style](http://serpent-tools.readthedocs.io/en/latest/develop/codestyle.html#code-style) of the project
- [x] New and/or changed features are [well documented](http://serpent-tools.readthedocs.io/en/latest/develop/documentation.html#documentation) and have adequate testing

## TODO
- [x] Add this PR to changelog
- [x] Remove the useless `titleFmt` argument for the plot