### PR TITLE
[DEV] Direct compare all arrays

### DIFF
--- a/serpentTools/tests/test_utils.py
+++ b/serpentTools/tests/test_utils.py
@@ -207,16 +207,20 @@ class DirectCompareTester(TestCase):
     def test_notImplemented(self):
         """Check the not-implemented cases."""
         self.checkStatus(DC_STAT_NOT_IMPLEMENTED, {'hello': 'world'},
-                         {'hello': 'world'}, 0, 0, msg="testing on dictionaries")
+                         {'hello': 'world'}, 0, 0,
+                         msg="testing on dictionaries")
 
     def test_stringArrays(self):
         """Verify the function handles string arrays properly."""
         stringList = ['hello', 'world', '1', '-1']
         vec0 = array(stringList)
-        self.checkStatus(DC_STAT_GOOD, vec0, vec0, 0, 0, msg='Identical string arrays')
+        self.checkStatus(DC_STAT_GOOD, vec0, vec0, 0, 0,
+                         msg='Identical string arrays')
         vec1 = array(stringList)
         vec1[-1] = 'foobar'
-        self.checkStatus(DC_STAT_NOT_IDENTICAL, vec0, vec1, 0, 0, msg='Dissimilar string arrays')
+        self.checkStatus(DC_STAT_NOT_IDENTICAL, vec0, vec1, 0, 0,
+                         msg='Dissimilar string arrays')
+
 
 class OverlapTester(TestCase):
     """Class for testing the Overlapping uncertainties function."""

--- a/serpentTools/tests/test_utils.py
+++ b/serpentTools/tests/test_utils.py
@@ -16,6 +16,13 @@ from serpentTools.utils import (
     directCompare,
     getOverlaps,
     splitDictByKeys,
+    DC_STAT_GOOD,
+    DC_STAT_LE_LOWER,
+    DC_STAT_MID,
+    DC_STAT_GE_UPPER,
+    DC_STAT_NOT_IDENTICAL,
+    DC_STAT_NOT_IMPLEMENTED,
+    DC_STAT_DIFF_TYPES,
 )
 
 
@@ -150,7 +157,7 @@ class DirectCompareTester(TestCase):
 
     def test_badTypes(self):
         """Verify that two objects of different types return -1."""
-        status = 255
+        status = DC_STAT_DIFF_TYPES
         value = 1
         for otherType in (bool, str):
             self.checkStatus(status, value, otherType(value), 0, 1,
@@ -163,13 +170,13 @@ class DirectCompareTester(TestCase):
     def test_identicalString(self):
         """Verify that identical strings return 0."""
         msg = obj = 'identicalStrings'
-        status = 0
+        status = DC_STAT_GOOD
         self.checkStatus(status, obj, obj, 0, 1, msg=msg)
 
     def test_dissimilarString(self):
         """Verify returns the proper code for dissimilar strings."""
         msg = "dissimilarStrings"
-        status = 200
+        status = DC_STAT_NOT_IDENTICAL
         self.checkStatus(status, 'item0', 'item1', 0, 1, msg=msg)
 
     def _testNumericsForItems(self, status, lower, upper):
@@ -183,19 +190,24 @@ class DirectCompareTester(TestCase):
         """Verify returns the proper code for close numerics."""
         lower = 5
         upper = 1E4
-        self._testNumericsForItems(1, lower, upper)
+        self._testNumericsForItems(DC_STAT_LE_LOWER, lower, upper)
 
     def test_acceptableHigh(self):
         """Verify returns the proper code for close but not quite values."""
         lower = 0
         upper = 1E4
-        self._testNumericsForItems(10, lower, upper)
+        self._testNumericsForItems(DC_STAT_MID, lower, upper)
 
     def test_outsideTols(self):
         """Verify returns the proper code for values outside tolerances."""
         lower = 1E-8
         upper = 1E-8
-        self._testNumericsForItems(100, lower, upper)
+        self._testNumericsForItems(DC_STAT_GE_UPPER, lower, upper)
+
+    def test_notImplemented(self):
+        """Check the not-implemented cases."""
+        self.checkStatus(DC_STAT_NOT_IMPLEMENTED, {'hello': 'world'},
+                         {'hello': 'world'}, 0, 0, msg="Testing on dictionaries")
 
 
 class OverlapTester(TestCase):

--- a/serpentTools/tests/test_utils.py
+++ b/serpentTools/tests/test_utils.py
@@ -149,11 +149,11 @@ class DirectCompareTester(TestCase):
         [array([1, 1, ]), array([1, 1.0001])],
     )
 
-    def checkStatus(self, expected, *args, **kwargs):
+    def checkStatus(self, expected, obj0, obj1, lower, upper, msg=None):
         """Wrapper around directCompare with ``args``. Pass ``kwargs`` to
         assertEqual."""
-        actual = directCompare(*args)
-        self.assertEqual(expected, actual, **kwargs)
+        actual = directCompare(obj0, obj1, lower, upper)
+        self.assertEqual(expected, actual, msg=msg)
 
     def test_badTypes(self):
         """Verify that two objects of different types return -1."""

--- a/serpentTools/tests/test_utils.py
+++ b/serpentTools/tests/test_utils.py
@@ -207,8 +207,16 @@ class DirectCompareTester(TestCase):
     def test_notImplemented(self):
         """Check the not-implemented cases."""
         self.checkStatus(DC_STAT_NOT_IMPLEMENTED, {'hello': 'world'},
-                         {'hello': 'world'}, 0, 0, msg="Testing on dictionaries")
+                         {'hello': 'world'}, 0, 0, msg="testing on dictionaries")
 
+    def test_stringArrays(self):
+        """Verify the function handles string arrays properly."""
+        stringList = ['hello', 'world', '1', '-1']
+        vec0 = array(stringList)
+        self.checkStatus(DC_STAT_GOOD, vec0, vec0, 0, 0, msg='Identical string arrays')
+        vec1 = array(stringList)
+        vec1[-1] = 'foobar'
+        self.checkStatus(DC_STAT_NOT_IDENTICAL, vec0, vec1, 0, 0, msg='Dissimilar string arrays')
 
 class OverlapTester(TestCase):
     """Class for testing the Overlapping uncertainties function."""

--- a/serpentTools/utils/compare.py
+++ b/serpentTools/utils/compare.py
@@ -1,6 +1,9 @@
 """
 Comparison utilities
 """
+
+from collections import Iterable
+
 from numpy import (
     fabs, zeros_like, ndarray, array, greater, multiply, subtract,
     equal,
@@ -145,7 +148,7 @@ def directCompare(obj0, obj1, lower, upper):
         return 0
 
     # Convert all to numpy arrays
-    if type0 in TPL_FLOAT_INT:
+    if not isinstance(type0, Iterable):
         obj0 = array([obj0])
         obj1 = array([obj1])
     else:

--- a/serpentTools/utils/compare.py
+++ b/serpentTools/utils/compare.py
@@ -110,8 +110,6 @@ COMPARE_STATUS_CODES = {
 """Keys of status codes with ``(caller, return)`` values."""
 
 
-
-
 @compareDocDecorator
 def directCompare(obj0, obj1, lower, upper):
     """
@@ -210,6 +208,7 @@ def _directCompareWithTols(obj0, obj1, lower, upper):
     if maxDiff >= upper:
         return DC_STAT_GE_UPPER
     return DC_STAT_MID
+
 
 directCompare.__doc__ = directCompare.__doc__.format(
     good=DC_STAT_GOOD,

--- a/serpentTools/utils/compare.py
+++ b/serpentTools/utils/compare.py
@@ -3,6 +3,7 @@ Comparison utilities
 """
 from numpy import (
     fabs, zeros_like, ndarray, array, greater, multiply, subtract,
+    equal,
 )
 
 from serpentTools.messages import (
@@ -155,10 +156,16 @@ def directCompare(obj0, obj1, lower, upper):
         if obj0.dtype.name == 'object':
             return -1
 
+    if not upper:
+        # exact comparison between arrays
+        if not equal(obj0, obj1).all():
+            return 200
+        return 0
+
     diff = multiply(
         fabs(subtract(obj0, obj1)), 100
     )
-    nonZI = greater(fabs(obj1), LOWER_LIM_DIVISION)
+    nonZI = greater(fabs(obj0), LOWER_LIM_DIVISION)
     diff[nonZI] /= obj0[nonZI]
     maxDiff = diff.max()
     if maxDiff < LOWER_LIM_DIVISION:


### PR DESCRIPTION
This PR expands the powers of `directCompare` by allowing the function to work with vectors of strings. `directCompare` also is more flexible and maintainable, with the status codes, used by logging and testing, being variables. These variables now will propagate changes through testing and documentation without having to track down instances one by one.

This change will be helpful for assisting the comparison of the depleted material objects coming soon.

- [x] PR fits the [project scope](http://serpent-tools.readthedocs.io/en/latest/develop/contributing.html#project-scope)
- [x] Code to be committed is [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) and matches the [code style](http://serpent-tools.readthedocs.io/en/latest/develop/codestyle.html#code-style) of the project
- [x] New and/or changed features are [well documented](http://serpent-tools.readthedocs.io/en/latest/develop/documentation.html#documentation) and have adequate testing