### PR TITLE
[API] Better dependency versions

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,13 @@
 Changelog
 =========
 
+.. _v0.5.4:
+
+:release-tag:`0.5.3`
+====================
+
+* :pull:`239` - Update python dependencies to continue use of python 2
+
 .. _v0.5.3:
 
 :release-tag:`0.5.3`

--- a/setup.py
+++ b/setup.py
@@ -41,9 +41,9 @@ classifiers = [
 ]
 
 installRequires = [
-    'six',
-    'numpy>=1.11.1',
-    'matplotlib>=1.5.0',
+    'six>=1.11.0',
+    'numpy>=1.15.1',
+    'matplotlib==2.2.3',
     'pyyaml>=3.08',
 ]
 


### PR DESCRIPTION
Fixes #238 by setting matplotlib version to py2 compatible version.

* Fix matplotlib to 2.2.3
* Bump numpy to >=1.15.1
* Bump six to >=1.11.0

Also bump version in changelog