### PR TITLE
BUG ResultReader now respects xs variable settings

### DIFF
--- a/serpentTools/parsers/results.py
+++ b/serpentTools/parsers/results.py
@@ -183,9 +183,10 @@ class ResultsReader(XSReader):
         """Process universes' data"""
         brState = self._getBUstate()  # obtain the branching tuple
         values = str2vec(varVals)  # convert the string to float numbers
-        if not self.universes or brState not in self.universes.keys():
+        if brState not in self.universes:
             self.universes[brState] = \
                 HomogUniv(brState[0], brState[1], brState[2], brState[3])
+        if varNameSer == self._keysVersion['univ']:
             return
         if varNameSer not in self._keysVersion['varsUnc']:
             vals, uncs = splitValsUncs(values)


### PR DESCRIPTION
Any variables requested with xs.variableGroups or
xs.variableSettings are now properly stored on the
ResultsReader. This allows for reduced memory
load when reading, as a small subset of variables
can be stored at the user's digression

Fixes #242