### PR TITLE
DOC/ENH Add notice on purpose of readDataFile

### DIFF
--- a/docs/examples/Branching.rst
+++ b/docs/examples/Branching.rst
@@ -27,10 +27,12 @@ The output files are described in more detail on the
 Basic Operation
 ---------------
 
-The simplest way to read these files is using the 
-:func:`~serpentTools.parsers.read` function. Here, we will read the 
-reference file distributed with this package by using
-:func:`~serpentTools.data.readDataFile`.
+.. note::
+
+   The preferred way to read your own output files is with the
+   :func:`~serpentTools.parsers.read` function. The
+   :func:`~serpentTools.data.readDataFile` function is used here
+   to make it easier to reproduce the examples
 
 .. note::
 

--- a/docs/examples/DepletionReader.rst
+++ b/docs/examples/DepletionReader.rst
@@ -30,6 +30,14 @@ Each such object has methods and attributes that should ease analysis.
     >>> import serpentTools
     >>> from serpentTools.settings import rc
 
+
+.. note::
+
+   The preferred way to read your own output files is with the
+   :func:`~serpentTools.parsers.read` function. The
+   :func:`~serpentTools.data.readDataFile` function is used here
+   to make it easier to reproduce the examples
+
 .. code:: 
     
     >>> depFile = 'demo_dep.m'

--- a/docs/examples/Detector.rst
+++ b/docs/examples/Detector.rst
@@ -51,6 +51,13 @@ lattice bins.
     >>> from matplotlib import pyplot
     >>> import serpentTools
 
+.. note::
+
+   The preferred way to read your own output files is with the
+   :func:`~serpentTools.parsers.read` function. The
+   :func:`~serpentTools.data.readDataFile` function is used here
+   to make it easier to reproduce the examples
+
 .. code:: 
     
     >>> pinFile = 'fuelPin_det0.m'

--- a/docs/examples/MicroXSReader.rst
+++ b/docs/examples/MicroXSReader.rst
@@ -44,9 +44,15 @@ files, the user must set the ``mdep`` card in the input
     >>> from serpentTools.settings import rc
     >>> mdxFile = 'ref_mdx0.m'
 
+.. note::
+
+   The preferred way to read your own output files is with the
+   :func:`~serpentTools.parsers.read` function. The
+   :func:`~serpentTools.data.readDataFile` function is used here
+   to make it easier to reproduce the examples
+
 .. code:: 
     
-    >>> %time
     >>> mdx = serpentTools.readDataFile(mdxFile)
 
 

--- a/docs/examples/ResultsReader.rst
+++ b/docs/examples/ResultsReader.rst
@@ -36,6 +36,13 @@ should ease the analyses.
     >>> from serpentTools.settings import rc
     >>> rc['serpentVersion'] = '2.1.30'
 
+.. note::
+
+   The preferred way to read your own output files is with the
+   :func:`~serpentTools.parsers.read` function. The
+   :func:`~serpentTools.data.readDataFile` function is used here
+   to make it easier to reproduce the examples
+
 .. code:: 
     
     >>> resFile = 'InnerAssembly_res.m'

--- a/docs/examples/Sensitivity.rst
+++ b/docs/examples/Sensitivity.rst
@@ -31,6 +31,13 @@ plot method is also contained on the reader.
     >>> from matplotlib import pyplot
     >>> import serpentTools
 
+.. note::
+
+   The preferred way to read your own output files is with the
+   :func:`~serpentTools.parsers.read` function. The
+   :func:`~serpentTools.data.readDataFile` function is used here
+   to make it easier to reproduce the examples
+
 .. code:: 
     
     >>> sens = serpentTools.readDataFile('flattop_sens.m')

--- a/docs/examples/XSPlot.rst
+++ b/docs/examples/XSPlot.rst
@@ -19,6 +19,12 @@ as documented on the Serpent wiki. ``serpentTools`` can then read the
 output, figuring out its filetype automatically as with other readers.
 Let’s plot some data used in the ``serpentTools`` regression suite.
 
+.. note::
+
+   The preferred way to read your own output files is with the
+   :func:`~serpentTools.parsers.read` function. The
+   :func:`~serpentTools.data.readDataFile` function is used here
+   to make it easier to reproduce the examples
 
 .. code:: 
     

--- a/serpentTools/data/__init__.py
+++ b/serpentTools/data/__init__.py
@@ -3,6 +3,7 @@ Module for loading reference and example data files
 """
 
 from os.path import join, exists
+from warnings import warn
 
 from serpentTools import __path__, read
 
@@ -66,5 +67,19 @@ def readDataFile(path, **kwargs):
     --------
     * :func:`serpentTools.read`
     """
-    filePath = getFile(path)
+    if not exists(path):
+        # assume this is a example/test file contained in this project
+        filePath = getFile(path)
+    else:
+        _warnDataFilePurpose()
+        filePath = path
     return read(filePath, **kwargs)
+
+
+def _warnDataFilePurpose():
+    """
+    Issue a warning indicating that readDataFile is not primary read function.
+    """
+    warn("Please use serpentTools.read as the primary read function. "
+         "readDataFile is intended for testing and example and may "
+         "be changed or removed in the future.", UserWarning)


### PR DESCRIPTION
Closes #244 by clearly indicating the purpose of readDataFile. If readDataFile is used to read a file that currently exits as directly passed, then a UserWarning is raised, but that file is still read. The warning indicates that read is the primary function for reading, while
readDataFile should be used only for working through examples. 

This should eliminate a fair amount of confusion and frustration early on as the examples indicate that readDataFile works by exclusively using that function. This function will not work, however, for reading files that do not exist in the data directory. Therefore this warning, and notices in the documented examples, are added to relieve this burden.