### PR TITLE
CI Fix all required packages for travis build

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,7 +2,7 @@ matplotlib==2.2.3
 numpy==1.15.1
 pyyaml==3.12
 six==1.11.0
-ipython==7.0.0
+ipython>=5.8.0,<=7.0.0
 flake8==3.5.0
 pandas==0.21.0
 jupyter==1.0.0

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,9 @@
-flake8>=3.1.0
-pandas>=0.21.0
-jupyter>=1.0
+matplotlib==2.2.3
+numpy==1.15.1
+pyyaml==3.12
+six==1.11.0
+ipython==7.0.0
+flake8==3.1.0
+pandas==0.21.0
+jupyter==4.4.0
 coverage==4.5.1

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,7 +3,7 @@ numpy==1.15.1
 pyyaml==3.12
 six==1.11.0
 ipython==7.0.0
-flake8==3.1.0
+flake8==3.5.0
 pandas==0.21.0
-jupyter==4.4.0
+jupyter==1.0.0
 coverage==4.5.1

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ classifiers = [
 installRequires = [
     'six>=1.11.0',
     'numpy>=1.15.1',
-    'matplotlib==2.2.3',
+    'matplotlib>=2.0',
     'pyyaml>=3.08',
 ]
 


### PR DESCRIPTION
Fixes #246 
The requirements-test.txt file contains the following locked versions of packages we required:
```
matplotlib==2.2.3
numpy==1.15.1
pyyaml==3.08
six==1.11.0
ipython==7.0.0
flake8==3.1.0
pandas==0.21.0
jupyter==4.4.0
coverage==4.5.1
```
This ensures a consistent test environment for our CI.

The python packages in the setup.py script have been set to soft >= requirements for versions that should be easy targets that retain all our functionality