### PR TITLE
API Better axis/colorbar labelling for det mesh plots

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -30,6 +30,7 @@ Changelog
   used.  
 * :pull:`249` - Better sparse support for depletion matrix, ``depmtx`` files with a
   |depmtxReader|
+* :pull:`252` - Better axis and colorbar labeling for |detector| mesh plots
 
 
 Deprecations

--- a/serpentTools/objects/base.py
+++ b/serpentTools/objects/base.py
@@ -169,7 +169,6 @@ class DetectorBase(NamedObject):
         'scores': 'Tally scores',
     }
 
-
     baseParams = """name: str
         Name of this detector"""
     baseAttrs = """grids: dict

--- a/serpentTools/objects/base.py
+++ b/serpentTools/objects/base.py
@@ -163,6 +163,13 @@ class DetectorBase(NamedObject):
     {attrs:s}
     """
 
+    _CBAR_LABELS = {
+        'tallies': 'Tally data',
+        'errors': 'Relative Uncertainty',
+        'scores': 'Tally scores',
+    }
+
+
     baseParams = """name: str
         Name of this detector"""
     baseAttrs = """grids: dict
@@ -433,9 +440,10 @@ class DetectorBase(NamedObject):
         return ax
 
     @magicPlotDocDecorator
-    def meshPlot(self, xdim, ydim, what='tallies', fixed=None, ax=None,
-                 cmap=None, logColor=False, xlabel=None, ylabel=None,
-                 logx=False, logy=False, loglog=False, title=None, **kwargs):
+    def meshPlot(self, xdim='x', ydim='y', what='tallies', fixed=None, ax=None,
+                 cmap=None, cbarLabel=None, logColor=False, xlabel=None,
+                 ylabel=None, logx=False, logy=False, loglog=False,
+                 title=None, **kwargs):
         """
         Plot tally data as a function of two bin types on a cartesian mesh.
 
@@ -460,6 +468,8 @@ class DetectorBase(NamedObject):
         {logy}
         {loglog}
         {title}
+        cbarLabel: str
+            Label to apply to colorbar. If not given, infer from ``what``
         {kwargs} :py:func:`~matplotlib.pyplot.pcolormesh`
 
         Returns
@@ -500,10 +510,17 @@ class DetectorBase(NamedObject):
         ygrid = self._getGrid(ydim)
         if data.shape != (ygrid.size - 1, xgrid.size - 1):
             data = data.T
-
-        ax = cartMeshPlot(data, xgrid, ygrid, ax, cmap, logColor, **kwargs)
+        if cbarLabel is None:
+            cbarLabel = self._CBAR_LABELS[what]
+        ax = cartMeshPlot(
+            data, xgrid, ygrid, ax, cmap, logColor,
+            cbarLabel=cbarLabel, **kwargs)
+        if xlabel is None:
+            xlabel = DETECTOR_PLOT_LABELS.get(xdim, xdim)
+        if ylabel is None:
+            ylabel = DETECTOR_PLOT_LABELS.get(ydim, ydim)
         ax = formatPlot(ax, loglog=loglog, logx=logx, logy=logy,
-                        xlabel=xlabel or xdim, ylabel=ylabel or ydim,
+                        xlabel=xlabel, ylabel=ylabel,
                         title=title)
         return ax
 

--- a/serpentTools/utils/plot.py
+++ b/serpentTools/utils/plot.py
@@ -45,10 +45,11 @@ DEPLETION_PLOT_LABELS = {
 
 DETECTOR_PLOT_LABELS = {
     'energy': 'Energy [MeV]',
-    'xmesh': 'X Position [cm]',
-    'ymesh': 'Y Position [cm]',
-    'zmesh': 'Z Position [cm]',
 }
+for dim in ['x', 'y', 'z']:
+    DETECTOR_PLOT_LABELS[dim] = "{} Position [cm]".format(dim.capitalize())
+    DETECTOR_PLOT_LABELS[dim + 'mesh'] = DETECTOR_PLOT_LABELS[dim]
+
 
 _DET_LABEL_INDEXES = {
     'reaction', 'material', 'cell', 'universe', 'lattice',


### PR DESCRIPTION
Automatically set a good x/y plot label for detector mesh plots based on input argumemts. Calling `xy.meshPlot('x', 'y')` will result in the x and y axis being labeled "X Position [cm]" and "Y Position [cm]", respectively. Similar structure for plotting against energy or z-mesh.

List the colorbar label as one of the input arguments. This was naively supported already, but now is explicit. If nothing is given, colorbar label is inferred from the quantity being plotted.