### PR TITLE
BUG Better handling of single concentration plots

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -31,6 +31,7 @@ Changelog
 * :pull:`249` - Better sparse support for depletion matrix, ``depmtx`` files with a
   |depmtxReader|
 * :pull:`252` - Better axis and colorbar labeling for |detector| mesh plots
+* :pull:`254` - Better plotting of single concentrations with |depmtxReader|
 
 
 Deprecations

--- a/serpentTools/parsers/depmatrix.py
+++ b/serpentTools/parsers/depmatrix.py
@@ -200,6 +200,7 @@ class DepmtxReader(BaseReader, SparseReaderMixin):
             raise ValueError(
                 "Value of {} not understood. Please pass one of {}"
                 .format(what, ' '.join(DENS_PLOT_WHAT_VALS)))
+
         if isinstance(labels, str):
             labels = labels,
         elif labels is None:
@@ -215,7 +216,8 @@ class DepmtxReader(BaseReader, SparseReaderMixin):
         if isinstance(markers, str):
             markers = markers,
         elif markers is None:
-            markers = ('o', 'x')
+            markers = ['x'] if len(plotAttrs) == 1 else ['o', 'x']
+
         if len(markers) != len(plotAttrs):
             raise ValueError(
                 "Number of markers {} not equal to number of quantities "


### PR DESCRIPTION
Fixes #253 by picking better default markers if only a single concentration is plotted. Avoids a ValueError raised when trying to plot a single quantity with two markers 