### PR TITLE
ENH Capture depleted material with underscores 

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -31,7 +31,7 @@ Changelog
 * :pull:`249` - Better sparse support for depletion matrix, ``depmtx`` files with a
   |depmtxReader|
 * :pull:`252` - Better axis and colorbar labeling for |detector| mesh plots
-
+* :pull:`255` - |depletionReader| can capture material with underscores now!
 
 Deprecations
 ------------

--- a/docs/examples/DepletionReader.rst
+++ b/docs/examples/DepletionReader.rst
@@ -296,12 +296,6 @@ replacements
 .. image:: DepletionReader_files/DepletionReader_26_0.png
 
 
-Limitations
------------
-
-Currently, the |depReader| cannot catch materials with underscore in the name,
-due to variables like ``ING_TOX`` also containing an underscore.
-Issue `#58 <https://github.com/CORE-GATECH-GROUP/serpent-tools/issues/58>`_
 
 .. _depletion-settings:
 

--- a/examples/DepletionReader.ipynb
+++ b/examples/DepletionReader.ipynb
@@ -462,14 +462,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Limitations\n",
-    "Currently, the `DepletionReader` cannot catch materials with underscore in the name, due to variables like `ING_TOX` also containing underscore. This is currently an open issue [#58](https://github.com/CORE-GATECH-GROUP/serpent-tools/issues/58)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "## Settings\n",
     "The `DepletionReader` also has a collection of settings to control what data is stored. If none of these settings are modified, the default is to store all the data from the output file."
    ]

--- a/serpentTools/parsers/_collections.py
+++ b/serpentTools/parsers/_collections.py
@@ -95,3 +95,20 @@ RES_DATA_NO_UNCS = {
 Set containing keys for objects stored in :attr:`ResultsReader.resdata`
 that do not contain uncertainties.
 """
+
+DEPLETION_VARIABLES = {
+    'ING_TOX',
+    'INH_TOX',
+    'VOLUME',
+    'BURNUP',
+    'ADENS',
+    'MDENS',
+    'H',
+    'A',
+    'SF',
+    'GSRC',
+    'MASS',
+}
+"""
+Set of all variables stored for material in depletion output
+"""

--- a/serpentTools/parsers/depletion.py
+++ b/serpentTools/parsers/depletion.py
@@ -147,27 +147,14 @@ class DepletionReader(DepPlotMixin, MaterialReader):
 
     def __init__(self, filePath):
         MaterialReader.__init__(self, filePath, 'depletion')
-        self._matPatterns = self._makeMaterialRegexs()
-        self._matchMatNVar = r'[A-Z]{3}_([0-9a-zA-Z]*)_([A-Z]*_?[A-Z]*)'
-        # Captures material name and variable from string
-        #  MAT_fuel1_ADENS --> ('fuel1', 'ADENS')
-        #  MAT_fUeL1g_ING_TOX --> ('fUeL1', 'ING_TOX')
-
-        self._matchTotNVar = r'[A-Z]{3}_([A-Z]*_?[A-Z]*)'
-        # Captures variables for total block from string::
-        #  TOT_ADENS --> ('ADENS', )
-        #  ING_TOX --> ('ING_TOX', )
+        patterns = self.settings['materials'] or ['.*']
+        # match all materials if nothing given
+        self._matPatterns = [re.compile(mat) for mat in patterns]
         DepPlotMixin.__init__(self)
 
     def __getitem__(self, name):
         """Retrieve a material from :attr:`materials`."""
         return self.materials[name]
-
-    def _makeMaterialRegexs(self):
-        """Return the patterns by which to find the requested materials."""
-        patterns = self.settings['materials'] or ['.*']
-        # match all materials if nothing given
-        return [re.compile(mat) for mat in patterns]
 
     def _read(self):
         """Read through the depletion file and store requested data."""

--- a/serpentTools/parsers/depletion.py
+++ b/serpentTools/parsers/depletion.py
@@ -8,7 +8,7 @@ from serpentTools.utils import (
     magicPlotDocDecorator, formatPlot, DEPLETION_PLOT_LABELS,
     convertVariableName, str2vec,
 )
-
+from ._collections import DEPLETION_VARIABLES
 from serpentTools.engines import KeywordParser
 from serpentTools.parsers.base import MaterialReader
 from serpentTools.objects.materials import DepletedMaterial
@@ -167,8 +167,6 @@ class DepletionReader(DepPlotMixin, MaterialReader):
         """Return the patterns by which to find the requested materials."""
         patterns = self.settings['materials'] or ['.*']
         # match all materials if nothing given
-        if any(['_' in pat for pat in patterns]):
-            warning('Materials with underscores are not supported.')
         return [re.compile(mat) for mat in patterns]
 
     def _read(self):
@@ -178,12 +176,12 @@ class DepletionReader(DepPlotMixin, MaterialReader):
         separators = ['\n', '];', '\r\n']
         with KeywordParser(self.filePath, keys, separators) as parser:
             for chunk in parser.yieldChunks():
-                if 'MAT' in chunk[0]:
-                    self._addMaterial(chunk)
-                elif 'TOT' in chunk[0]:
-                    self._addTotal(chunk)
-                else:
-                    self._addMetadata(chunk)
+                mvar = getMatlabVarName(chunk)
+                if mvar[:3] in ['MAT', 'TOT']:
+                    name, variable = getMaterialNameAndVariable(mvar)
+                    self._checkAddData(chunk, name, variable)
+                    continue
+                self._addMetadata(chunk)
         if 'days' in self.metadata:
             for mKey in self.materials:
                 self.materials[mKey].days = self.metadata['days']
@@ -210,23 +208,14 @@ class DepletionReader(DepPlotMixin, MaterialReader):
     def _cleanSingleLine(chunk):
         return chunk[0][chunk[0].index('[') + 1:chunk[0].index(']')]
 
-    def _addMaterial(self, chunk):
-        """Add data from a MAT chunk."""
-        name, variable = self._getGroupsFromChunk(self._matchMatNVar, chunk)
-        if any([re.match(pat, name) for pat in self._matPatterns]):
-            self._processChunk(chunk, name, variable)
-
-    def _addTotal(self, chunk):
-        """Add data from a TOT chunk"""
-        variable = self._getGroupsFromChunk(self._matchTotNVar, chunk)[0]
-        self._processChunk(chunk, 'total', variable)
-
-    def _getGroupsFromChunk(self, regex, chunk):
-        match = re.match(regex, chunk[0])
-        if match:
-            return match.groups()
-        raise Exception('{} not determine match from the following chunk:\n'
-                        '{}'.format(self, ''.join(chunk)))
+    def _checkAddData(self, chunk, name, variable):
+        if name == 'total':
+            if not self.settings['processTotal']:
+                return
+            return self._processChunk(chunk, name, variable)
+        for pattern in self._matPatterns:
+            if pattern.match(name):
+                return self._processChunk(chunk, name, variable)
 
     def _processChunk(self, chunk, name, variable):
         if (self.settings['materialVariables']
@@ -377,3 +366,24 @@ class DepletionReader(DepPlotMixin, MaterialReader):
             self.metadata['burnup'], other.metadata['burnup'],
             lower, upper, 'burnup')
         return similar
+
+
+def getMaterialNameAndVariable(mlabName):
+    for serpVar in DEPLETION_VARIABLES:
+        leng = len(serpVar)
+        if serpVar == mlabName[-len(serpVar):]:
+            matName = mlabName[4:-(leng + 1)]
+            if not matName:
+                if 'TOT' == mlabName[:3]:
+                    return 'total', serpVar
+                break
+            return matName, serpVar
+    raise ValueError(
+        "Could not find a match for {}. "
+        "Please alert developers".format(mlabName))
+
+
+def getMatlabVarName(chunk):
+    if isinstance(chunk, list):
+        return getMatlabVarName(chunk[0])
+    return chunk[:chunk.index(' ')]

--- a/serpentTools/tests/test_depletion.py
+++ b/serpentTools/tests/test_depletion.py
@@ -7,7 +7,6 @@ from numpy.testing import assert_equal
 
 from six import iteritems
 
-from serpentTools.parsers import read
 from serpentTools.data import getFile
 from serpentTools.settings import rc
 from serpentTools.parsers.depletion import (
@@ -23,15 +22,17 @@ FILE_WITH_UNDERSCORES = 'underscores_dep.m'
 ORIG_FUEL = "fuel"
 NEW_FUEL_NAME = "fuel_0"
 
+
 def setUpModule():
     """
     Set up the module
 
     *. Create a new file with underscores
     """
-    with open(DEP_FILE_PATH) as incoming, open(FILE_WITH_UNDERSCORES, 'w') as out:
-        for line in incoming:
-            out.write(line.replace(ORIG_FUEL, NEW_FUEL_NAME))
+    with open(DEP_FILE_PATH) as incoming:
+        with open(FILE_WITH_UNDERSCORES, 'w') as out:
+            for line in incoming:
+                out.write(line.replace(ORIG_FUEL, NEW_FUEL_NAME))
 
 
 def tearDownModule():
@@ -253,7 +254,6 @@ class DepletionUtilTester(TestCase):
         with self.assertRaises(ValueError):
             getMaterialNameAndVariable(self.BAD_0)
             getMaterialNameAndVariable(self.BAD_1)
-
 
     def test_getMatlabVarName(self):
         self.assertEqual(self.BAD_0, getMatlabVarName(self.VAR_CHUNK))

--- a/serpentTools/tests/test_depletion.py
+++ b/serpentTools/tests/test_depletion.py
@@ -13,6 +13,7 @@ from serpentTools.settings import rc
 from serpentTools.parsers.depletion import (
     DepletionReader, getMaterialNameAndVariable, getMatlabVarName,
 )
+from serpentTools.tests.utils import LoggerMixin
 
 
 DEP_FILE = 'ref_dep.m'
@@ -52,10 +53,14 @@ class _DepletionTestHelper(TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.filePath = cls.FILE
+        # Silence the debugger but we don't care about checking messages
+        logger = LoggerMixin()
+        logger.attach()
+
         cls.expectedMaterials = {cls.MATERIAL, }
         if cls.PROCESS_TOTAL:
             cls.expectedMaterials.add('total')
+        # Set some settings to control the output
         with rc as tempRC:
             tempRC['verbosity'] = 'debug'
             tempRC['depletion.materials'] = [cls.MATERIAL, ]
@@ -65,6 +70,7 @@ class _DepletionTestHelper(TestCase):
             )
             cls.reader = DepletionReader(cls.FILE)
             cls.reader.read()
+        logger.detach()
 
 
 class DepletionTester(_DepletionTestHelper):


### PR DESCRIPTION
Closes #58 by allowing the DepletionReader to work with materials containing underscores. Had to move away from the regular expression parsing because some variables contain underscores, while some don't. Added a bunch of variables into `serpentTools/parsers/_collections.py`. These variables are used in the process of figuring out what to strip out from the variable name to obtain the actual name of the material.

Added some tests to ensure that we can indeed do this, as well as some tests for 
utilities that break up the material names.

- [x] PR fits the [project scope](http://serpent-tools.readthedocs.io/en/latest/develop/contributing.html#project-scope)
- [x] Code to be committed is [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) and matches the [code style](http://serpent-tools.readthedocs.io/en/latest/develop/codestyle.html#code-style) of the project
- [x] New and/or changed features are [well documented](http://serpent-tools.readthedocs.io/en/latest/develop/documentation.html#documentation) and have adequate testing

## TODO
- [x] Add this PR to changelog
- [x] Find places where we say we can't do this and remove them