### PR TITLE
API Fix pyyaml version and use safe_load

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,6 +11,9 @@
 Changelog
 =========
 
+Next
+====
+* :meth:`serpentTools.settings.rc.loadYaml` uses ``safe_load``
 .. _v0.6.0:
 
 0.6.0

--- a/serpentTools/settings.py
+++ b/serpentTools/settings.py
@@ -2,7 +2,7 @@
 import os
 
 from six import iteritems
-import yaml
+from yaml import safe_load
 
 from serpentTools import messages, __path__
 
@@ -376,7 +376,7 @@ class UserSettingsLoader(dict):
             return variables
         varFile = os.path.join(ROOT_DIR, 'variables.yaml')
         with open(varFile) as fObj:
-            groups = yaml.load(fObj)
+            groups = safe_load(fObj)
         thisVersion = groups[serpentVersion]
         baseGroups = groups['base']
         for key in keywords:
@@ -411,7 +411,7 @@ class UserSettingsLoader(dict):
         """
         messages.debug('Attempting to read from {}'.format(filePath))
         with open(filePath) as yFile:
-            configSettings = yaml.safe_load(yFile)
+            configSettings = safe_load(yFile)
         messages.debug('Loading settings onto object with strict:{}'
                        .format(strict))
 

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ installRequires = [
     'six>=1.11.0',
     'numpy>=1.15.1',
     'matplotlib>=2.0',
-    'pyyaml>=3.08',
+    'pyyaml==3.13',
 ]
 
 if not getenv('TRAVIS', None) == 'true':


### PR DESCRIPTION
Fix pyyaml to 3.13 in setup.py, as this is the latest release ([4.1 has been retracted on github:yaml/pyyaml](https://github.com/yaml/pyyaml/releases/tag/4.1-retracted))

Also use `safe_load` instead of load for reading custom config files. Safer without loss of performance, at
least for typically small config files expected with  this project. `safe_load` just means that arbitrary python objects can't be created. Helps prevent bad things 