### PR TITLE
API DepletionReader export to Matlab file

### DIFF
--- a/docs/api/depletion.rst
+++ b/docs/api/depletion.rst
@@ -4,12 +4,6 @@
 Depletion Reader
 ================
 
-.. warning::
-
-    Does not support depleted materials with underscores,
-    i.e. ``fuel_1`` will not be matched with the current methods.
-    Follow up on, or claim, the issue on GitHub: :issue:`58`
-
 .. autoclass:: serpentTools.parsers.depletion.DepletionReader
     :special-members: __getitem__
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,7 +13,11 @@ Changelog
 
 Next
 ====
-* :meth:`serpentTools.settings.rc.loadYaml` uses ``safe_load``
+* :pull:`256` :meth:`serpentTools.settings.rc.loadYaml` uses ``safe_load``
+* :pull:`257` |depletionReader| now can utilize 
+  :meth:`~serpentTools.parsers.depletion.DepletionReader.saveAsMatlab` for
+  exporting data to a binary ``.mat`` file
+
 .. _v0.6.0:
 
 0.6.0

--- a/serpentTools/parsers/depletion.py
+++ b/serpentTools/parsers/depletion.py
@@ -359,6 +359,14 @@ class DepletionReader(DepPlotMixin, MaterialReader):
         """
         Write a binary MATLAB file from the contents of this reader
 
+
+        .. note::
+
+            Vectors will be stored as either column or row
+            matrices, e.g. ``1xN`` or ``Nx1``. This can be
+            controlled by passing ``oned_as`` to be either
+            ``'row'`` or ``'column'``
+
         Parameters
         ----------
         fileP: str or file-like object
@@ -378,7 +386,7 @@ class DepletionReader(DepPlotMixin, MaterialReader):
         Raises
         ------
         ImportError:
-            If ``scipy`` is not installed
+            If :term:`scipy` is not installed
 
         See Also
         --------

--- a/serpentTools/parsers/depletion.py
+++ b/serpentTools/parsers/depletion.py
@@ -12,7 +12,7 @@ from ._collections import DEPLETION_VARIABLES
 from serpentTools.engines import KeywordParser
 from serpentTools.parsers.base import MaterialReader
 from serpentTools.objects.materials import DepletedMaterial
-
+from serpentTools.utils.core import deconvertVariableName
 from serpentTools.messages import (
     warning, debug, error, SerpentToolsException,
 )
@@ -354,6 +354,58 @@ class DepletionReader(DepPlotMixin, MaterialReader):
             lower, upper, 'burnup')
         return similar
 
+    def saveAsMatlab(self, fileP, reconvert=True, metadata=True,
+                     **savematKwargs):
+        """
+        Write a binary MATLAB file from the contents of this reader
+
+        Parameters
+        ----------
+        fileP: str or file-like object
+            Name of the file to write
+        reconvert: bool
+            If this evaluates to true, convert values back into their
+            original form as they appear in the output file, e.g.
+            ``MAT_TOTAL_ING_TOX``. Otherwise, maintain the ``mixedCase``
+            style, ``total_ingTox``.
+        metadata: bool or str or list of strings
+            If this evaluates to true, then write all metadata to the
+            file as well.
+        savematKwargs:
+            Additional keyword arguments to pass to
+            :func:`scipy.io.savemat`
+
+        Raises
+        ------
+        ImportError:
+            If ``scipy`` is not installed
+
+        See Also
+        --------
+        :func:`scipy.io.savemat`
+        """
+        from scipy.io import savemat
+
+        # set these here to reduce number of if/elses
+
+        if reconvert:
+            converter = deconvert
+            data = {
+                deconvertVariableName(k): v
+                for k, v in iteritems(self.metadata)
+            }
+        else:
+            # don't want to throw material data into metadata
+            data = {}
+            data.update(self.metadata)
+            converter = prepToMatlab
+
+        for matName, material in iteritems(self.materials):
+            for varName, varData in iteritems(material.data):
+                data[converter(matName, varName)] = varData
+
+        savemat(fileP, data, **savematKwargs)
+
 
 def getMaterialNameAndVariable(mlabName):
     for serpVar in DEPLETION_VARIABLES:
@@ -374,3 +426,17 @@ def getMatlabVarName(chunk):
     if isinstance(chunk, list):
         return getMatlabVarName(chunk[0])
     return chunk[:chunk.index(' ')]
+
+
+_MAT_FMT_ORIG = "MAT_{}_{}"
+_MAT_FMT_CC = "{}_{}"
+
+
+def deconvert(material, variable):
+    """Restore the original name as present in the depletion file"""
+    return _MAT_FMT_ORIG.format(material, deconvertVariableName(variable))
+
+
+def prepToMatlab(material, variable):
+    """Create the name of a single variable for MATLAB"""
+    return _MAT_FMT_CC.format(material, variable)

--- a/serpentTools/parsers/depletion.py
+++ b/serpentTools/parsers/depletion.py
@@ -390,15 +390,14 @@ class DepletionReader(DepPlotMixin, MaterialReader):
 
         if reconvert:
             converter = deconvert
-            data = {
-                deconvertVariableName(k): v
-                for k, v in iteritems(self.metadata)
-            }
         else:
-            # don't want to throw material data into metadata
-            data = {}
-            data.update(self.metadata)
             converter = prepToMatlab
+
+        if metadata:
+            data = {k.upper() if reconvert else k: v
+                    for k, v in iteritems(self.metadata)}
+        else:
+            data = {}
 
         for matName, material in iteritems(self.materials):
             for varName, varData in iteritems(material.data):

--- a/serpentTools/utils/core.py
+++ b/serpentTools/utils/core.py
@@ -153,6 +153,17 @@ def convertVariableName(variable):
                                      for item in lowerSplits[1:]])
 
 
+def deconvertVariableName(variable):
+    """Convert ``mixedCase`` to ``SERPENT_CASE``"""
+    out = ""
+    for char in variable:
+        if char.isupper():
+            out += '_' + char
+            continue
+        out += char.upper()
+    return out
+
+
 LEADER_TO_WIKI = "http://serpent.vtt.fi/mediawiki/index.php/"
 
 


### PR DESCRIPTION
Utilizes [`scipy.io.savemat`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.io.savemat.html?highlight=savemat#scipy.io.savemat) to take contents of the reader and export them to a binary `.mat` file. This can be loaded into MATLAB, and in many cases is faster and more successful than reading in the text file.
The method supports converting variables back to their original SERPENT_STYLE names or not, and optionally saving metadata as well.

Added unit tests that cover three cases:

- Reconvert variable names back and write metadata
- Reconvert variable names but don't write metadata
- Don't convert variable names but do write metadata

- [x] PR fits the [project scope](http://serpent-tools.readthedocs.io/en/latest/develop/contributing.html#project-scope)
- [x] Code to be committed is [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) and matches the [code style](http://serpent-tools.readthedocs.io/en/latest/develop/codestyle.html#code-style) of the project