### PR TITLE
DOC Clean up and fix glossary

### DIFF
--- a/docs/develop/checklist.rst
+++ b/docs/develop/checklist.rst
@@ -36,7 +36,7 @@ project with
 
 Individual test files can also be run with
 
-..code::
+.. code::
 
     $ python my_test_scipt.py
 

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -12,24 +12,28 @@ Glossary
         packages. For a smaller, more minimal approach, see
         :term:`Miniconda`. For more information, see
         `<https://www.anaconda.com/>`_.
+
     Anaconda prompt
         Modified Windows prompt to be used with the :term:`Anaconda` python
         distrubution. Reconfigures python paths to point to packages
         installed via :term:`conda`
-    Conda
-        From `<https://conda.io>`_:
 
-            The package and environment manager bundled with Anaconda
-            that installs and updates conda packages and their
-            dependencies.
+    conda
+        From `<https://www.conda.io/docs/>`_: 
+
+          Conda is an open source package management system and environment
+          management system that runs on Windows, macOS, and Lunix. Conda
+          quickly installs, runs, and updates packages and their dependncies
 
     CI
         Continuous integration. Software we utilize to check that pull
         requests don't break the code.
+
     git
         Distributed version control system. Allows us to test and implement
         new features with ease. For more information, see
         `<https://git-scm.com>`_.
+
     Jupyter notebook
         Powerful web application used in this project, for examples and
         tutorials containing real python code. From `<https://jupyter.org>`_:
@@ -37,37 +41,40 @@ Glossary
             The Jupyter Notebook is an open-source web application that allows
             you to create and share documents that contain live code, equations,
             visualizations and narrative text.
-    
+
     lint
         Bits of potentially erroneous code. Can be identified by a :term:`linter`
+
     linter
         Program that analyzes source code to check for errors, bugs,
         stylistic issues, and other potential hangups.
+
     matplotlib
         Primary python package for plotting data. Highly customizable
         and extensible. More information at `<https://matplotlib.org>`_
+
     Miniconda
-        Mininal installer for :term:`conda`. From `<https://conda.io>`_:
+        Minimal installer for :term:`conda`. From `<https://conda.io>`_:
 
             Miniconda is a small, bootstrap version of Anaconda that only
             includes conda, Python, the packages they depend on, and a
             small number of useful packages
 
-        For more information, see `<https://conda.io/miniconda.html>`_
-
     numpy
         Widely-used python package that allows multidimensional arrays
         and linear algebra routines. More information at
-        `<www.numpy.org>`_
-   scipy
+        `<https://www.numpy.org>`_
+
+    scipy
          Widely-used python package that contains more mathematical support
-         and data structures, such as sparse matrices. Builds off of
-         :term:`numpy`. Not required for this package, but allows the
+         and data structures, such as sparse matrices.
+         Not required for this package, but allows the
          sparsity of some matrices to be exploited. More information at
          `<https://docs.scipy.org/doc/scipy/reference/>`_
+
     SERPENT
         Monte Carlo particle transport code developed at VTT Technical
         Research Centre of Finland, Ltd. Produces output files
         that can be parsed by this project. More information, including
-        distributoin and licensing of ``SERPENT`` can be found at
+        distribution and licensing of ``SERPENT`` can be found at
         `<http://montecarlo.vtt.fi>`_. 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -54,6 +54,7 @@ using :term:`SERPENT`.
    develop/index
    license
    contributors
+   glossary
 
 .. [1] Leppanen, J. et al. (2015) "The Serpent Monte Carlo code: Status,
     development and applications in 2013." Ann. Nucl. Energy, `82 (2015) 142-150


### PR DESCRIPTION
Glossary actually renders now in `sphinx`. Originally wasn't working due to an error in spacing. Now looks great! :book: 