### PR TITLE
DOC Add instructions for pip install

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,6 +10,10 @@ serpent-tools
     :target: http://serpent-tools.readthedocs.io/en/latest/?badge=latest
     :alt: Documentation Status
 
+.. image:: https://badge.fury.io/py/serpentTools.svg
+   :target: https://badge.fury.io/py/serpentTools
+   :alt: PyPi badge
+
 .. image:: https://zenodo.org/badge/102786755.svg
    :target: https://zenodo.org/badge/latestdoi/102786755
    :alt: Zenodo DOI 10.5281/zenodo.1301036
@@ -25,30 +29,15 @@ found at `<http://montecarlo.vtt.fi>`_
 Installation
 ============
 
-The ``serpentTools`` package can be downloaded either as a git repository or
-as a zipped file. Both can be obtained through the ``Clone or download`` option
-at the
-`serpent-tools GitHub <https://github.com/CORE-GATECH-GROUP/serpent-tools>`_.
+``serpentTools`` can be installed with ``pip`` using::
+
+   $ python -m pip install --user --upgrade pip serpentTools
+
 
 For more detailed instructions, including operating-system specific
-instructions, see
+instructions and building from source, see
 `Installation Guide <http://serpent-tools.readthedocs.io/en/latest/install.html>`_.
 
-Once the repository has been downloaded or extracted from zip, the package
-can be installed with::
-
-    cd serpentTools
-    python setup.py install
-    python setup.py test
-
-Installing with `setuptools <https://pypi.python.org/pypi/setuptools/38.2.4>`_
-is preferred over the standard ``distutils`` module. ``setuptools`` can be
-installed with ``pip`` as::
-
-    pip install -U setuptools
-
-Installing in this manner ensures that the supporting packages,
-like ``numpy`` are installed and up to date.
 
 Issues
 ======

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -64,6 +64,10 @@ Glossary
         Widely-used python package that allows multidimensional arrays
         and linear algebra routines. More information at
         `<https://www.numpy.org>`_
+    
+    pip
+        Recommended tool for installing Python packages. More at
+        `<https://pypi.org/project/pip/>`_
 
     scipy
          Widely-used python package that contains more mathematical support

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,6 +16,10 @@ Welcome to serpentTools's documentation!
         :target: http://serpent-tools.readthedocs.io/en/latest/?badge=latest
         :alt: Documentation Status
 
+    .. image:: https://badge.fury.io/py/serpentTools.svg
+       :target: https://badge.fury.io/py/serpentTools
+       :alt: PyPi badge
+
     .. image:: https://zenodo.org/badge/102786755.svg
        :target: https://zenodo.org/badge/latestdoi/102786755
        :alt: Zenodo DOI 10.5281/zenodo.1301036

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -17,21 +17,19 @@ a brief walk through at :ref:`install-python-dist`.
     terminal, or a modified prompt. See :ref:`install-python-dist`
     for more information if you are not sure.
 
-Currently, the only way to obtain the package is via Github. If you 
-only want a specific instance of the project, you can download
-and install a zipped version of the project by following the
-instructions in :ref:`install-release`.
+.. _install-pip:
 
-If you want the entire history of the project, or want a constant
-link to the most up-to-date development version of the project,
-you can clone and install the package via :term:`git`  by following
-the instructions in :ref:`install-git`.
+Installing from pip
+===================
 
-For installing via GitHub and our ``setup.py`` script, having
-`setuptools <https://pypi.org/project/setuptools/>`_ installed
-makes things go a tad more smoothly. This will automatically
-install some of the required packages for you when you
-run the setup script.
+:term:`pip` is the easiest way to install the latest version of 
+``serpentTools``. This can be done with::
+
+   $ python -m install --user --upgrade pip serpentTools
+
+This installs the latest ``serpentTools`` release and upgrades your version of ``pip``
+along the way. When a new release is issued, run the command again to install
+the updated version.
 
 .. _install-release:
 


### PR DESCRIPTION
Project can be installed from pypi now! https://pypi.org/project/serpentTools/

Badge added to README.rst and docs main page. Install page updated to reflect that installing with
pip is the easiest way. You can see how the README will render [here](https://github.com/CORE-GATECH-GROUP/serpent-tools/blob/f24b7586bd5ade98fc684f996bd828f3fbea5527/README.rst). Look at that sweet badge :100: 