### PR TITLE
DEV/TST Update install requirements: numpy, six, pandas

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
 
 # install
 install:
-  - pip install -r requirements-test.txt
+  - pip install -r requirements.txt -r requirements-test.txt
   - python setup.py install
 
 # use xvfb to give the plot functions something to use

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,10 +1,6 @@
-matplotlib==2.2.3
-numpy==1.15.1
-pyyaml==3.12
-six==1.11.0
 ipython>=5.8.0,<=7.0.0
 flake8==3.5.0
-pandas==0.21.0
+pandas==0.24.0
 jupyter==1.0.0
 coverage==4.5.1
 scipy==1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+six==1.12.0
+numpy==1.16.0
+matplotlib>=2.2.3
+pyyaml==3.13

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 from os.path import join
-from os import getenv
 from glob import glob
 try:
     from setuptools import setup
@@ -40,17 +39,8 @@ classifiers = [
     'Programming Language :: Python :: 3.6'
 ]
 
-installRequires = [
-    'six>=1.11.0',
-    'numpy>=1.15.1',
-    'matplotlib>=2.0',
-    'pyyaml==3.13',
-]
-
-if not getenv('TRAVIS', None) == 'true':
-    # hack to install scipy if not on cluster
-    # PR 45/44
-    installRequires.append('scipy')
+with open('./requirements.txt') as req:
+    installRequires = req.read()
 
 pythonRequires = '>=2.7,!=3.0,!=3.1,!=3.2,!=3.3,!=3.4'
 


### PR DESCRIPTION
Added a requirements.txt file to explicitly point to
required packages. Can be installed with
pip install -r requirements.txt

## Install
numpy == 1.16.0  // last major release w/ python2
six == 1.12.0
matplotlib >= 2.2.3
- Drop official need for scipy
## Test
pandas == 0.24.0 // last major release w/ python2