### PR TITLE
DEV Obtain plot axes with gca()

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -29,6 +29,8 @@ Next
   collecting group constants from coefficient files. Collects
   group constants in in multi-dimensional matrices according
   to perturbations, universes, and burnup.
+* Plotting routines now use attach to the active plot or generate
+  a new plot figure if ``ax`` argument not given - :issue:`267`
 
 .. warning::
 

--- a/serpentTools/objects/base.py
+++ b/serpentTools/objects/base.py
@@ -6,7 +6,7 @@ from abc import ABCMeta, abstractmethod
 from six import add_metaclass
 
 from numpy import arange, hstack, log, divide
-from matplotlib.pyplot import axes
+from matplotlib.pyplot import gca
 
 from serpentTools.messages import (
     debug, warning, SerpentToolsException, info,
@@ -424,7 +424,7 @@ class DetectorBase(NamedObject):
         xdata, autoX = self._getPlotXData(xdim, data)
         xlabel = xlabel or autoX
         ylabel = ylabel or "Tally data"
-        ax = ax or axes()
+        ax = ax or gca()
 
         if steps:
             if 'drawstyle' in kwargs:

--- a/serpentTools/objects/containers.py
+++ b/serpentTools/objects/containers.py
@@ -358,7 +358,7 @@ class HomogUniv(NamedObject):
 
         """
         qtys = [qtys, ] if isinstance(qtys, str) else qtys
-        ax = ax or pyplot.axes()
+        ax = ax or pyplot.gca()
         onlyXS = True
         sigma = max(0, int(sigma))
         drawstyle = 'steps-post' if steps else None

--- a/serpentTools/objects/detectors.py
+++ b/serpentTools/objects/detectors.py
@@ -29,7 +29,7 @@ from numpy import unique, array, empty, inf
 from matplotlib.figure import Figure
 from matplotlib.patches import RegularPolygon
 from matplotlib.collections import PatchCollection
-from matplotlib.pyplot import axes
+from matplotlib.pyplot import gca
 
 from serpentTools.messages import warning, debug, SerpentToolsException
 from serpentTools.objects.base import DetectorBase
@@ -321,7 +321,7 @@ class HexagonalDetector(Detector):
             if ax and fig.axes and ax not in fig.axes:
                 raise IndexError("Passed argument for 'figure' and 'ax', "
                                  "but ax is not attached to figure.")
-            ax = ax or (fig.axes[0] if fig.axes else axes())
+            ax = ax or (fig.axes[0] if fig.axes else gca())
         alpha = kwargs.get('alpha', None)
 
         ny = len(self.indexes['ycoord'])
@@ -337,7 +337,7 @@ class HexagonalDetector(Detector):
         values = empty(nItems)
         coords = self.grids['COORD']
 
-        ax = ax or axes()
+        ax = ax or gca()
         pos = 0
         xmax, ymax = [-inf, ] * 2
         xmin, ymin = [inf, ] * 2

--- a/serpentTools/objects/materials.py
+++ b/serpentTools/objects/materials.py
@@ -358,7 +358,7 @@ class DepletedMaterial(DepletedMaterialBase):
             if isinstance(zai, str):
                 zai = [zai, ]
         yVals = self.getValues(xUnits, yUnits, xVals, names, zai)
-        ax = ax or pyplot.axes()
+        ax = ax or pyplot.gca()
         labels = self._formatLabel(labelFmt, names, zai)
         for row in range(yVals.shape[0]):
             ax.plot(xVals, yVals[row], label=labels[row], **kwargs)

--- a/serpentTools/objects/xsdata.py
+++ b/serpentTools/objects/xsdata.py
@@ -245,7 +245,7 @@ class XSData(NamedObject):
             if mt not in self.MT:
                 error("{} not in collected MT numbers, {}".format(mt, self.MT))
 
-        ax = ax or pyplot.axes()
+        ax = ax or pyplot.gca()
 
         x = self.metadata['egrid']
         for mt in mts:

--- a/serpentTools/parsers/depletion.py
+++ b/serpentTools/parsers/depletion.py
@@ -97,7 +97,7 @@ class DepPlotMixin(object):
             raise KeyError("Plot method only uses x-axis data from <days> and "
                            "<burnup>, not {}".format(xUnits))
         missing = set()
-        ax = ax or pyplot.axes()
+        ax = ax or pyplot.gca()
         materials = materials or self.materials.keys()
         labelFmt = labelFmt or '{mat} {iso}'
         for mat in materials:

--- a/serpentTools/parsers/sensitivity.py
+++ b/serpentTools/parsers/sensitivity.py
@@ -6,7 +6,7 @@ from itertools import product
 
 from six import iteritems
 from numpy import transpose, hstack
-from matplotlib.pyplot import axes
+from matplotlib.pyplot import gca
 
 from serpentTools.utils.plot import magicPlotDocDecorator, formatPlot
 from serpentTools.engines import KeywordParser
@@ -309,7 +309,7 @@ class SensitivityReader(BaseReader):
         perts = self._getCleanedPertOpt('perts', pert)
         mats = self._getCleanedPertOpt('materials', mat)
 
-        ax = ax or axes()
+        ax = ax or gca()
 
         sigma = max(int(sigma), 0)
         resMat = self.sensitivities[resp]

--- a/serpentTools/plot.py
+++ b/serpentTools/plot.py
@@ -113,7 +113,7 @@ def cartMeshPlot(data, xticks=None, yticks=None, ax=None, cmap=None,
     norm = normalizerFactory(data, normalizer, logColor, xticks, yticks)
 
     # make the plot
-    ax = ax or pyplot.axes()
+    ax = ax or pyplot.gca()
     if xticks is None:
         mappable = ax.imshow(data, cmap=cmap, norm=norm)
     else:
@@ -157,7 +157,7 @@ def plot(xdata, plotData, ax=None, labels=None, yerr=None, **kwargs):
         of ``plotData``
 
     """
-    ax = ax or pyplot.axes()
+    ax = ax or pyplot.gca()
 
     if yerr is not None:
         if not yerr.shape == plotData.shape:

--- a/serpentTools/samplers/depletion.py
+++ b/serpentTools/samplers/depletion.py
@@ -271,7 +271,7 @@ class SampledDepletedMaterial(SampledContainer, DepletedMaterialBase):
                                          colIndices))
         else:
             xUncs = zeros_like(xVals)
-        ax = ax or pyplot.axes()
+        ax = ax or pyplot.gca()
         labels = self._formatLabel(labelFmt, names)
         yVals = yVals.copy(order='F')
         yUncs = yUncs.copy(order='F') * sigma
@@ -330,7 +330,7 @@ class SampledDepletedMaterial(SampledContainer, DepletedMaterialBase):
         if not self.allData:
             raise SamplerError("Data from all sampled files has been freed "
                                "and cannot be used in this plot method")
-        ax = ax or pyplot.axes()
+        ax = ax or pyplot.gca()
         if xUnits not in ('days', 'burnup'):
             raise KeyError("Plot method only uses x-axis data from <days> "
                            "and <burnup>, not {}".format(xUnits))

--- a/serpentTools/samplers/detector.py
+++ b/serpentTools/samplers/detector.py
@@ -247,7 +247,7 @@ class SampledDetector(SampledContainer, DetectorBase):
                     samplerData.shape))
         xdata, autoX = self._getPlotXData(xdim, samplerData)
         xlabel = xlabel or autoX
-        ax = ax or pyplot.axes()
+        ax = ax or pyplot.gca()
         N = self._index
         allTallies = self.allTallies.copy(order='F')
         for n in range(N):

--- a/serpentTools/tests/test_detector.py
+++ b/serpentTools/tests/test_detector.py
@@ -151,6 +151,16 @@ class CartesianDetectorTester(DetectorHelper):
     },
     }
 
+    def test_sharedPlot(self):
+        """Verify that the same axes object is returned on subsequent plots
+        """
+        det = self.detectors[self.DET_NAME]
+        # plot along two reactions with no axes call
+        # ensure that returned objects are equal
+        ax0 = det.plot(fixed={'reaction': 0, 'ymesh': 0})
+        ax1 = det.plot(fixed={'reaction': 1, 'ymesh': 0})
+        self.assertTrue(ax0 is ax1)
+
 
 class HexagonalDetectorTester(DetectorHelper):
     """


### PR DESCRIPTION
Closes #267 by refactoring calls to and imports of pyplot.axes to pyplot.gca.

No user change needed if used in jupyter notebooks or if no plotting is used. The default behavior of matplotlib was to reuse the existing plot anyway, but with a deprecation warning. 