### PR TITLE
DEV/CI Bundle package data and test install methods

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,19 @@ python:
   - "3.6"
   - "3.5"
   - "2.7"
+env:
+  - ST_INSTALL=setup
+  - ST_INSTALL=sdist
+  - ST_INSTALL=bdist_wheel
+  - ST_INSTALL=bdist_egg
 
-# install
-install:
+before_install:
   - pip install -r requirements.txt -r requirements-test.txt
-  - python setup.py install
+  - rm -rf dist
+# install matrix
+# build some distributions (source and wheel) and install from those
+install:
+  - bash scripts/travis/install.sh
 
 # use xvfb to give the plot functions something to use
 # PR 70

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,3 +3,4 @@ include serpentTools/_version.py
 include serpentTools/variables.yaml
 include serpentTools/data/*.m
 include serpentTools/data/*.coe
+include requirements.txt

--- a/scripts/travis/install.sh
+++ b/scripts/travis/install.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Install script that depends on $INSTALL variable
+# Options:
+# setup: install with setup.py
+# sdist: create a source distribution and install from that
+# bdist_wheel: create a wheel and install from that
+
+if [[ -z $ST_INSTALL ]]; then exit; fi
+
+set -ev
+set -o pipefail
+
+ST_VERSION=$(python setup.py version | grep Version | cut -d" " -f 2)
+echo $ST_VERSION
+
+case $ST_INSTALL in
+    'setup')
+        python setup.py install
+        ;;
+    'sdist')
+        python setup.py sdist
+        pip install dist/serpentTools-${ST_VERSION}.tar.gz
+        ;;
+    'bdist_wheel')
+        python setup.py bdist_wheel
+        easy_install dist/serpentTools-${ST_VERSION}*whl
+        ;;
+    'bdist_egg')
+        python setup.py bdist_egg
+        easy_install dist/serpentTools-${ST_VERSION}*egg
+        ;;
+    *)
+        echo No install option
+        exit 1
+esac
+                

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ setupArgs = {
     'package_data': {
         'serpentTools.data': ['data/{}'.format(ext) for ext in DATA_EXTS],
     },
+    'include_package_data': True,
     'cmdclass': versioneer.get_cmdclass(),
     'data_files': [
         ('serpentTools', ['serpentTools/variables.yaml', ]),


### PR DESCRIPTION
Closes #271 by ensuring that data files and variable.yaml are bundled into all our distributions. This will ensure that our data files are included when people install from pypi or other install methods.

In the future, we should only include the data files that we need for testing, and put the example files elsewhere.

Also included some changes to the travis build script to test the install methods.