### PR TITLE
API Convert sensitivity files to MATLAB

### DIFF
--- a/serpentTools/parsers/sensitivity.py
+++ b/serpentTools/parsers/sensitivity.py
@@ -19,25 +19,41 @@ class SensitivityReader(BaseReader):
     """
     Class for reading sensitivity files
 
-    The arrays that are stored in ``sensitivities`` and
-    ``energyIntegratedSens`` are stored under converted names.
+    The arrays that are stored in :attr:`sensitivities` and
+    :attr:`energyIntegratedSens` are stored under converted names.
     The original names from SERPENT are of the form
     ``ADJ_PERT_KEFF_SENS`` or ``ADJ_PERT_KEFF_SENS_E_INT``,
     respectively. Since this reader stores the resulting arrays
     in unique locations, the names are converted to a succint form.
     The two arrays listed above would be stored both as ``keff``
-    in ``sensitivities`` and ``energyIntegratedSens``.
+    in :attr:`sensitivities` and :attr:`energyIntegratedSens`.
     All names are converted to ``mixedCaseNames`` to fit the
     style of the project.
 
-    Ordered dictionaries ``materials``, ``zais``, and
-    ``perts`` contain keys of the names of their respective
+    Ordered dictionaries :attr:`materials`, :attr:`zais` and
+    :attr:`perts` contain keys of the names of their respective
     data, and the corresponding index, ``iSENS_ZAI_zzaaai``,
     in the sensitivity arrays. These arrays are zero-indexed,
     so the first item will have an index of zero. The data stored
-    in the ``sensitivities`` and ``energyIntegratedSens`` dictionaries
+    in the :attr:`sensitivities` and :attr:`energyIntegratedSens` dictionaries
     has the exact same structure as if the arrays were loaded into
     ``MATLAB``/``Octave``, but with zero-indexing.
+
+    The matrices in :attr:`sensitivities` are ordered as they
+    would be in MATLAB. The five dimensions correspond to:
+
+        1. :attr:`materials` that were contained perturbed isotopes
+        2. :attr:`zais` that were perturbed
+        3. :attr:`perts` - reactions that were perturbed, e.g.
+           ``'total xs'``
+        4: :attr:`energies` - which energy group contained the
+           perturbation. Will have one fewer dimensions than
+           the number of values in :attr:`energies`, corresponding
+           to the number of energy groups.
+        5: [value, relative uncertainty] pairs
+
+    The matrices in :attr:`energyIntegratedSens` will have the same
+    structure, but with the :attr:`energies` dimension removed.
 
     Parameters
     ----------

--- a/serpentTools/tests/test_sensivity.py
+++ b/serpentTools/tests/test_sensivity.py
@@ -336,6 +336,25 @@ class Sens2MatlabHelper(SensitivityTestHelper):
         gathered = self.reader._gather_matlab(self.RECONVERT)
         self._testGathered(gathered)
 
+    @skipUnless(HAS_SCIPY, "SCIPY needed for this test")
+    def test_toMatlab(self):
+        """Verify the contents of the reader can be written to matlab"""
+        from scipy.io import loadmat
+        fp = "sens2matlab_r{}.mat".format(int(self.RECONVERT))
+        toMatlab(self.reader, fp)
+        gathered = loadmat(fp)
+        # some vectors will be written as 2D row/column vectors
+        # need to reshape them to 1D arrays
+        keys = gathered.keys()
+        for key in keys:
+            if key[:2] == '__':  # special stuff from savemat
+                continue
+            value = gathered[key]
+            if value.size > 1 and 1 in value.shape:
+                gathered[key] = value.flatten()
+
+        remove(fp)
+
 
 class ReconvertedSens2MatlabTester(Sens2MatlabHelper):
     """Class for testing the sens - matlab conversion with original names"""


### PR DESCRIPTION
Implemented the gathering method that allows sensitivity readers to be written to MATLAB using scipy.io.savemat. New tests were added, and some documentation updated.