### PR TITLE
TST Remove call to deprecated timepoints in dep test_plotter

### DIFF
--- a/serpentTools/tests/test_depletion.py
+++ b/serpentTools/tests/test_depletion.py
@@ -221,7 +221,7 @@ class DepletedMaterialTester(_DepletionTestHelper):
 
     def test_plotter(self):
         """Verify the plotting functionality is operational."""
-        self.material.plot('days', 'adens', timePoints=self.requestedDays,
+        self.material.plot('days', 'adens',
                            names=['Xe135', 'U235'])
 
 


### PR DESCRIPTION
Closes #283 

There are some other warnings raised by the conversion in `scipy.io.savemat` that we can't control. There is a future warning that we will remove by `0.7.0` with the depletion `saveAsMatlab` method not accepting metadata