### PR TITLE
API DepletionMatrix to Matlab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,26 +46,8 @@ coverage.xml
 *.cover
 .hypothesis/
 
-# Translations
-*.mo
-*.pot
-
-# Django stuff:
-*.log
-local_settings.py
-
-# Flask stuff:
-instance/
-.webassets-cache
-
-# Scrapy stuff:
-.scrapy
-
 # Sphinx documentation
 docs/_build/
-
-# PyBuilder
-target/
 
 # Jupyter Notebook
 .ipynb_checkpoints
@@ -73,35 +55,16 @@ target/
 # pyenv
 .python-version
 
-# celery beat schedule file
-celerybeat-schedule
-
-# SageMath parsed files
-*.sage.py
-
-# dotenv
-.env
-
 # virtualenv
 .venv
 venv/
 ENV/
-
-# Spyder project settings
-.spyderproject
-.spyproject
-
-# Rope project settings
-.ropeproject
-
-# mkdocs documentation
-/site
-
-# mypy
-.mypy_cache/
 
 # pycharm
 .idea/*
 
 # vim
 .*.swp
+
+# Ctag file
+tags

--- a/serpentTools/parsers/depmatrix.py
+++ b/serpentTools/parsers/depmatrix.py
@@ -238,6 +238,22 @@ class DepmtxReader(BaseReader, SparseReaderMixin):
                    )
         return ax
 
+    def _gather_matlab(self, reconvert):
+        out = {'t': self.deltaT}
+        if reconvert:
+            out['N0'] = self.n0
+            out['N1'] = self.n1
+            out['ZAI'] = self.zai
+        else:
+            out['n0'] = self.n0
+            out['n1'] = self.n1
+            out['zai'] = self.zai
+        if self.sparse:
+            out['A'] = self.depmtx.toarray()
+        else:
+            out['A'] = self.depmtx
+        return out
+
 
 def _parseIsoBlock(stream, storage, match, line, regex):
     """Read through the N0, N1 block and add data to storage"""

--- a/serpentTools/tests/test_toMatlab.py
+++ b/serpentTools/tests/test_toMatlab.py
@@ -57,10 +57,9 @@ class Det2MatlabHelper(MatlabTesterHelper):
     def test_det2Matlab(self):
         """Test the conversion to matlab files"""
         from scipy.io import loadmat
-        filePath = 'detector_{}.mat'.format(
-            'conv' if self.CONVERT else 'unconv')
-        toMatlab(self.detector, filePath, self.CONVERT, append=False)
-        fromMatlab = loadmat(filePath)
+        writer = BytesIO()
+        toMatlab(self.detector, writer, self.CONVERT, append=False)
+        fromMatlab = loadmat(writer)
 
         binsKey = self.converterFunc(self.detector.name, 'bins')
         self.assertTrue(binsKey in fromMatlab)
@@ -70,8 +69,6 @@ class Det2MatlabHelper(MatlabTesterHelper):
         self.assertTrue(gridKey in fromMatlab)
         assert_array_equal(fromMatlab[gridKey],
                            self.detector.grids[self.GRID_KEY])
-
-        remove(filePath)
 
 
 class ConvertedDet2MatlabTester(Det2MatlabHelper):

--- a/serpentTools/tests/test_toMatlab.py
+++ b/serpentTools/tests/test_toMatlab.py
@@ -2,7 +2,6 @@
 Tests for testing the MATLAB conversion functions
 """
 
-from os import remove
 from unittest import TestCase, SkipTest
 from six import BytesIO, iteritems
 from numpy import arange


### PR DESCRIPTION
Related to #282 by implementing methods for exporting data from depletion matrix files to matlab. Writes a full matrix, regardless of if the matrix is stored in sparse format.