### PR TITLE
API/DOC Move exceptions into high-level API

### DIFF
--- a/docs/api/exceptions.rst
+++ b/docs/api/exceptions.rst
@@ -4,9 +4,9 @@
 Exceptions
 ==========
 
-.. autoclass:: serpentTools.messages.SerpentToolsException
+.. autoclass:: serpentTools.SerpentToolsException
 
-.. autoclass:: serpentTools.messages.SamplerError
+.. autoclass:: serpentTools.SamplerError
 
-.. autoclass:: serpentTools.messages.MismatchedContainersError
+.. autoclass:: serpentTools.MismatchedContainersError
 

--- a/serpentTools/__init__.py
+++ b/serpentTools/__init__.py
@@ -1,5 +1,6 @@
 # flake8: noqa
 from serpentTools.parsers import *
+from serpentTools.messages import *
 from serpentTools.data import *
 from serpentTools.samplers import *
 from serpentTools.seed import *

--- a/serpentTools/messages.py
+++ b/serpentTools/messages.py
@@ -16,6 +16,12 @@ from collections import Callable
 
 from numpy import ndarray
 
+__all__ = [
+    'SerpentToolsException',
+    'SamplerError',
+    'MismatchedContainersError',
+]
+
 
 class SerpentToolsException(Exception):
     """Base-class for all exceptions in this project"""

--- a/serpentTools/objects/base.py
+++ b/serpentTools/objects/base.py
@@ -218,7 +218,7 @@ class DetectorBase(NamedObject):
 
         Raises
         ------
-        SerpentToolsException
+        :class:`~serpentTools.SerpentToolsException`
             If the data has not been reshaped or is None [e.g. scores]
         KeyError
             If the data set to slice not in the allowed selection
@@ -300,7 +300,7 @@ class DetectorBase(NamedObject):
 
         Raises
         ------
-        SerpentToolsException
+        :class:`~serpentTools.SerpentToolsException`
             if number of rows in data not equal to
             number of energy groups
 
@@ -393,7 +393,7 @@ class DetectorBase(NamedObject):
 
         Raises
         ------
-        SerpentToolsException
+        :class:`~serpentTools.SerpentToolsException`
             If data contains more than 2 dimensions
 
         See Also
@@ -483,7 +483,7 @@ class DetectorBase(NamedObject):
 
         Raises
         ------
-        SerpentToolsException
+        :class:`~serpentTools.SerpentToolsException`
             If data to be plotted, with or without constraints, is not 1D
         KeyError
             If the data set by ``what`` not in the allowed selection

--- a/serpentTools/objects/containers.py
+++ b/serpentTools/objects/containers.py
@@ -115,7 +115,7 @@ class HomogUniv(NamedObject):
 
     Raises
     ------
-    SerpentToolsException:
+    :class:`~serpentTools.SerpentToolsException`
         If a negative value of burnup, step, or burnup days is passed
 
     """
@@ -666,6 +666,12 @@ class BranchContainer(BaseObject):
         univID: int or str
             Identifier for this universe
         burnup: float or int
+
+        Raises
+        ------
+        :class:`~serpentTools.SerpentToolsException`
+            If passed a value of ``burnDays`` and set up to work with burnup,
+            or vice versa
         """
         if self.__hasDays is None and burnup:
             self.__hasDays = burnup < 0
@@ -713,7 +719,7 @@ class BranchContainer(BaseObject):
         ------
         KeyError:
             If the requested universe could not be found
-        SerpentToolsException:
+        :class:`~serpentTools.SerpentToolsException`
             If neither burnup nor index are given
         """
         if burnup is None and index is None:

--- a/serpentTools/parsers/results.py
+++ b/serpentTools/parsers/results.py
@@ -120,10 +120,12 @@ class ResultsReader(XSReader):
 
     Raises
     ------
-    SerpentToolsException:  Serpent version is not supported
-                            No universes are found in the file
-                            No results are collected
-                            Corrupted results
+    :class:`~serpentTools.SerpentToolsException`:
+        Serpent version is not supported,
+        No universes are found in the file,
+        No results are collected,
+        Corrupted results
+
     IOError: file is unexpectedly closes while reading
     """
 
@@ -300,7 +302,7 @@ class ResultsReader(XSReader):
         ------
         KeyError:
             If the requested universe could not be found
-        SerpentToolsException:
+        :class:`~serpentTools.SerpentToolsException`
             If burnup, days and index are not given
         """
         if index is None and burnup is None and timeDays is None:

--- a/serpentTools/samplers/depletion.py
+++ b/serpentTools/samplers/depletion.py
@@ -318,13 +318,13 @@ class SampledDepletedMaterial(SampledContainer, DepletedMaterialBase):
 
         Raises
         ------
-        SamplerError
+        :class:`~serpentTools.SamplerError`
             If ``self.allData`` is empty. Sampler was instructed to
             free all materials and does not retain data from all containers
 
         See Also
         --------
-        :py:meth:`~serpentTools.samplers.depletion.SampledDepletedMaterial.plot`
+        :meth:`~serpentTools.samplers.depletion.SampledDepletedMaterial.plot`
 
         """
         if not self.allData:

--- a/serpentTools/samplers/detector.py
+++ b/serpentTools/samplers/detector.py
@@ -228,10 +228,10 @@ class SampledDetector(SampledContainer, DetectorBase):
 
         Raises
         ------
-        SamplerError
+        :class:`~serpentTools.SamplerError`
             If ``allTallies`` is None, indicating this object has been
             instructed to free up data from all sampled files
-        SerpentToolsException
+        :class:`~serpentTools.SerpentToolsException`
             If data to be plotted, after applying ``fixed``, is not
             one dimensional
 


### PR DESCRIPTION
Can import exceptions with `serpentTools.SerpentToolsExceptions`,
`serpentTools.SamplerError`, and `serpentTools.MismatchedContainersError`