### PR TITLE
API INCOMP Store single tally detectors with floats

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -47,6 +47,9 @@ Incompatible API Changes
   burnup step was one. All burnup indices are now decreased by
   one. Similarly, if no burnup was present in the file, the
   values of burnup and days for all universes is zero.
+* When reading detectors with a single tally, the value of ``tallies``,
+  ``errors``, and ``scores`` are stored as floats, rather than 
+  :term:`numpy` arrays.
 
 Pending Deprecations
 --------------------

--- a/serpentTools/objects/base.py
+++ b/serpentTools/objects/base.py
@@ -173,11 +173,11 @@ class DetectorBase(NamedObject):
         Name of this detector"""
     baseAttrs = """grids: dict
         Dictionary with additional data describing energy grids or mesh points
-    tallies: None or {np}
+    tallies: None, float, or {np}
         Reshaped tally data to correspond to the bins used
-    errors: None or {np}
+    errors: None, float, or {np}
         Reshaped relative error data corresponding to bins used
-    scores: None or {np}
+    scores: None, float, or {np}
         Reshaped array of tally scores. SERPENT 1 only
     indexes: None or :class:`collections.OrderedDict`
         Collection of unique indexes for each requested bin

--- a/serpentTools/objects/detectors.py
+++ b/serpentTools/objects/detectors.py
@@ -31,7 +31,7 @@ from matplotlib.patches import RegularPolygon
 from matplotlib.collections import PatchCollection
 from matplotlib.pyplot import gca
 
-from serpentTools.messages import warning, debug, SerpentToolsException
+from serpentTools.messages import warning, SerpentToolsException
 from serpentTools.objects.base import DetectorBase
 from serpentTools.utils import (
     magicPlotDocDecorator, formatPlot, setAx_xlims, setAx_ylims,
@@ -108,22 +108,27 @@ class Detector(DetectorBase):
         if self.__reshaped:
             warning('Data has already been reshaped')
             return
-        debug('Starting to sort tally data...')
         shape = []
         self.indexes = OrderedDict()
-        for index in range(1, 10):
-            uniqueVals = unique(self.bins[:, index])
-            if len(uniqueVals) > 1:
-                indexName = self._indexName(index)
-                self.indexes[indexName] = array(uniqueVals, dtype=int) - 1
-                shape.append(len(uniqueVals))
-        self.tallies = self.bins[:, 10].reshape(shape)
-        self.errors = self.bins[:, 11].reshape(shape)
-        if self.bins.shape[1] == 13:
-            self.scores = self.bins[:, 12].reshape(shape)
+        hasScores = self.bins.shape[1] == 13
+        if self.bins.shape[0] == 1:
+            self.tallies = self.bins[0, 10]
+            self.errors = self.bins[0, 11]
+            if hasScores:
+                self.scores = self.bins[0, 12]
+        else:
+            for index in range(1, 10):
+                uniqueVals = unique(self.bins[:, index])
+                if len(uniqueVals) > 1:
+                    indexName = self._indexName(index)
+                    self.indexes[indexName] = array(uniqueVals, dtype=int) - 1
+                    shape.append(len(uniqueVals))
+            self.tallies = self.bins[:, 10].reshape(shape)
+            self.errors = self.bins[:, 11].reshape(shape)
+            if hasScores:
+                self.scores = self.bins[:, 12].reshape(shape)
         self._map = {'tallies': self.tallies, 'errors': self.errors,
                      'scores': self.scores}
-        debug('Done')
         self.__reshaped = True
         return shape
 


### PR DESCRIPTION
Closes #235 

When reading detectors with a single tally, the value of ``tallies``, ``errors``, and ``scores`` are stored as floats, rather than numpy arrays.

The numpy arrays were previously of a single value, often leading to mistaken accessing methods. Slicing doesn't work as one would first expect. Now, these are floats and can be used with, *hopefully*, less issues

Documentation has been updated in the changelog and the detector objects.

Labeled as incompatible because this will change how detectors with a single value are used, but not multidimensional detectors