### PR TITLE
API ResultsReader to MATLAB

### DIFF
--- a/serpentTools/parsers/results.py
+++ b/serpentTools/parsers/results.py
@@ -29,6 +29,7 @@ from serpentTools.utils import (
     formatPlot,
     placeLegend,
     magicPlotDocDecorator,
+    deconvertVariableName,
 )
 from serpentTools.messages import (
     warning, SerpentToolsException,
@@ -678,3 +679,33 @@ class ResultsReader(XSReader):
             return OrderedDict([[item, '{}{}'.format(item, tail)]
                                 for item in y])
         return y
+
+    @staticmethod
+    def ioConvertName(name):
+        """
+        Return the name of the variable used for exporting - camelCase
+        """
+        return name
+
+    @staticmethod
+    def ioReconvertName(name):
+        """
+        Return the name of the variable used for exporting - SERPENT_CASE
+        """
+        return deconvertVariableName(name)
+
+    def _gather_matlab(self, reconvert):
+        if reconvert:
+            varFunc = self.ioReconvertName
+            out = {
+                varFunc(key): value for key, value in iteritems(self.metadata)
+            }
+            out.update({
+                varFunc(key): value for key, value in iteritems(self.resdata)
+            })
+        else:
+            out = {}
+            varFunc = self.ioConvertName
+            out.update(self.metadata)
+            out.update(self.resdata)
+        return out

--- a/serpentTools/parsers/results.py
+++ b/serpentTools/parsers/results.py
@@ -691,10 +691,13 @@ class ResultsReader(XSReader):
         array, rather than a stacked 2D matrix. The axis are ordered
         ``burnup, universeIndex, group, value/uncertainty``
 
+        The ordering of the universes can be found in the ``'UNIVERSES'``
+        vector if ``reconvert==True``, otherwise ``'universes'``. Each
+        universe ID is present in this vector, ordered to their
+        position along the second axis in the matrix.
+
         Parameters
         ----------
-        obj: ``serpentTools`` container
-            Parser or container to be written to file
         fileP: str or file-like object
             Name of the file to write
         reconvert: bool

--- a/serpentTools/parsers/results.py
+++ b/serpentTools/parsers/results.py
@@ -681,20 +681,6 @@ class ResultsReader(XSReader):
                                 for item in y])
         return y
 
-    @staticmethod
-    def ioConvertName(name):
-        """
-        Return the name of the variable used for exporting - camelCase
-        """
-        return name
-
-    @staticmethod
-    def ioReconvertName(name):
-        """
-        Return the name of the variable used for exporting - SERPENT_CASE
-        """
-        return deconvertVariableName(name)
-
     def toMatlab(self, fileP, reconvert=True, append=True,
                  format='5', longNames=True, compress=True,
                  oned='row'):
@@ -771,7 +757,7 @@ class ResultsReader(XSReader):
 
     def _gather_matlab(self, reconvert):
         if reconvert:
-            varFunc = self.ioReconvertName
+            varFunc = getSerpentCaseName
             out = {
                 varFunc(key): value for key, value in iteritems(self.metadata)
             }
@@ -780,7 +766,7 @@ class ResultsReader(XSReader):
             })
         else:
             out = {}
-            varFunc = self.ioConvertName
+            varFunc = getMixedCaseName
             out.update(self.metadata)
             out.update(self.resdata)
         out.update(self._gather_univdata(varFunc))
@@ -821,6 +807,20 @@ class ResultsReader(XSReader):
                                      expD, uncD, univData)
 
         return univData
+
+
+def getMixedCaseName(name):
+    """
+    Return the name of the variable used for exporting - camelCase
+    """
+    return name
+
+
+def getSerpentCaseName(name):
+    """
+    Return the name of the variable used for exporting - SERPENT_CASE
+    """
+    return deconvertVariableName(name)
 
 
 def gatherPairedUnivData(universe, uIndex, bIndex, shapeStart, convFunc,

--- a/serpentTools/parsers/results.py
+++ b/serpentTools/parsers/results.py
@@ -35,7 +35,7 @@ from serpentTools.messages import (
     warning, SerpentToolsException,
     info,
 )
-from serpentTools.io import toMatlab
+from serpentTools.io import MatlabConverter
 
 
 MapStrVersions = {
@@ -755,8 +755,9 @@ class ResultsReader(XSReader):
         --------
         * :func:`scipy.io.savemat`
         """
-        return toMatlab(self, fileP, reconvert, append, format, longNames,
-                        compress, oned)
+        converter = MatlabConverter(self, fileP)
+        return converter.convert(reconvert, append, format, longNames,
+                                 compress, oned)
 
     def _gather_matlab(self, reconvert):
         if reconvert:

--- a/serpentTools/parsers/results.py
+++ b/serpentTools/parsers/results.py
@@ -800,7 +800,7 @@ class ResultsReader(XSReader):
 
             # position in matrix
             uIndex = univOrder.index(univKey[0])
-            bIndex = univKey[2] - 1
+            bIndex = univKey[2]
 
             for expName, uncName in zip(
                     ('infExp', 'b1Exp', 'gc'), ('infUnc', 'b1Unc', 'gcUnc')):

--- a/serpentTools/tests/test_toMatlab.py
+++ b/serpentTools/tests/test_toMatlab.py
@@ -187,7 +187,7 @@ class ResultToMatlabHelper(MatlabTesterHelper):
             self.assertTrue(univKey[0] in univOrder,
                             msg="{} // {}".format(univKey, univOrder))
             uIndex = univOrder.index(univKey[0])
-            actBurnIx = univKey[2] - 1
+            actBurnIx = univKey[2]
             self.assertTrue(actBurnIx in burnOrder,
                             msg="{} // {}".format(univKey, burnOrder))
             burnIndex = burnOrder.index(actBurnIx)


### PR DESCRIPTION
Works to address #282 by adding a `toMatlab` method for exporting content of the `ResultsReader` to matlab. 
The only thing that should be noted is the group constants are stored not as 2D matrices, as they would if you loaded the .mat file directly. Instead, the are constucted be `burnup, universe index, <groups>, value/unc`. Here, `groups` means either number of macro/micro energy groups, or a sub-2D matrix in the case of scattering