### PR TITLE
API Update default SERPENT version to 2.1.30

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -19,6 +19,10 @@ Next
 * Overhaul, reorganization, and cleanup of documentation
 * |DepletionReader| ``saveAsMatlab`` in favor of
   :meth:`~serpentTools.DepletionReader.toMatlab`
+* SERPENT ``2.1.30`` is the default version of :ref:`serpentVersion`. Will
+  alter some variable groups, like :ref:`optimization-base` and
+  :ref:`optimization-2-1-30`, that exist in both versions but are slightly
+  different.
 
 .. _v0.6.2:
 

--- a/docs/examples/ResultsReader.rst
+++ b/docs/examples/ResultsReader.rst
@@ -33,7 +33,6 @@ should ease the analyses.
     >>> import numpy as np
     >>> import serpentTools
     >>> from serpentTools.settings import rc
-    >>> rc['serpentVersion'] = '2.1.30'
 
     >>> resFile = 'InnerAssembly_res.m'
     >>> res = serpentTools.readDataFile(resFile)

--- a/serpentTools/parsers/results.py
+++ b/serpentTools/parsers/results.py
@@ -349,9 +349,10 @@ class ResultsReader(XSReader):
                     verWarning = False
                     varType, varVals = self._getVarValues(tline)  # version
                     if self.__serpentVersion not in varVals:
-                        warning("SERPENT {} found in {}, but version {} is defined"
-                                " in settings".format(varVals, self.filePath,
-                                                      self.__serpentVersion))
+                        warning("SERPENT {} found in {}, but version {} is "
+                                "defined in settings"
+                                .format(varVals, self.filePath,
+                                        self.__serpentVersion))
                         warning("  Attemping to read anyway. Please report "
                                 "strange behaviors/failures to developers.")
                 if self._keysVersion['univ'] in tline:

--- a/serpentTools/parsers/results.py
+++ b/serpentTools/parsers/results.py
@@ -333,8 +333,10 @@ class ResultsReader(XSReader):
         if self.__serpentVersion in MapStrVersions:
             self._keysVersion = MapStrVersions[self.__serpentVersion]
         else:
-            warning("Version {} is not supported by the "
+            warning("SERPENT {} is not supported by the "
                     "ResultsReader".format(self.__serpentVersion))
+            warning("  Attemping to read anyway. Please report strange "
+                    "behaviors/failures to developers.")
         univSet = set()
         verWarning = True
         with open(self.filePath) as fid:
@@ -347,9 +349,11 @@ class ResultsReader(XSReader):
                     verWarning = False
                     varType, varVals = self._getVarValues(tline)  # version
                     if self.__serpentVersion not in varVals:
-                        warning("Version {} is used, but version {} is defined"
-                                " in settings".format(varVals,
+                        warning("SERPENT {} found in {}, but version {} is defined"
+                                " in settings".format(varVals, self.filePath,
                                                       self.__serpentVersion))
+                        warning("  Attemping to read anyway. Please report "
+                                "strange behaviors/failures to developers.")
                 if self._keysVersion['univ'] in tline:
                     varType, varVals = self._getVarValues(tline)  # universe
                     if varVals in univSet:

--- a/serpentTools/settings.py
+++ b/serpentTools/settings.py
@@ -110,7 +110,7 @@ defaultSettings = {
         'type': bool
     },
     'serpentVersion': {
-        'default': '2.1.29',
+        'default': '2.1.30',
         'options': ['2.1.29', '2.1.30'],
         'description': 'Version of SERPENT',
         'type': str

--- a/serpentTools/tests/test_ResultsReader.py
+++ b/serpentTools/tests/test_ResultsReader.py
@@ -1,7 +1,7 @@
 """Test the results reader."""
 
 from os import remove
-import unittest
+from unittest import TestCase
 
 from numpy import array
 from numpy.testing import assert_equal
@@ -32,7 +32,17 @@ def tearDownModule():
     remove(NO_GCU_FILE)
 
 
-class TestBadFiles(unittest.TestCase):
+class Serp2129Helper(TestCase):
+    """Sets the serpentVersion to 2.1.29 for reading"""
+
+    def setUp(self):
+        rc['serpentVersion'] = '2.1.29'
+
+    def tearDown(self):
+        rc['serpentVersion'] = '2.1.30'
+
+
+class TestBadFiles(Serp2129Helper):
     """
     Test bad files.
 
@@ -68,16 +78,6 @@ class TestBadFiles(unittest.TestCase):
             badReader.read()
         remove(badFile)
 
-
-class TestEmptyAttributes(unittest.TestCase):
-    """
-    Test a case, in which some results do exist in the file,
-    however the read procedure assigns no results into the attributes.
-    Hence metadata, resdata and universes are all empty
-
-    Raises SerpentToolsException
-    """
-
     def test_emptyAttributes(self):
         """Verify that the reader raises error when all attributes are empty"""
         testFile = getFile('pwr_emptyAttributes_res.m')
@@ -88,7 +88,7 @@ class TestEmptyAttributes(unittest.TestCase):
                 testReader.read()
 
 
-class TestGetUniv(unittest.TestCase):
+class TestGetUniv(TestCase):
     """
     Test the getUniv method.
 
@@ -133,7 +133,7 @@ class TestGetUniv(unittest.TestCase):
         assert_equal(xsDict.infExp['infAbs'], self.expectedinfValAbs)
 
 
-class TesterCommonResultsReader(unittest.TestCase):
+class TesterCommonResultsReader(TestCase):
     """
     Class with common tests for the results reader.
 
@@ -565,7 +565,6 @@ class TestFilterResultsNoBurnup(TesterCommonResultsReader):
         self.file = getFile('pwr_noBU_res.m')
         # universe id, Idx, Idx, Idx
         with rc:
-            rc['serpentVersion'] = '2.1.30'
             rc['xs.variableGroups'] = ['versions', 'gc-meta', 'xs',
                                        'diffusion', 'eig', 'burnup-coeff']
             rc['xs.getInfXS'] = True  # only store inf cross sections
@@ -582,7 +581,6 @@ class TestResultsNoBurnNoGcu(TestFilterResultsNoBurnup):
     def setUp(self):
         self.file = NO_GCU_FILE
         with rc:
-            rc['serpentVersion'] = '2.1.30'
             rc['xs.variableGroups'] = ['versions', 'gc-meta', 'xs',
                                        'diffusion', 'eig', 'burnup-coeff']
             rc['xs.getInfXS'] = True  # only store inf cross sections
@@ -592,7 +590,7 @@ class TestResultsNoBurnNoGcu(TestFilterResultsNoBurnup):
             self.reader.read()
 
 
-class RestrictedResultsReader(unittest.TestCase):
+class RestrictedResultsReader(Serp2129Helper):
     """Class that restricts the variables read from the results file"""
 
     expectedInfFlux_bu0 = TestReadAllResults.expectedInfVals
@@ -629,4 +627,5 @@ class RestrictedResultsReader(unittest.TestCase):
 del TesterCommonResultsReader
 
 if __name__ == '__main__':
-    unittest.main()
+    from unittest import main
+    main()


### PR DESCRIPTION
SERPENT 2.1.30 is the latest SERPENT and has been out for a good while so I propose we set the default version for this package to be 2.1.30. This effects two sections:
1. The selection of some variables with `xs.variableGroups`. However, inspecting `variables.yaml`
and our documentation, this only involves the `optimization` setting. The impact of the change is minimal I believe.
2. Warnings produced by the ResultsReader. The files are similarly structured, so the reader doesn't catastrophically fail for the two versions. Additional warning messages are produced now if the versions don't match indicating the reader is attempting to continue reading, and any strange behavior should be reported. It's likely we will also encounter the strange behavior in our research, if a new version has a different `res.m` structure, and should begin working on a patch soon after.

Testing and documentation have been updated accordingly.