### PR TITLE
REL Release 0.7.0rc0

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,13 +6,15 @@
 Changelog
 =========
 
-Next
-====
+.. _v0.7.0:
+
+:release-tag:`0.7.0rc0`
+=======================
 
 * Easier construction of |BranchCollector| objects with
   :class:`~serpentTools.xs.BranchCollector.fromFile`.
 * Don't require passing branch information to |BranchCollector|. Will be inferred
-  from file and set with ``(p1, p2, ...)``. State data can be used to 
+  from file and set with ``(p0, p1, ...)``. State data can be used to 
   determine which index is a given perturbation type.
 * Direct ``toMatlab`` methods for |ResultsReader|, |SensitivityReader|,
   |DepmtxReader| |DepletionReader|, |DetectorReader|, |HistoryReader|,

--- a/serpentTools/xs.py
+++ b/serpentTools/xs.py
@@ -22,7 +22,7 @@ class BranchedUniv(object):
     """
     Class for storing cross sections for a single universe across branches
 
-    .. versionadded:: 0.6.2
+    .. versionadded:: 0.7.0
 
     Parameters
     ----------
@@ -182,13 +182,7 @@ class BranchCollector(object):
     """
     Main class that collects and arranges branched data
 
-    .. versionadded:: 0.6.2
-
-    .. warning::
-
-        This is experimental, and the structure of
-        the underlying data may change. This will
-        be stable in version 0.7.0
+    .. versionadded:: 0.7.0
 
     Parameters
     ----------

--- a/serpentTools/xs.py
+++ b/serpentTools/xs.py
@@ -24,13 +24,6 @@ class BranchedUniv(object):
 
     .. versionadded:: 0.6.2
 
-    .. warning::
-
-        This is experimental, and the structure of
-        the underlying data may change. This will
-        be stable in version 0.7.0
-
-
     Parameters
     ----------
     univID: str or int
@@ -228,8 +221,6 @@ class BranchCollector(object):
     )
 
     def __init__(self, source):
-        warn("This is an experimental feature, subject to change.",
-             UserWarning)
         if isinstance(source, BranchingReader):
             reader = source
         else:


### PR DESCRIPTION
Closes #282  and #263 
## Changelog and back-incompatible changes
Updated change log to point the `Next` changes to version `0.7.0rc0`. There's a lot of changes, including some API breaking (#288 and #289) changes. The change to zero-indexed universes is more noticeable, while the single valued detectors is less noticeable.
## BranchCollector
I have been using the branch collector nearly regularly and I like the data layout and API. I think it's is viable for public release w/o warnings. Previously, the BranchCollector raised a warning that this was an experimental feature subject to change. I don't think this is necessary. 