### PR TITLE
BUG Better labelling of HomogUniv plots w/o groups

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -43,6 +43,13 @@ Deprecations
   :ref:`optimization-2-1-30`, that exist in both versions but are slightly
   different.
 
+Bug Fixes
+---------
+
+* Fixed a bug that caused some plots not to return the axes object of the plot
+* |HomogUniv| plots are plotted against energy group when no group structure
+  can be determined, and now labeled as such
+
 .. _v0.6.2:
 
 :release-tag:`0.6.2`

--- a/serpentTools/utils/plot.py
+++ b/serpentTools/utils/plot.py
@@ -17,6 +17,7 @@ __all__ = [
     'setAx_ylims',
     'normalizerFactory',
     'placeLegend',
+    'inferAxScale'
 ]
 
 LEGEND_KWARGS = {


### PR DESCRIPTION
Closes #298 by changing the x-axis label to be Energy Group if no group structure was found.
Also intelligently logscale the x and y axis if logx and logy are both None and loglog is not None

Using the same script from #298, the following plots are made from the results and coe files:
![res-0 7 0rc0+3 g568ad8a](https://user-images.githubusercontent.com/19477741/54709507-ff3e8b80-4b1b-11e9-9f71-2ee630ec98e4.png)

![coe-0 7 0rc0+3 g568ad8a](https://user-images.githubusercontent.com/19477741/54709513-049bd600-4b1c-11e9-8ac7-90a8c1faeb6b.png)