### PR TITLE
CLI/BUG Failed exit code from seed interface

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -49,6 +49,8 @@ Bug Fixes
 * Fixed a bug that caused some plots not to return the axes object of the plot
 * |HomogUniv| plots are plotted against energy group when no group structure
   can be determined, and now labeled as such
+* Removed a non-zero exit code from a successful use of the :ref:`cli-seed`
+  command line command
 
 .. _v0.6.2:
 

--- a/serpentTools/__main__.py
+++ b/serpentTools/__main__.py
@@ -14,7 +14,7 @@ import six
 
 import serpentTools
 from serpentTools import settings
-from serpentTools.messages import info, debug, error
+from serpentTools.messages import info, error
 from serpentTools.parsers import inferReader
 from serpentTools.io import MatlabConverter
 

--- a/serpentTools/__main__.py
+++ b/serpentTools/__main__.py
@@ -146,9 +146,12 @@ def _toMatlab(args):
 def _seedInterface(args):
     """Interface to launch the uniquely-seeded file generation"""
     from serpentTools.seed import seedFiles
-    return seedFiles(args.file, args.N, seed=args.seed,
-                     outputDir=args.output_dir,
-                     link=args.link, length=args.length)
+    files = seedFiles(args.file, args.N, seed=args.seed,
+                      outputDir=args.output_dir,
+                      link=args.link, length=args.length)
+    if not args.q:
+        print('\n'.join(files))
+    return 0
 
 
 def _listDefaults(args):

--- a/serpentTools/__main__.py
+++ b/serpentTools/__main__.py
@@ -119,9 +119,6 @@ def _toMatlab(args):
     if not outFile:
         base = splitext(inFile)[0]
         outFile = base + '.mat'
-        herald = info
-    else:
-        herald = debug
 
     # inferReader returns the class, but we need an instance
     reader = inferReader(inFile)(inFile)
@@ -139,7 +136,12 @@ def _toMatlab(args):
     converter.convert(True, append=args.append,
                       format=args.format, longNames=args.longNames,
                       compress=not args.large, oned=args.oned)
-    herald("Wrote contents from {} to {}".format(inFile, outFile))
+    if not args.q:
+        if args.v:
+            info("Wrote contents of {} to {}".format(inFile, outFile))
+        else:
+            print(outFile)
+
     return 0
 
 


### PR DESCRIPTION
Previously, if you ran `$ python -m serpentTool seed <file> <N>`, the files generated were passed to `sys.exit()`, creating a non-zero exit code and a less than helpful printout. The files were still generated fine, but the non-zero exit code is often indicative of a failure by many commands.

Now, a return code of 0 indicates success, and the files are printed out in a manner more conducive for scripting/piping to other programs.

Added support for the user's verbosity in the seed and to-matlab interfaces