### PR TITLE
DOC Explain terminal notation in installation guide

### DIFF
--- a/docs/command-line.rst
+++ b/docs/command-line.rst
@@ -10,6 +10,9 @@ access this interface with::
 
     $ python -m serpentTools
 
+Where the above command is executed from the terminal, neglecting the ``$``.
+More information can be found in :ref:`install_terminals`.
+
 .. note::
     
     Outputs here are accurate up to version ``0.6.1+12``

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -9,13 +9,28 @@ python that plays well with libraries like :term:`numpy` and :term:`matplotlib`.
 This is easy or less easy depending on your operating system, but we have
 a brief walk through at :ref:`install-python-dist`.
 
-.. note::
+.. _install_terminals:
 
-    Commands below that begin with ``$`` must be run from the
-    terminal containing your preferred python distribution.
-    Depending on operating system, this could be the normal
-    terminal, or a modified prompt. See :ref:`install-python-dist`
-    for more information if you are not sure.
+Terminal terminology
+====================
+
+Commands below that begin with ``$`` must be run from the
+terminal containing your preferred python distribution, neglecting
+the ``$``.
+Depending on operating system, this could be the normal
+terminal, or a modified prompt. See :ref:`install-python-dist`
+for more information if you are not sure.
+
+Commands that begin with ``>>>`` should be run inside of a python
+environment.
+The following would be a valid set of instructions to pass to your terminal,
+printing a very basic python command::
+
+    $ python -m "print('hello world')"
+    hello world
+    $ python
+    >>> print('hello world')
+    hello world
 
 .. _install-pip:
 


### PR DESCRIPTION
Got some feedback that the notation used in the installation was misleading and possibly confusing for new users. Added a brief section describing what lines like 
```
$ python -m serpentTools
```
and
```
>>> print('hello')
```
do and how they should be executed