### PR TITLE
BUG/DEV str2vec to handle spaceless strings, performance - #305

### DIFF
--- a/serpentTools/tests/test_utils.py
+++ b/serpentTools/tests/test_utils.py
@@ -60,6 +60,13 @@ class VectorConverterTester(TestCase):
         expected = [0, 1, 2, 3]
         self._runConversionTest(int, expected, list)
 
+    def test_vecOfStr(self):
+        """Verify a single word can be converted with str2vec"""
+        key = 'ADF'
+        expected = array('ADF')
+        actual = str2vec(key)
+        assert_array_equal(expected, actual)
+
     def _runConversionTest(self, valType, expected, outType=None):
         if outType is None:
             outType = array
@@ -67,7 +74,7 @@ class VectorConverterTester(TestCase):
         else:
             compareType = outType
         for case in self.testCases:
-            actual = str2vec(case, of=valType, out=outType)
+            actual = str2vec(case, dtype=valType, out=outType)
             self.assertIsInstance(actual, compareType, msg=case)
             ofRightType = [isinstance(xx, valType) for xx in actual]
             self.assertTrue(all(ofRightType),

--- a/serpentTools/tests/test_utils.py
+++ b/serpentTools/tests/test_utils.py
@@ -45,8 +45,9 @@ class VariableConverterTester(TestCase):
 class VectorConverterTester(TestCase):
     """Class for testing the str2vec function"""
 
-    def setUp(self):
-        self.testCases = ("0 1 2 3", [0, 1, 2, 3], (0, 1, 2, 3), arange(4))
+    @classmethod
+    def setUpClass(cls):
+        cls.testCases = ("0 1 2 3", [0, 1, 2, 3], (0, 1, 2, 3), arange(4))
 
     def test_str2Arrays(self):
         """Verify that the str2vec converts to arrays."""
@@ -86,8 +87,9 @@ class VectorConverterTester(TestCase):
 class SplitValsTester(TestCase):
     """Class that tests splitValsUncs."""
 
-    def setUp(self):
-        self.input = arange(4)
+    @classmethod
+    def setUp(cls):
+        cls.input = arange(4)
 
     def test_splitVals(self):
         """Verify the basic functionality."""
@@ -328,8 +330,9 @@ class OverlapTester(TestCase):
 class SplitDictionaryTester(TestCase):
     """Class for testing utils.splitDictByKeys."""
 
-    def setUp(self):
-        self.map0 = {
+    @classmethod
+    def setUpClass(cls):
+        cls.map0 = {
             'hello': 'world',
             'missingFrom1': True,
             'infKeff': arange(2),
@@ -338,7 +341,7 @@ class SplitDictionaryTester(TestCase):
             'anaKeff': arange(6),
             'notBool': 1,
         }
-        self.map1 = {
+        cls.map1 = {
             'hello': 'world',
             'infKeff': arange(2),
             'float': 0.24,
@@ -347,9 +350,9 @@ class SplitDictionaryTester(TestCase):
             'anaKeff': arange(2),
             'absKeff': arange(2),
         }
-        self.badTypes = {'notBool': (int, bool)}
-        self.badShapes = {'anaKeff': ((6, ), (2, )), }
-        self.goodKeys = {'hello', 'absKeff', 'float', 'infKeff', }
+        cls.badTypes = {'notBool': (int, bool)}
+        cls.badShapes = {'anaKeff': ((6, ), (2, )), }
+        cls.goodKeys = {'hello', 'absKeff', 'float', 'infKeff', }
 
     def callTest(self, keySet=None):
         return splitDictByKeys(self.map0, self.map1, keySet)

--- a/serpentTools/utils/core.py
+++ b/serpentTools/utils/core.py
@@ -4,7 +4,7 @@ Core utilities
 
 from re import compile
 
-from numpy import array, ndarray
+from numpy import array, ndarray, fromiter
 
 
 # Regular expressions
@@ -15,28 +15,33 @@ SCALAR_REGEX = compile(r'=.+;')  # scalar
 FIRST_WORD_REGEX = compile(r'^\w+')  # first word in the line
 
 
-def str2vec(iterable, of=float, out=array):
+def str2vec(iterable, dtype=float, out=array):
     """
     Convert a string or other iterable to vector.
 
     Parameters
     ----------
     iterable: str or iterable
-        If string, will be split with ``split(splitAt)``
-        to create a list. Every item in this list, or original
+        If a string containing spaces, will be split using
+        ```iterable.split()``. If no spaces are found, the
+        outgoing type is filled with a single string, e.g.
+        a list with a single string as the first and only
+        entry. This is returned directly, avoiding conversion
+        with ``dtype``.
+        Every item in this split list, or original
         iterable, will be iterated over and converted accoring
         to the other arguments.
-    of: type
+    dtype: type
         Convert each value in ``iterable`` to this data type.
     out: type
         Return data type. Will be passed the iterable of
-        converted items of data dtype ``of``.
+        converted items of data dtype ``dtype``.
 
     Returns
     -------
     vector
         Iterable of all values of ``iterable``, or split variant,
-        converted to type ``of``.
+        converted to type ``dtype``.
 
     Examples
     --------
@@ -53,10 +58,19 @@ def str2vec(iterable, of=float, out=array):
         >>> str2vec(x)
         array([1., 2., 3., 4.,])
 
+        >>> str2vec("ADF")
+        array(['ADF', dtype='<U3')
+
     """
-    vec = (iterable.split() if isinstance(iterable, str)
-           else iterable)
-    return out([of(xx) for xx in vec])
+    if isinstance(iterable, str):
+        if ' ' in iterable:
+            iterable = iterable.split()
+        else:
+            return out([iterable])
+    cmap = map(dtype, iterable)
+    if out is array:
+        return fromiter(cmap, dtype)
+    return out(cmap)
 
 
 def splitValsUncs(iterable, copy=False):


### PR DESCRIPTION
Closes #305 by allowing the conversion to handle string without spaces and create arrays of strings. When we perform `iterable.split()` on the string `'ADF'`, we get back a string that cannot be converted to floats or ints. This PR would instead return a direct array (or list or tuple) of the string.

## Performance

Utilize the python `map` function and `numpy.fromiter` to improve performance of the conversion. The following simple bash script compares two ways to construct a list of floats, and two ways to construct and array of floats. All commands work with the same range of values. 
```
#!/bin/bash
N=${1-10000}
echo Testing with $N values

python -m timeit -s "xr = range(${N})" "list(map(float, xr))"
python -m timeit -s "xr = range(${N})" "[float(xx) for xx in xr]"
python -m timeit -s "from numpy import fromiter; xr = range(${N})" "fromiter(map(float, xr), float)"
python -m timeit -s "from numpy import array; xr=range(${N})" "array([float(xx) for xx in xr])"
```
The times are ordered as:
1. List of floats using map
2. List of floats using list comprehension
3. Array of floats using map
4. Array of floats using list comprehension
```
Testing with 10 values
500000 loops, best of 5: 751 nsec per loop
500000 loops, best of 5: 913 nsec per loop
200000 loops, best of 5: 1.23 usec per loop
200000 loops, best of 5: 1.71 usec per loop
Testing with 100 values
50000 loops, best of 5: 5.3 usec per loop
50000 loops, best of 5: 7.54 usec per loop
50000 loops, best of 5: 6.9 usec per loop
20000 loops, best of 5: 10.8 usec per loop
Testing with 1000 values
5000 loops, best of 5: 59.5 usec per loop
5000 loops, best of 5: 83.3 usec per loop
5000 loops, best of 5: 69.6 usec per loop
2000 loops, best of 5: 111 usec per loop
Testing with 10000 values
500 loops, best of 5: 605 usec per loop
500 loops, best of 5: 837 usec per loop
500 loops, best of 5: 692 usec per loop
200 loops, best of 5: 1.08 msec per loop
```
We can see that, for small values, the two are comparable. As the number of entries increases the `map`-based approach becomes comparatively faster. This speed up is nice when people read universe data with 100s of energy groups, or detectors with thousands of groups. This function is called a lot, and this marginal speed up *should* make a difference in the scheme of reading. We don't have a profiling and timing suite yet, but we should.