### PR TITLE
API Add threshold argument for detector mesh plots

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,6 +12,9 @@ Next
 * Add :meth:`~serpentTools.objects.HomogUniv.__getitem__` and 
   :meth:`~serpentTools.objects.HomogUniv.__setitem__` convenience
   methods for accessing expected values on |HomogUniv| objects
+* Add ``thresh`` argument to |Detector| 
+  :meth:`~serpentTools.objects.CartesianDetector.meshPlot`, where
+  only data greater than ``thresh`` is plotted.
 
 .. _v0.7.0:
 

--- a/serpentTools/objects/base.py
+++ b/serpentTools/objects/base.py
@@ -448,7 +448,7 @@ class DetectorBase(NamedObject):
     def meshPlot(self, xdim='x', ydim='y', what='tallies', fixed=None, ax=None,
                  cmap=None, cbarLabel=None, logColor=False, xlabel=None,
                  ylabel=None, logx=False, logy=False, loglog=False,
-                 title=None, **kwargs):
+                 title=None, thresh=None, **kwargs):
         """
         Plot tally data as a function of two bin types on a cartesian mesh.
 
@@ -473,6 +473,7 @@ class DetectorBase(NamedObject):
         {logy}
         {loglog}
         {title}
+        {mthresh}
         cbarLabel: str
             Label to apply to colorbar. If not given, infer from ``what``
         {kwargs} :py:func:`~matplotlib.pyplot.pcolormesh`
@@ -519,7 +520,7 @@ class DetectorBase(NamedObject):
             cbarLabel = self._CBAR_LABELS[what]
         ax = cartMeshPlot(
             data, xgrid, ygrid, ax, cmap, logColor,
-            cbarLabel=cbarLabel, **kwargs)
+            cbarLabel=cbarLabel, thresh=thresh, **kwargs)
         if xlabel is None:
             xlabel = DETECTOR_PLOT_LABELS.get(xdim, xdim)
         if ylabel is None:

--- a/serpentTools/objects/base.py
+++ b/serpentTools/objects/base.py
@@ -484,7 +484,7 @@ class DetectorBase(NamedObject):
 
         Raises
         ------
-        :class:`~serpentTools.SerpentToolsException`
+        :class:`serpentTools.SerpentToolsException`
             If data to be plotted, with or without constraints, is not 1D
         KeyError
             If the data set by ``what`` not in the allowed selection
@@ -495,6 +495,7 @@ class DetectorBase(NamedObject):
         See Also
         --------
         * :meth:`slice`
+        * :func:`serpentTools.plot.cartMeshPlot`
         * :func:`matplotlib.pyplot.pcolormesh`
         """
         if fixed:

--- a/serpentTools/plot.py
+++ b/serpentTools/plot.py
@@ -1,6 +1,7 @@
 """Plot routines"""
 
 from numpy import meshgrid
+from numpy.ma import masked_less_equal
 from matplotlib import pyplot
 
 from serpentTools.messages import warning
@@ -17,7 +18,8 @@ __all__ = [
 
 @magicPlotDocDecorator
 def cartMeshPlot(data, xticks=None, yticks=None, ax=None, cmap=None,
-                 logColor=False, normalizer=None, cbarLabel=None, **kwargs):
+                 logColor=False, normalizer=None, cbarLabel=None,
+                 thresh=None, **kwargs):
     """
     Create a cartesian mesh plot of the data
 
@@ -47,6 +49,7 @@ def cartMeshPlot(data, xticks=None, yticks=None, ax=None, cmap=None,
         ``norm = normalizer(data, xticks, yticks)``
     cbarLabel: None or str
         Label to apply to colorbar
+    {thresh}
     {kwargs} :py:func:`matplotlib.pyplot.pcolormesh` or
         :func:`matplotlib.pyplot.imshow` if ``xticks`` and ``yticks``
         are ``None``
@@ -107,12 +110,16 @@ def cartMeshPlot(data, xticks=None, yticks=None, ax=None, cmap=None,
                 "Use logColor instead.")
         logColor = bool(logColor or kwargs['logScale'])
 
+    if thresh is not None:
+        data = masked_less_equal(data, thresh)
+
     if logColor and data.min() < 0:
         raise ValueError("Will not apply log normalization to data with "
                          "negative elements")
     norm = normalizerFactory(data, normalizer, logColor, xticks, yticks)
 
     # make the plot
+
     ax = ax or pyplot.gca()
     if xticks is None:
         mappable = ax.imshow(data, cmap=cmap, norm=norm)

--- a/serpentTools/plot.py
+++ b/serpentTools/plot.py
@@ -60,9 +60,9 @@ def cartMeshPlot(data, xticks=None, yticks=None, ax=None, cmap=None,
 
     Raises
     ------
-    ValueError:
+    ValueError
         If ``logColor`` and data contains negative quantities
-    TypeError:
+    TypeError
         If only one of ``xticks`` or ``yticks`` is ``None``.
 
     Examples
@@ -91,6 +91,19 @@ def cartMeshPlot(data, xticks=None, yticks=None, ax=None, cmap=None,
     plotting sparse matrices, as the zero-valued indices can be
     identified without obscuring the trends presented in the
     non-zero data.
+
+    Alternatively, one can use the ``thresh`` argument to
+    set a threshold for plotted data. Any value less
+    than or equal to ``thresh`` will not be colored,
+    and the colorbar will be updated to reflect this.
+
+    .. plot::
+        :include-source:
+
+        >>> from serpentTools.plot import cartMeshPlot
+        >>> from numpy import arange
+        >>> data = arange(100).reshape(10, 10)
+        >>> cartMeshPlot(data, thresh=50)
 
     See Also
     --------

--- a/serpentTools/utils/docstrings.py
+++ b/serpentTools/utils/docstrings.py
@@ -76,13 +76,15 @@ LEGEND = """legend: bool or str or None
 
 NCOL = """ncol: int\n    Integer number of columns to apply to the legend."""
 
+MESH_THRESH = """thresh: float\n    Do not plot data less than or equal to this value."""
+
 PLOT_MAGIC_STRINGS = {
     'loglog': LOG_LOG, 'logy': LOGY, 'logx': LOGX,
     'xlabel': XLABEL, 'ylabel': YLABEL, 'sigma': SIGMA,
     'ax': AX, 'rax': RETURNS_AX, 'labels': LABELS, 'xlabel': XLABEL,
     'ylabel': YLABEL, 'kwargs': KWARGS, 'cmap': CMAP, 'title': TITLE,
     'matLabelFmt': MAT_FMT_DOC, 'legend': LEGEND, 'ncol': NCOL,
-    'univLabelFmt': UNIV_FMT_DOC,
+    'univLabelFmt': UNIV_FMT_DOC, 'mthresh': MESH_THRESH,
 }
 """Magic strings that, if found as {x}, will be replaced by the key of x"""
 

--- a/serpentTools/utils/docstrings.py
+++ b/serpentTools/utils/docstrings.py
@@ -76,7 +76,8 @@ LEGEND = """legend: bool or str or None
 
 NCOL = """ncol: int\n    Integer number of columns to apply to the legend."""
 
-MESH_THRESH = """thresh: float\n    Do not plot data less than or equal to this value."""
+MESH_THRESH = """thresh: float
+    Do not plot data less than or equal to this value."""
 
 PLOT_MAGIC_STRINGS = {
     'loglog': LOG_LOG, 'logy': LOGY, 'logx': LOGX,


### PR DESCRIPTION
Utilize [`numpy` masked arrays](https://docs.scipy.org/doc/numpy/reference/maskedarray.generic.html#module-numpy.ma) to only color data greater than or equal to 
a specific value. Helpful for power plots, where the power in non-fuel locations is zero, but you don't want that dragging down the plot. 

Can also be used in conjunction with the log color option