### PR TITLE
DEV Add compatibility for importing from collections

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,6 +15,7 @@ Next
 * Add ``thresh`` argument to |Detector| 
   :meth:`~serpentTools.objects.CartesianDetector.meshPlot`, where
   only data greater than ``thresh`` is plotted.
+* Mitigate pending deprecated imports from ``collections`` - :issue:`313`
 
 .. _v0.7.0:
 

--- a/docs/develop/utils.rst
+++ b/docs/develop/utils.rst
@@ -7,6 +7,8 @@ Utilities
 
 .. automodule:: serpentTools.utils
 
+.. automodule:: serpentTools.utils.compat
+
 
 .. _dev-testUtils:
 

--- a/serpentTools/_compat.py
+++ b/serpentTools/_compat.py
@@ -1,0 +1,13 @@
+# flake8: noqa
+"""
+Minor compatibility between python 2 and python 3 outside of six
+
+Provided objects:
+    - ``Iterable``, ``Callable`: ``collections.x`` or ``collections.abc.x``
+"""
+import six
+
+if six.PY2:
+    from collections import Iterable, Callable
+else:
+    from collections.abc import Iterable, Callable

--- a/serpentTools/messages.py
+++ b/serpentTools/messages.py
@@ -12,7 +12,7 @@ import warnings
 import logging
 from logging import Handler
 from logging.config import dictConfig
-from collections import Callable
+from serpentTools._compat import Callable
 
 from numpy import ndarray
 

--- a/serpentTools/parsers/base.py
+++ b/serpentTools/parsers/base.py
@@ -5,13 +5,13 @@ Contains the abstract base class upon which all readers
 are built.
 """
 
-from collections import Callable
 from abc import ABCMeta, abstractmethod
 import re
 
 from six import add_metaclass
 
 from numpy import array
+from serpentTools._compat import Callable
 from serpentTools.messages import info
 from serpentTools.settings import rc
 from serpentTools.objects.base import BaseObject

--- a/serpentTools/utils/compare.py
+++ b/serpentTools/utils/compare.py
@@ -1,15 +1,13 @@
 """
 Comparison utilities
 """
-
-from collections import Iterable
-
 from numpy.core.defchararray import equal as charEqual
 from numpy import (
     fabs, zeros_like, ndarray, array, greater, multiply, subtract,
     equal,
 )
 
+from serpentTools._compat import Iterable
 from serpentTools.messages import (
     error,
     logIdentical,

--- a/serpentTools/xs.py
+++ b/serpentTools/xs.py
@@ -3,13 +3,13 @@ Utilities for collecting and exporting group constants from a
 branching file
 """
 
-from collections import Iterable
 from itertools import product
 from warnings import warn
 from six import iteritems
 from six.moves import range
 from numpy import empty, nan, array, ndarray
 
+from serpentTools._compat import Iterable
 from serpentTools import BranchingReader
 
 __all__ = [


### PR DESCRIPTION
Closes #313 by adding a compatibility file from which modules can import collections[.abc].Iterable and Callable abstract base classes. This are not included in the six module, but are easily resolved.