### PR TITLE
DOC Use autodoc_default_options dict

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -188,7 +188,9 @@ texinfo_documents = [
 ]
 
 # -- Options for auto documentation --------------------------------------
-autodoc_default_flags = ['members', 'inherited-members']
+autodoc_default_options = {
+    'members': 'inherited-members',
+}
 
 # -- Links to external documentation
 intersphinx_mapping = {


### PR DESCRIPTION
Closes #308 by relying on dictionary based default options rather than ``autodoc_default_flags``. Skipping ci because this is a documentation related change