### PR TITLE
REL Release 0.7.1

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,17 +6,19 @@
 Changelog
 =========
 
-Next
-====
+.. _v0.7.1
+
+:release-tag:`0.7.1`
+====================
 
 * Add :meth:`~serpentTools.objects.HomogUniv.__getitem__` and 
   :meth:`~serpentTools.objects.HomogUniv.__setitem__` convenience
   methods for accessing expected values on |HomogUniv| objects
-* Add ``thresh`` argument to |Detector| 
-  :meth:`~serpentTools.objects.CartesianDetector.meshPlot`, where
+* Add ``thresh`` argument to |Detector| ``meshPlot`` where
   only data greater than ``thresh`` is plotted.
 * Mitigate pending deprecated imports from ``collections`` - :issue:`313`
 * Increase required version of :term:`yaml` to ``5.1.1``
+* Include ``SERPENT`` ``2.1.31`` support in :ref:`serpentVersion` setting
 
 Bug fixes
 ---------
@@ -32,6 +34,8 @@ Pending Deprecations
   :attr:`serpentTools.xs.BranchCollector.universes` are stored as strings,
   rather than integers, e.g. ``0`` is replaced with ``"0"``. A workaround
   is in-place, but will be removed in future versions.
+* ``SERPENT`` 1 style detectors with additional score column will not be
+  supported starting at version ``0.8.0``.
 
 .. _v0.7.0:
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -216,6 +216,7 @@ rst_prolog = """
 .. |DepletionReader| replace:: :class:`~serpentTools.DepletionReader`
 .. |DepmtxReader| replace:: :class:`~serpentTools.DepmtxReader`
 .. |BranchCollector| replace:: :class:`~serpentTools.BranchCollector`
+.. |BranchedUniv| replace:: :class:`~serpentTools.BranchedUniv`
 .. |BranchingReader| replace:: :class:`~serpentTools.BranchingReader`
 .. |XSPlotReader| replace:: :class:`~serpentTools.XSPlotReader`
 .. |HistoryReader| replace:: :class:`~serpentTools.HistoryReader`

--- a/docs/defaultSettings.rst
+++ b/docs/defaultSettings.rst
@@ -204,7 +204,7 @@ Version of SERPENT
 
   Default: 2.1.29
   Type: str
-  Options: [2.1.29, 2.1.30]
+  Options: [2.1.29, 2.1.30, 2.1.31]
 
 .. _verbosity:
 

--- a/serpentTools/settings.py
+++ b/serpentTools/settings.py
@@ -111,7 +111,7 @@ defaultSettings = {
     },
     'serpentVersion': {
         'default': '2.1.30',
-        'options': ['2.1.29', '2.1.30'],
+        'options': ['2.1.29', '2.1.30', '2.1.31'],
         'description': 'Version of SERPENT',
         'type': str
     },


### PR DESCRIPTION
The biggest change here is the inclusion of serpent 2.1.31 into the `serpentVersions` setting. Some baseline analysis and discussion with users have shown that the output files are not too different thankfully. I propose that we leave 2.1.30 as the default, at least up to our release of 0.8.0. This should give time for any bugs to [hopefully] come out of the wood work to be fixed.