### PR TITLE
API Better handling of discontinuity factors

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,18 @@
 Changelog
 =========
 
+Next
+====
+
+* Better handling of discontinuity factors
+* |HomogUniv| objects no longer automatically convert data to arrays
+
+Incompatible API Changes
+------------------------
+
+* Values are stored in array form on |HomogUniv| when it makes sense.
+  For example, values like ``infKinf`` are stored as scalars.
+
 .. _v0.7.1
 
 :release-tag:`0.7.1`

--- a/serpentTools/objects/containers.py
+++ b/serpentTools/objects/containers.py
@@ -7,14 +7,13 @@ Contents
 * :py:class:`~serpentTools.objects.containers.BranchContainer`
 
 """
-from re import compile
 from itertools import product
 from warnings import warn
 from numbers import Real
 
 from six import iteritems, PY2
 from matplotlib import pyplot
-from numpy import array, arange, hstack, ndarray, zeros_like
+from numpy import arange, hstack, ndarray, zeros_like
 
 from serpentTools.settings import rc
 from serpentTools.objects.base import NamedObject, BaseObject

--- a/serpentTools/objects/containers.py
+++ b/serpentTools/objects/containers.py
@@ -63,9 +63,6 @@ __all__ = (
 )
 
 
-CRIT_RE = compile('K[EI][NF]F')
-
-
 class HomogUniv(NamedObject):
     """
     Class for storing homogenized universe specifications and retrieving them
@@ -241,14 +238,9 @@ class HomogUniv(NamedObject):
         """
         Return the new value to be stored after some cleaning.
 
-        Makes sure all vectors, everything but keff/kinf data, are
-        converted to numpy arrays. Reshapes scattering matrices
-        if number of groups is known and ``xs.reshapeScatter``
+        Reshapes scattering matrices if number of groups
+        is known and ``xs.reshapeScatter``
         """
-        if not isinstance(value, ndarray):
-            value = array(value)
-        if CRIT_RE.search(name):
-            return value[0]
         ng = self.numGroups
         if self.__reshaped and name in SCATTER_MATS:
             if ng is None:

--- a/serpentTools/tests/test_ResultsReader.py
+++ b/serpentTools/tests/test_ResultsReader.py
@@ -1,5 +1,5 @@
 """Test the results reader."""
-
+# pylint: disable=line-too-long
 from os import remove
 from shutil import copy
 from unittest import TestCase
@@ -41,7 +41,12 @@ DF_SURFACE                (idx, [1:  3])  = 'ADF' ;
 DF_SYM                    (idx, 1)        = 1 ;
 DF_N_SURF                 (idx, 1)        = 4 ;
 DF_N_CORN                 (idx, 1)        = 4 ;
-""")
+DF_VOLUME                 (idx, 1)        =  4.62250E+02 ;
+DF_SURF_AREA              (idx, [1:  4])  = [ 2.15000E+01  2.15000E+01  2.15000E+01  2.15000E+01 ];
+DF_MID_AREA               (idx, [1:  4])  = [ 2.15000E+00  2.15000E+00  2.15000E+00  2.15000E+00 ];
+DF_CORN_AREA              (idx, [1:  4])  = [ 2.15000E+00  2.15000E+00  2.15000E+00  2.15000E+00 ];
+DF_SURF_IN_CURR           (idx, [1:  16]) = [  1.19014E+15 0.00046  1.99543E+14 0.00114  1.19014E+15 0.00046  1.99543E+14 0.00114  1.19014E+15 0.00046  1.99543E+14 0.00114  1.19014E+15 0.00046  1.99543E+14 0.00114 ];
+""") # noqa
 
 
 def tearDownModule():
@@ -727,9 +732,25 @@ class ResADFTester(TestCase):
         cls.reader.read()
 
     def test_adf(self):
+        """Verify the storage of ADF data"""
         univ = self.reader.getUniv('0', index=0)
-        expected = array('ADF')
-        assert_array_equal(expected, univ.gc['dfSurface'])
+        self.assertTrue(type(univ.infExp['infKinf']) is float)
+        self.assertEqual(1.15306, univ.infExp['infKinf'])
+        self.assertEqual(0.00127, univ.infUnc['infKinf'])
+        self.assertTrue(type(univ.gc['dfSurface']) is str)
+        self.assertEqual('ADF', univ.gc['dfSurface'])
+        self.assertTrue(type(univ.gc['dfSym']) is int)
+        self.assertEqual(1, univ.gc['dfSym'])
+        self.assertTrue(type(univ.gc['dfVolume']) is float)
+        self.assertEqual(4.62250E+02, univ.gc['dfVolume'])
+        assert_array_equal(
+            array([2.15000E+01, 2.15000E+01, 2.15000E+01, 2.15000E+01]),
+            univ.gc['dfSurfArea'])
+        assert_array_equal(array([
+            1.19014E+15, 1.99543E+14, 1.19014E+15, 1.99543E+14,
+            1.19014E+15, 1.99543E+14, 1.19014E+15, 1.99543E+14]),
+            univ.gc['dfSurfInCurr'])
+        self.assertTrue('dfSurfArea' not in univ.gcUnc)
 
 
 if __name__ == '__main__':

--- a/serpentTools/tests/test_container.py
+++ b/serpentTools/tests/test_container.py
@@ -29,12 +29,12 @@ class _HomogUnivTestHelper(TestCase):
         # Data definition
         rawData = {'B1_1': vec, 'B1_AS_LIST': list(vec),
                    'INF_1': vec, 'INF_S0': mat, 'CMM_TRANSP_X': vec,
-                   'INF_KEFF': vec, 'B1_KINF': vec, 'IMP_KEFF': vec,
-                   'INF_KINF': vec}
+                   'INF_KEFF': testK, 'B1_KINF': testK, 'IMP_KEFF': testK,
+                   'INF_KINF': testK}
         attrs = {'MACRO_E': groupStructure}
         # Partial dictionaries
         self.b1Unc = self.b1Exp = {
-            'b11': vec, 'b1AsList': vec, 'b1Kinf': testK,
+            'b11': vec, 'b1AsList': list(vec), 'b1Kinf': testK,
         }
         self.infUnc = self.infExp = {
             'inf1': vec, 'infS0': mat, 'infKeff': testK, 'infKinf': testK,

--- a/serpentTools/utils/compare.py
+++ b/serpentTools/utils/compare.py
@@ -4,7 +4,7 @@ Comparison utilities
 from numpy.core.defchararray import equal as charEqual
 from numpy import (
     fabs, zeros_like, ndarray, array, greater, multiply, subtract,
-    equal,
+    equal, asarray,
 )
 
 from serpentTools._compat import Iterable
@@ -540,6 +540,10 @@ def getLogOverlaps(quantity, arr0, arr1, unc0, unc1, sigma, relative=True):
       :mod:`serpentTools.messages`
     """
 
+    arr0 = asarray(arr0)
+    unc0 = asarray(unc0)
+    arr1 = asarray(arr1)
+    unc1 = asarray(unc1)
     if (arr0 == arr1).all():
         logIdenticalWithUncs(arr0, unc0, unc1, quantity)
         return True


### PR DESCRIPTION
Resolves an issue where all data was fed to the `HomogUniv` objects under the assumption that everything was a vector with uncertainties. Some quantities, like `infKeff` are now stored as single scalars, rather than vectors of a single item. Other quantities, like `dfSurfArea`, are stored as vectors but do not have any uncertainties. This may cause some issues if people expect a single-valued vector when pulling `infKeff`, so this is delayed to the next major release, `0.8.0`, and marked as containing [potentially] incompatible API changes