### PR TITLE
API Introduce potentially breaking changes for 0.8.0 

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,6 +11,7 @@ Next
 
 * Better handling of discontinuity factors
 * |HomogUniv| objects no longer automatically convert data to arrays
+* Serpent 2.1.31 is the default version for :ref:`serpentVersion` setting
 
 Incompatible API Changes
 ------------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -18,6 +18,8 @@ Incompatible API Changes
 
 * Values are stored in array form on |HomogUniv| when it makes sense.
   For example, values like ``infKinf`` are stored as scalars.
+* Setting ``expectGcu`` has been removed as :pull:`324` fixed how files without
+  group constants are handled.
 
 .. _v0.7.1
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -20,6 +20,9 @@ Incompatible API Changes
   For example, values like ``infKinf`` are stored as scalars.
 * Setting ``expectGcu`` has been removed as :pull:`324` fixed how files without
   group constants are handled.
+* Keys to |BranchedUniv| objects stored in
+  :attr:`serpentTools.xs.BranchCollector.universes` are stored as strings,
+  rather than integers, e.g. ``0`` is replaced with ``"0"`` - :pull:`321`
 
 .. _v0.7.1
 

--- a/docs/defaultSettings.rst
+++ b/docs/defaultSettings.rst
@@ -189,7 +189,7 @@ If True, no checks are performed prior to preparing data. Set this to be True on
 Version of SERPENT
 ::
 
-  Default: 2.1.29
+  Default: 2.1.31
   Type: str
   Options: [2.1.29, 2.1.30, 2.1.31]
 

--- a/serpentTools/objects/containers.py
+++ b/serpentTools/objects/containers.py
@@ -8,8 +8,6 @@ Contents
 
 """
 from itertools import product
-from warnings import warn
-from numbers import Real
 
 from six import iteritems, PY2
 from matplotlib import pyplot
@@ -39,11 +37,6 @@ from serpentTools.messages import (
     critical,
     error,
 )
-
-if PY2:
-    from collections import Iterable
-else:
-    from collections.abc import Iterable
 
 SCATTER_MATS = set()
 SCATTER_ORDERS = 8
@@ -612,33 +605,6 @@ class HomogUniv(NamedObject):
     compareGCData.__doc__ = __docCompare.format(qty='gc')
 
 
-# remove for versions >= 0.8.0
-
-class _BranchContainerUnivDict(dict):
-    """
-    Workaround for supporting integer and string universe ids
-
-    Keys are of the form ``univID, index, burnup``
-    """
-
-    def __getitem__(self, key):
-        if not isinstance(key, Iterable):
-            raise KeyError(key)
-        if isinstance(key[0], Real) and key not in self:
-            warn("Universe ids are stored as unconverted strings, not int. "
-                 "Support for previous integer-access will be removed in "
-                 "future versions.",
-                 FutureWarning)
-            key = (str(key[0]), ) + key[1:]
-        return dict.__getitem__(self, key)
-
-    def get(self, key, default=None):
-        try:
-            return self[key]
-        except KeyError:
-            return default
-
-
 class BranchContainer(BaseObject):
     """
     Class that stores data for a single branch.
@@ -677,8 +643,7 @@ class BranchContainer(BaseObject):
         self.filePath = filePath
         self.branchID = branchID
         self.stateData = stateData
-        # Revert to dict for version >= 0.8.0
-        self.universes = _BranchContainerUnivDict()
+        self.universes = {}
         self.branchNames = branchNames
         self.__orderedUniverses = None
         self.__keys = set()

--- a/serpentTools/parsers/results.py
+++ b/serpentTools/parsers/results.py
@@ -50,6 +50,7 @@ MapStrVersions = {
     },
 }
 MapStrVersions['2.1.30'] = MapStrVersions['2.1.29']
+MapStrVersions['2.1.31'] = MapStrVersions['2.1.29']
 """
 Assigns search strings for different Serpent versions
 """

--- a/serpentTools/settings.py
+++ b/serpentTools/settings.py
@@ -27,7 +27,7 @@ SETTING_DOC_FMTR = """.. _{tag}:
 
 """
 
-_DEPRECATED = {'results.expectGcu'}
+_DEPRECATED = set()
 
 SETTING_OPTIONS_FMTR = "Options: [{}]"
 defaultSettings = {

--- a/serpentTools/settings.py
+++ b/serpentTools/settings.py
@@ -106,8 +106,11 @@ defaultSettings = {
         'type': bool
     },
     'serpentVersion': {
-        'default': '2.1.30',
+        'default': '2.1.31',
         'options': ['2.1.29', '2.1.30', '2.1.31'],
+        # When adding new version of Serpent, add / update
+        # MapStrVersions with variables that indicate the start of specific
+        # data blocks / time parameters like burnup
         'description': 'Version of SERPENT',
         'type': str
     },

--- a/serpentTools/xs.py
+++ b/serpentTools/xs.py
@@ -5,7 +5,6 @@ branching file
 
 from itertools import product
 from warnings import warn
-from numbers import Real
 
 from six import iteritems
 from six.moves import range
@@ -18,35 +17,6 @@ __all__ = [
     'BranchCollector',
     'BranchedUniv',
 ]
-
-
-# remove for versions >= 0.8.0
-
-
-class IntToStringDict(dict):
-    """Dictionary that allows accessing string keys with Reals
-
-    Used to mitigate API changes in how universe keys are stored
-    in BranchingReader and BranchCollector objects.
-    """
-
-    def __getitem__(self, key):
-        if key in self:
-            return dict.__getitem__(self, key)
-        if isinstance(key, Real) and float(key) in self:
-            warn("Universes will be stored as unconverted strings in future "
-                 "versions", FutureWarning)
-            return dict.__getitem__(self, str(key))
-        raise KeyError(key)
-
-    def get(self, key, default=None):
-        if key in self:
-            return dict.__getitem__(self, key)
-        if isinstance(key, Real) and float(key) in self:
-            warn("Universes will be stored as unconverted strings in future "
-                 "versions", FutureWarning)
-            return dict.__getitem__(self, str(key))
-        return dict.get(self, key, default)
 
 
 class BranchedUniv(object):
@@ -255,8 +225,7 @@ class BranchCollector(object):
         self.filePath = reader.filePath
         self._branches = reader.branches
         self.xsTables = {}
-        # Revert do dict for version >= 0.8.0
-        self.universes = IntToStringDict()
+        self.universes = {}
         self._perturbations = None
         self._states = None
         self._axis = None

--- a/tests/test_ResultsReader.py
+++ b/tests/test_ResultsReader.py
@@ -96,7 +96,6 @@ class TestBadFiles(Serp2129Helper):
             for _line in range(5):
                 badObj.write(str(_line))
         badReader = ResultsReader(badFile)
-        badReader.settings['expectGcu'] = False
         with self.assertRaises(SerpentToolsException):
             badReader.read()
         remove(badFile)
@@ -608,7 +607,6 @@ class TestResultsNoBurnNoGcu(TestFilterResultsNoBurnup):
                                        'diffusion', 'eig', 'burnup-coeff']
             rc['xs.getInfXS'] = True  # only store inf cross sections
             rc['xs.getB1XS'] = False
-            rc['results.expectGcu'] = False
             self.reader = ResultsReader(self.file)
             self.reader.read()
 

--- a/tests/test_branching.py
+++ b/tests/test_branching.py
@@ -82,12 +82,6 @@ class BranchContainerTester(_BranchTesterHelper):
         cls.refBranch = cls.reader.branches[cls.refBranchID]
         cls.refUniv = cls.refBranch.universes[cls.refUnivKey]
 
-    def test_universeIDWorkaround(self):
-        """Test that, for now, integer universe ids work"""
-        # Remove this test for versions >= 0.8.0
-        key = (int(self.refUnivKey[0]), ) + self.refUnivKey[1:]
-        self.assertIs(self.refUniv, self.refBranch.universes[key])
-
     def test_loadedUniv(self):
         """Verify the reference universe has the correct data loaded"""
         assortedExpected = {


### PR DESCRIPTION
This PR introduces some changes that we have been preparing for leading up to the next release, but have not fully implemented. These are

- Serpent 2.1.31 is the default version of the `serpentVersion` setting. This really only affects the results reader. Other readers are left alone. This version was supported in an exploratory stance in version 0.7.0 [26b2e0c75da9c9aaa8a1be2c04ac74d2df3f3a0d]
- Setting `expectGcu` has been removed. This setting was deprecated with PR #324 and any attempt to alter this setting notified the user of this deprecation [72b34819c992841d0b1dcc30060e0c6c2a04ee50]
- Remove the workaround that allowed integer universe names when reading from coefficient files. This was brought up in #318 / #321 with a1e6fa2e293ca003819f64db8d2013144367e8cb and now is removed.