### PR TITLE
API namedtuples for universe, microxs keys

### DIFF
--- a/docs/containers/universes.rst
+++ b/docs/containers/universes.rst
@@ -5,3 +5,9 @@ Homogenized Universes
 
 .. autoclass:: serpentTools.objects.HomogUniv
     :special-members: __getitem__, __setitem__, __bool__, __nonzero__
+
+
+Universe Identifier
+===================
+
+.. autoclass:: serpentTools.objects.UnivTuple

--- a/docs/readers/microxs.rst
+++ b/docs/readers/microxs.rst
@@ -6,3 +6,6 @@ Micro XS Reader
 
 .. autoclass:: serpentTools.MicroXSReader
 
+
+.. autoclass:: serpentTools.MicroXSTuple
+

--- a/examples/ResultsReader.ipynb
+++ b/examples/ResultsReader.ipynb
@@ -51,8 +51,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 2 µs, sys: 1 µs, total: 3 µs\n",
-      "Wall time: 5.01 µs\n"
+      "CPU times: user 2 µs, sys: 1e+03 ns, total: 3 µs\n",
+      "Wall time: 4.29 µs\n"
      ]
     }
    ],
@@ -66,15 +66,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Metadata (`metadata`)"
+    "# Metadata"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`metadata` is a collective data that describes the problem.\n",
-    "The following data is included: titles, data paths, and other descriptive data exist on the reader "
+    "`metadata` is a collective data that describes the problem. These are values that do not change over burnup and across homogenized universes. The following data is included: titles, data paths, and other descriptive data exist on the reader."
    ]
   },
   {
@@ -96,13 +95,6 @@
     "print(res.metadata['version'])  # Serpent version used for the execution\n",
     "print(res.metadata['decayDataFilePath'])  # Directory path for data libraries\n",
     "print(res.metadata['inputFileName'])  # Directory path for data libraries"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Obtain all the variables in the metadata via `.keys()`"
    ]
   },
   {
@@ -142,7 +134,6 @@
     }
    ],
    "source": [
-    "# Grep the value of a certain key, e.g. simulation start date\n",
     "res.metadata['startDate']"
    ]
   },
@@ -152,16 +143,33 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "5000 10 50\n"
-     ]
+     "data": {
+      "text/plain": [
+       "(5000, 10, 50)"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
-    "# statistics used for the execution (histories, inactive and active cycles)\n",
-    "print(res.metadata['pop'], res.metadata['skip']  , res.metadata['cycles'])"
+    "res.metadata['pop'], res.metadata['skip']  , res.metadata['cycles']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Results Data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Results are stored as a function of time/burnup/index and include integral parameters of the system.\n",
+    "Results, such as `k-eff`, total `flux`, and execution times are included in `.resdata`. Some results include values and uncertainities (e.g. criticality) and some just the values (e.g. CPU resources). "
    ]
   },
   {
@@ -170,34 +178,27 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "User defined version: 2.1.30\n",
-      "Used version: Serpent 2.1.30\n"
-     ]
+     "data": {
+      "text/plain": [
+       "['minMacroxs', 'dtThresh', 'stFrac', 'dtFrac', 'dtEff']"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
-    "# Obtain the version defined in the settings\n",
-    "print('User defined version: {}'.format(rc['serpentVersion']))\n",
-    "# Obtain the version actually used in the execution\n",
-    "print('Used version: {}'.format(res.metadata['version']))"
+    "list(res.resdata.keys())[0:5]"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Results Data (`resdata`)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Results are stored as a function of time/burnup/index and include integral parameters of the system.\n",
-    "Results, such as `k-eff`, total `flux`, execution times are included in `.resdata`. Some results include values and uncertainities (e.g. criticality) and some just the values (e.g. CPU resources). "
+    "Values are presented in similar fashion as if they were read in to Matlab, with one exception. Serpent currently appends a new row for each burnup step, but also for each homogenized universe. This results in repetition of many quantities as Serpent loops over group constant data. The `ResultsReader` understands Serpent outputs and knows when to append \"new\" result data to avoid repetition. \n",
+    "\n",
+    "The structure of the data is otherwise identical to Matlab. For many quantities, the first column indicates expected value, while the second column contains relative uncertainties. For a better reference, please consult the Serpent wiki on structure of the main output file."
    ]
   },
   {
@@ -208,7 +209,12 @@
     {
      "data": {
       "text/plain": [
-       "['minMacroxs', 'dtThresh', 'stFrac', 'dtFrac', 'dtEff']"
+       "array([[1.29160e+00, 9.00000e-04],\n",
+       "       [1.29500e+00, 9.30000e-04],\n",
+       "       [1.29172e+00, 9.10000e-04],\n",
+       "       [1.29172e+00, 7.80000e-04],\n",
+       "       [1.29312e+00, 6.80000e-04],\n",
+       "       [1.29140e+00, 7.80000e-04]])"
       ]
      },
      "execution_count": 8,
@@ -217,10 +223,7 @@
     }
    ],
    "source": [
-    "# All the variables can be obtained by using 'resdata.keys()'\n",
-    "AllVariables = res.resdata.keys() # contains all the variable as a dict_keys\n",
-    "# The example below shows only the first five variables in the resdata dictionary\n",
-    "list(AllVariables)[0:5]"
+    "res.resdata['absKeff']"
    ]
   },
   {
@@ -229,21 +232,18 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[[1.29160e+00 9.00000e-04]\n",
-      " [1.29500e+00 9.30000e-04]\n",
-      " [1.29172e+00 9.10000e-04]\n",
-      " [1.29172e+00 7.80000e-04]\n",
-      " [1.29312e+00 6.80000e-04]\n",
-      " [1.29140e+00 7.80000e-04]]\n"
-     ]
+     "data": {
+      "text/plain": [
+       "array([1.2916 , 1.295  , 1.29172, 1.29172, 1.29312, 1.2914 ])"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
-    "# Time-dependent variables, such as k-eff, are stored in 'resdata'\n",
-    "print(res.resdata['absKeff'])  # Values (1st col.) + std (2nd col.) "
+    "res.resdata['absKeff'][:,0]"
    ]
   },
   {
@@ -254,7 +254,12 @@
     {
      "data": {
       "text/plain": [
-       "array([1.2916 , 1.295  , 1.29172, 1.29172, 1.29312, 1.2914 ])"
+       "array([[0.      , 0.      ],\n",
+       "       [0.1     , 0.100001],\n",
+       "       [1.      , 1.00001 ],\n",
+       "       [2.      , 2.00001 ],\n",
+       "       [3.      , 3.00003 ],\n",
+       "       [4.      , 4.00004 ]])"
       ]
      },
      "execution_count": 10,
@@ -263,8 +268,7 @@
     }
    ],
    "source": [
-    "# Obtain only the values for 'absKeff'\n",
-    "res.resdata['absKeff'][:,0]"
+    "res.resdata['burnup']"
    ]
   },
   {
@@ -275,7 +279,12 @@
     {
      "data": {
       "text/plain": [
-       "array([0.0009 , 0.00093, 0.00091, 0.00078, 0.00068, 0.00078])"
+       "array([[ 0.     ],\n",
+       "       [ 1.20048],\n",
+       "       [12.0048 ],\n",
+       "       [24.0096 ],\n",
+       "       [36.0144 ],\n",
+       "       [48.0192 ]])"
       ]
      },
      "execution_count": 11,
@@ -284,8 +293,7 @@
     }
    ],
    "source": [
-    "# Obtain only the uncertainties for 'absKeff'\n",
-    "res.resdata['absKeff'][:,1]"
+    "res.resdata['burnDays']"
    ]
   },
   {
@@ -294,52 +302,23 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[[0.       0.      ]\n",
-      " [0.1      0.100001]\n",
-      " [1.       1.00001 ]\n",
-      " [2.       2.00001 ]\n",
-      " [3.       3.00003 ]\n",
-      " [4.       4.00004 ]]\n",
-      "[[ 0.     ]\n",
-      " [ 1.20048]\n",
-      " [12.0048 ]\n",
-      " [24.0096 ]\n",
-      " [36.0144 ]\n",
-      " [48.0192 ]]\n"
-     ]
+     "data": {
+      "text/plain": [
+       "array([[10.814 ],\n",
+       "       [20.3573],\n",
+       "       [30.0783],\n",
+       "       [39.4965],\n",
+       "       [48.919 ],\n",
+       "       [58.6448]])"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
-    "# Burnup data is not written by default, a burnup mode is defined within the input file\n",
-    "# Extract burnup related quantities\n",
-    "print(res.resdata['burnup']) # burnup intervals (MWd/kg) \n",
-    "print(res.resdata['burnDays']) # time points (days)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[[10.814 ]\n",
-      " [20.3573]\n",
-      " [30.0783]\n",
-      " [39.4965]\n",
-      " [48.919 ]\n",
-      " [58.6448]]\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Some variables are stored with no uncertainties\n",
-    "print(res.resdata['totCpuTime']) # total CPU time,  "
+    "res.resdata['totCpuTime']"
    ]
   },
   {
@@ -353,27 +332,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<matplotlib.axes._subplots.AxesSubplot at 0x7ff3d0a8cda0>"
+       "<matplotlib.axes._subplots.AxesSubplot at 0x7fa54d078990>"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZQAAAEKCAYAAAA1qaOTAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvOIA7rQAAIABJREFUeJzt3Xl4VeW5/vHvExIS5iHMY1BkliCEKVrEGRRxpGgBUZxrz6H+1FbbHj3VTvZYPYdjFalSwAFx6inWakXrDEFBjYIgoEwhaAISxgQIeX5/7BWbUiA7sHZ2kn1/ritX9hrzLNzue693rXe95u6IiIgcq6R4FyAiInWDAkVEREKhQBERkVAoUEREJBQKFBERCYUCRUREQqFAERGRUChQREQkFAoUEREJRXK8C6hOrVq18oyMjHiXISJSqyxdunSLu7eubL2ECpSMjAyWLFkS7zJERGoVM1sfzXpq8hIRkVAoUEREJBQKFBERCUVCXUMRkcS1f/9+8vLyKCkpiXcpNVZaWhqdOnUiJSXlqLZXoIhIQsjLy6NJkyZkZGRgZvEup8Zxd7Zu3UpeXh7dunU7qn2oyUtEEkJJSQnp6ekKk8MwM9LT04/pDE6BIiIJQ2FyZMf676NAERE5jPGPLGL8I4viXUatoUAJgd50InIsGjduHPW6s2bN4gc/+AEAZWVlTJ48mSlTpuDuh93mnXfeoW/fvgwYMIDi4mJuu+02+vbty2233XbMtVeki/IiIrWQu3PDDTewf/9+/vjHPx6xuerJJ5/k1ltv5aqrrgLgkUceobCwkNTU1FBr0hmKiEg1uvDCCxk0aBB9+/ZlxowZ386/5ZZbGDhwIGeccQaFhYUATJs2jT59+tC/f38uu+yyf9rP1KlT2bp1K3PmzCEpKfJR/uqrrzJ8+HAGDhzIuHHj2LVrF48++ijPPPMMd999NxMmTGDs2LHs3r2boUOHMm/evFCPTWcoIpJwfv7icj7L31Hpep9tjqwTTZN2nw5Nuev8vpWuN3PmTFq2bElxcTGDBw/mkksuYffu3QwcOJDf/e533H333fz85z/nwQcf5De/+Q1r164lNTWVoqKib/fx1FNP0bt3b958802SkyMf41u2bOEXv/gFr732Go0aNeLee+/l/vvv58477+Tdd99lzJgxXHrppUCkie3jjz+utNaq0hmKiEg1mjZtGpmZmQwbNoyNGzeyevVqkpKSGD9+PAATJ07k3XffBaB///5MmDCBJ5544tvgABg4cCDr16/n/fff/3ZeTk4On332GSeffDIDBgxg9uzZrF8f1TMdQ6MzFBFJONGcScA/zkzmXT88lL/75ptv8tprr7Fo0SIaNmzIyJEjD9nvo/x6yEsvvcTbb7/N/Pnzueeee1i+fDkAvXr14u677+a73/0uf/vb3+jbty/uzllnncXcuXNDqfVo6AxFRKSabN++nRYtWtCwYUNWrlxJTk4OELlb67nnngMizVmnnHIKZWVlbNy4kdNOO43f/va3FBUVsWvXrm/3lZ2dzfTp0znvvPPYsGEDw4YN47333mPNmjUA7Nmzh1WrVlXr8ekMRUSkmowaNYrp06fTv39/evbsybBhwwBo1KgRy5cvZ9CgQTRr1ox58+Zx4MABJk6cyPbt23F3br75Zpo3b/5P+xszZgyFhYWMGjWKd955h1mzZnH55Zezd+9eAH7xi1/Qo0ePajs+O9K9y6H8AbOZwBigwN37HWL5BODHweQu4EZ3zw2WTQWuBQz4g7v/dzB/ADAdSANKge+7+/sH7/tgWVlZHosBtsI+LRaR8K1YsYLevXtXaZtE/H/7UP9OZrbU3bMq27Y6zlBmAQ8Ccw6zfC1wqrtvM7PRwAxgqJn1IxImQ4B9wCtm9pK7rwZ+C/zc3V82s3OD6ZGxPQwRSTSJFCRhiPk1FHd/G/jmCMsXuvu2YDIH6BS87g3kuPsedy8F3gIuKt8MaBq8bgbkh164iIhUSU27hnI18HLwehnwSzNLB4qBc4Hy9qofAn8zs/uIhGJ2dRcqIrWPu+sBkUdwrJdAasxdXmZ2GpFA+TGAu68A7gUWAK8AuUSulwDcCNzs7p2Bm4HHjrDf68xsiZktKe99KiKJJy0tja1btx7zh2ZdVT4eSlpa2lHvo0acoZhZf+BRYLS7by2f7+6PEYSFmf0KyAsWTQamBq+fDbY9JHefQeS6DFlZWXoniSSoTp06kZeXh75YHl75iI1HK+6BYmZdgBeASe6+6qBlbdy9IFjnYqD8Clk+cCrwJnA6sLr6KhaR2iglJeWoRyKU6MQ8UMxsLpE7sFqZWR5wF5AC4O7TgTuBdOChoG2ztMLtac8H11D2AzdVuHh/LfA/ZpYMlADXxfo4RETkyGIeKO5+eSXLrwGuOcyy7xxm/rvAoGOvTkREwlJjLsqLiEjtpkAREZFQKFBERCQUChQREQmFAkVEREKhQBERkVAoUEREJBQKFBERCYUCRUREQqFAERGRUChQREQkFAoUEREJhQJFRERCoUAREZFQKFBERCQUChQREQmFAkVEREKhQBERkVAoUEREJBQKFBERCYUCRUREQqFAERGRUChQREQkFAoUEREJhQJFRERCoUAREZFQKFBERCQUChQREQmFAkVEREIR80Axs5lmVmBmyw6zfIKZfRL8LDSzzArLpprZMjNbbmY/PGi7fzOzz4Nlv431cYiIyJFVxxnKLGDUEZavBU519/7APcAMADPrB1wLDAEygTFmdkKw7DTgAqC/u/cF7otZ9SIiEpWYB4q7vw18c4TlC919WzCZA3QKXvcGctx9j7uXAm8BFwXLbgR+4+57g30UxKR4ERGJWk27hnI18HLwehkwwszSzawhcC7QOVjWA/iOmS02s7fMbPDhdmhm15nZEjNbUlhYGNPiRUQSWXK8CygXNGNdDZwC4O4rzOxeYAGwC8gFSoPVk4EWwDBgMPCMmR3n7n7wft19BkEzWlZW1r8sFxGRcNSIMxQz6w88Clzg7lvL57v7Y+4+0N1HEGk2Wx0sygNe8Ij3gTKgVXXXLSIi/xD3QDGzLsALwCR3X3XQsjYV1rkYmBss+j/g9GBZD6A+sKW6ahYRkX8V8yYvM5sLjARamVkecBeQAuDu04E7gXTgITMDKHX3rGDz580sHdgP3FTh4v1MYGZwK/I+YPKhmrtERKT6xDxQ3P3ySpZfA1xzmGXfOcz8fcDEY69ORGqb8Y8sAmDe9cPjXIkcLO5NXiIiUjcoUEREJBQKFBERCYUCRUREQqFAERGRUChQREQkFAoUEREJhQJFRERCoUAREZFQKFAkdOMfWfRtb2YRSRwKFBERCYUCRUREQqFAiUJlTTjf7N5H8f4D1ViRiEjNo0A5RvtKy1hdsIvl+Tv4YN038S5HRCRuFCjH6OsdJQCUlTkTH13M35Z/FeeKRETiQ4FyjPK2FQNwXOtG9GrflBufWMpTizfEuSoRkeoXdaCY2V2xLKS2yi+KBEqj1GTmXjuUET1a85M/fcr/vLYaDSIpIomkKiM23mVmDYGWwIfA0xWG5E1Y5YGSWi+JhvWT+cMVWdz+/Kc88NoqCnaWcPcF/aiXZHGuUkQk9qrS5OVACfA3oDOw0MwyY1JVLbKpqJjkJCMpCI2UekncN64/N5x6PE8u3sD3n1xKie4AkyNQR1CpK6oSKCvd/S53f87dfwJcADwQo7pqjU1FxaQm//M/o5lx++he3DmmD39b/jVXPPY+24v3x6lCEZHqUZVA2WJmg8on3H0V0Dr8kmqXTUXF1E8+9D/jlFO6Me3yk/ho4za+O30RX20vqebqRESqT1UC5d+BJ8zsCTP7sZk9CayNUV21gruTX1RManK9w64zNrMDs64awqaiYi5+6D3WFOysxgpFRKpP1IHi7rnAAGBuMOsN4PJYFFVbfLN7HyX7y/6lyetgJ3dvxdPXDWPfAefS6YtYuj7h72UQkTqoSv1Q3H2vu7/k7ve6+6PuvjtWhdUG+UWRJqzDNXlV1K9jM164MZvmDVKY8GgOr6/4OtbliYhUq6gCxcyGmNng4HUfM/t/ZnZubEur+TaV3zIcRaAAdElvyHM3ZnNCmyZc9/hSnvlgYyzLExEBqu9Owko/CYMOjdOAh83s18CDQGPgdjP7aYzrq9HKAyWaM5RyrRqn8vR1w8g+Pp0fPf8JD/5dHSBFpG6IpmPjpUSunaQCXwGd3H2Hmf0XsBj4ZQzrq9Hyi4ppkFKP5Cp2XGyUmsxjkwfzo+dyue/VVRTs3Mtd5/dVB0gRqdWiCZRSdz8A7DGzL9x9B4C7F5tZWWzLq9k2bSumQ/M0zKoeBPWTk7j/uwNo1TiVR99dy5Zde3lg/IAj3jEmIlKTRdNWsy945ArAt/1QzKwZUGmgmNlMMysws2WHWT7BzD4Jfv6p972ZTTWzZWa23Mx+eIhtbzUzN7NWURxH6PK3F9OxRcPKVzyMpCTjZ2P68NNze/PXT79i8sz32VGiDpAiUjtFEygj3H0PgLtXDJAUYHIU288CRh1h+VrgVHfvD9wDzAAws37AtcAQIBMYY2YnlG9kZp2Bs4C4Pdo3v6iYjs3Tjnk/1444jgfGZ7Jk3TbGP5JDwQ51gBSR2qfSQHH3veWvzeysCvO3AO2i2P5t4LAjT7n7wgoPmcwBOgWvewM57r7H3UuBt4CLKmz6APAjIs8Yq3Yl+w+wZdc+OjRrEMr+LjqpE49dOZj1W3dz8cML+bJwVyj7FRGpLlUdD+XeSqaP1dXAy8HrZcAIM0sPmtzOJfJQSsxsLLAp6GwZF+VPGe7YIpxAATi1R2vmXjuM4n0HuHT6Ij7eWBTavkVEYu1YB9gK7bYkMzuNSKD8GMDdVxAJrAXAK0AuUBqEy0+BO6Pc73VmtsTMlhQWFoZV7re3DHdoHl6gAGR2bs5zN2bTKLUel8/I4Y3PC0Ldv4hIrETbsfGPZjYT6BJcZJ8ZZhFm1h94FLjA3beWz3f3x9x9oLuPINJstho4HugG5JrZOiJNZB+a2SGb39x9hrtnuXtW69bhPcvy2zOUkAMFoFurRjx/YzbdWjXi2tlLeH5pXuh/Q0QkbNEOsDUr+P0dYHaYBZhZF+AFYFLwBOOKy9q4e0GwzsXA8OB6S5sK66wDsoJrOtVm07ZikgzaNTv2i/KH0qZJGvOuH8b1jy/llmdzKdy1l+tHHHdUtyiLiFSHqALF3d8CMLOd5a/LF1W2rZnNBUYCrcwsD7iLyB1iuPt0Ik1X6cBDwYdlqbtnBZs/b2bpwH7gppo0QuSmohLaNk0jpd6xthoeXpO0FP541WBueSaX37y8koIde/nZeb2/HcxLRKQmqcoQwAD7Kpn+F+5+xCcSu/s1wDWHWfadKPafUdk6sZBfVBz69ZNDSU2ux7TLTqJ1k1RmvreWwl17uW9cf3WAFJEap0qB4u7DjjSdSDYVFTOgc/Nq+VtJScadY/rQpkka976ykm9272X6xEE0SUuplr8vIhKNaB4O+Xjwe2rsy6kdysqczdur5wylnJlx48jjuW9cJjlffsNlM3Io3Lm38g1FRKpJNBcABplZV2CKmbUws5YVf2JdYE1UuGsv+w94KL3kq+rSQZ149IosvizczSUPL2TdloQekkZEapBoAuVhIv1AegJLD/pZErvSaq5NMejUWBWn9WrDU9cOZWfJfi6dvpBP87bHpQ4RkYqiCZQh7t4bwN2Pc/duFX6Oi3F9NdKmbbHp1FgVJ3VpwXM3ZpOaXI/LZizindXhddoUETkaVWny+lxNXhGx7NRYFce3bswL38+mc8uGTJn1AX/+eFNc6xGRxBZNoEwn0uTVC/gQNXmRX1RMk7TkGnGXVdumacy7fjgDu7Rg6tMf8+g7X8a7JBFJUNE8bXha0OQ186DmrsRt8ioqjvvZSUXNGqQwe8oQRvdrxy9eWsGv/rqCsjINKywi1asq3bxvMrOJZvYfEHlkipkNiVFdNdqmopIaFSgAaSn1ePB7A5k0rCsz3v6SW57NZf+BhB5QU0SqWVUC5ffAcOB7wfTOYF7C2bRtT1wvyB9OvSTj7gv6cuvZPfjTR5u4evYSdu8tjXdZIpIgqhIoQ939JqAEIHiuVv2YVFWD7SzZz46S0rjdMlwZM+MHp5/AvZecyLurC7n8Dzls2aUOkFK3qEm3ZqpKoOw3s3oED4Q0s9ZEMaZ8XZNfFBmetyaeoVQ0fnAXZkzK4vOvdnLpwwvZsHVPvEsSOSYbtu7h92+s4ZO87XywfhuTZ77PGysLFC41SFWe5TUN+BPQxsx+CVwK/CwmVdVgNeWW4Wic2actT107lCmzlnDxwwuZPWUwfTs0i3dZIlH7ekcJf/lkMy/m5n87gmnj1GTaNU1lxeYdXDXrA7qmN2TSsK6My+pMswbxv/MykUUdKO7+pJktBc4gMlLjhcGoigllUy0KFIBBXVvy/I3DueKx9xn/SA4zJg0iu3ureJclcljbdu/j5WVf8WJuPjlrt+IOvds35cejejGmf3tufTYy8vfjVw/lleVfMXvhOn7x0gruX7CKi07qyJXZGZzQtkmcjyIxVRooZtbJ3fMA3H0lsLLCsvPd/cUY1lfjbCoqJqWe0aZJarxLiVr3Nk14/vvZTJ75Plf+8QPuH5/JmP4d4l2WyLd27S1lwWdf8WLuZt5eVUhpmdOtVSP+7fQTGJvZnu5t/jUg6icnMTazA2MzO7Bs03ZmLVzHs0vzeHLxBrKPT2dydgZn9m5LPY0fVG2iOUN53czOcfd1FWea2RQiY7snVKDkFxXTrllarRvkqn2zBjx7fTbXzPmAf5v7EVt27uXKk7vFuyxJYCX7D/Dm5wW8mLuZ11d+Tcn+Mto3S2PKKd0Ym9mBvh2aRj1Cab+OzbhvXCZ3jO7F0x9s5Imc9Vz/+FI6Nm/ApOFdGZ/VmRaNEu4eomoXTaDcDCwws3PdfTWAmd1B5PbhU2NZXE20aVvN6tRYFc0apvD41UP5t7kf8Z8vfkbBzr3cdk5PDSss1Wb/gTLeW7OFF3M38+ryr9i5t5T0RvUZN6gzYwd0YFCXFsf0ZS29cSo3ndad60ccx4LPvmbWwnX85uWVPLBgFRcO6Mjk7Az6dGga4hFJRZUGirv/1cz2Ai+b2YVERlccDIyoSUPyVpf8omKGHZ8e7zKOWlpKPR6eMJD/+PNyHnrzCwp27uXXF58Y06GMJbGVlTlL1m9jfu4m/vrpV3yzex9NUpM5p187xmZ2IPv4dJJDfv8l10ti9IntGX1ie1Zs3sGcRev400ebmLdkI0MyWjI5O4Oz+7bV+z5k0Y4p/7qZXQm8CSwEznD3khjWVSPtP1DGVztqXi/5qkqul8SvLupHmyap/M/rq9m6ay+/nzCQhvWrOiK0yKG5O8s27WB+7ib+8slmNm8vIS0liTN6t2VsZgdO7dGatJTqGca6d/um/Pri/vx4VC+eWbKROYvWc9NTH9KuaRoTh3XhsiFdaNW49lwTrcmiuSi/k0jfEwNSidzlVWCRdhJ394Q5f/x6RwllXnvu8DoSM+Pms3rQukkqd/55Gd/7w2JmXjmYlmpnlmOwpmAn8z/O58VPNrN2y25S6hkjTmjN7aN7cWbvtjRKjd+XluYN63PdiOO5+pTjeGNlAbMXreO+V1cx7fU1jMlsz5XZGfTvVD3DetdV0TR56f67QG3p1FgVE4d1pVXjVP796Y+4dPpC5kwZQqcWDeNdltQiG7/Zw4uf5DP/43xWfrUTMxh+XDrXjziOUf3a0bxhzfqSUi/JOLNPW87s05Y1BbuYs2gdzy/N44UPN3FSl+ZcmZ3B6H7tqZ+s5rCqivrrgpmNA15x951m9jNgIHCPu38Us+pqmE1Fkd7mNfWxK0drVL92PHH1UK6Z/QEXP7SQ2VOG0Lt9wpx4ylEo2FnCS59sZn5uPh9tiHQ4PKlLc+46vw/nndieNk2rf3jso9G9TWPuvqAft57Tk+eX5jFn0XqmPv0x9zRewfeGdmHi0C615lhqgqqcf/6Huz9rZqcA5wD3ERkrZWhMKquBvj1DaVa3AgVgSLeWPHtDpK/Kdx9ZxB+uyGLYcbX35gMJ3/Y9+3l5WSREcr7cSplDr3ZN+NGonpzfvwOdW9beM9umaSlcdXI3Jg/P4O3VhcxeuI5pr6/moTfWMPrE9lyZ3ZWBXVrojshKVCVQDgS/zwMedvc/m9l/hl9SzZW3rZj0RvVpUL96LiZWt57tIh0gr3hsMVfMfJ9plw1gVL/28S5L4mj33lJeW/E18z/O5+3Vhew/4GSkN+QHp3Xn/MwOda5HelKSMbJnG0b2bMO6LbuZs2g9zy7ZyIu5+fTr2JTJwzM4P7NDtd1QUNtUJVA2mdkjwFnAvWaWStUeLlnr5RcV16nrJ4fSsXkDnrshm6tnf8CNT37I3Rf0Y9KwrvEuS6rR3tIDvPl5IfNz83l9RaTDYbumaVyZncHYzI706xh9h8PaLKNVI+48vw+3nN2DFz7axJyF67jtuU/49csruWxwZyYO61rnPw+qqiqB8l1gFPBf7l5kZu2B22JTVs20qaiY41s3incZMdeiUX2evGYYP3jqQ/7j/5ZRuKOEm8/qkRAfIomq9EAZC7/Yyou5+byy/Ct2lpTSslF9Lh3UibGZHcnqemwdDmuzRqnJTBrWlYlDu7Doi63MWriO6W99wSNvf8nZfdoyOTuDod1a6v8PqhYoZUA3YKKZOfAu8HBMqqqB3J38omJGnNA63qVUiwb16/HIpEH85E+fMu3vayjctZd7LugXegc0iZ+yMmfphm28mJvPXz/dzJZdkQ6HZ/dtx9gBkQ6H6vj3D2ZGdvdWZHdvxcZv9vDE4vXM+2AjLy/7il7tmjA5O4MLB3Sss03i0ahKoMwBdgD/G0xfDjwOjAu7qJroQJmzZ98BOjRPnDs+kuslce8l/WnTJI0H31hD4c59PPi9k9R+XIu5O8vzdzA/N5+/5OaTv72E1OQkzuzdlvMzOzCyZ/V1OKzNOrdsyB2je/PDM3owP3cTsxau544XPuU3L69k/ODOTBrWtVbfpHC0qhIoPd09s8L0G2aWG3ZBNdXe0shYYp3q2C3DlTEzbj2nJ62bpPKfLy5nwqOLeWxyVo3rWyBHtqZg17ch8uWW3SQnGSN6tOZHo3pxZp+2NI5jh8ParEH9eowf3IXvZnXmg3XbmL1wHY+9u5Y/vPMlZ/Rqy+TsrpzSvVXCNIdV5V30kZkNc/ccADMbCrxX2UZmNhMYAxS4e79DLJ8A/DiY3AXc6O65wbKpwLVEeun/wd3/O5j/X8D5wD7gC+Aqdy+qwrFUWXmgJOpFuMnZGbRqnMrN8z5m3PRFzJ4yJGH/LWqLvG17eDE3MjjVZ5t3YAbDuqVz7YjjGNW3nZ6+GyIzY0i3lgzp1pLN24t5MmcDc9/fwGsrvub41o2YnJ3BxQM71fngjubRK58SefRKCnCFmW0IFnUBPovib8wCHiTSZHYoa4FT3X2bmY0GZgBDzawfkTAZQiQ4XjGzl4InHi8A7nD3UjO7F7iDf4RSTOwLAqUuPHblaJ3Xvz0tGqVw/ZylXPJwpANkjzp222htV7hzLy99Enn0ydL1kWe3DujcnDvH9OG8/u1pq056Mde+WQNuPacnPzi9Oy99spnZi9Zx55+X81+vfM4lgzoxOTuDbq3q5s090cTlmGP5A+7+tpllHGH5wgqTOUCn4HVvIMfd9wCY2VvARcBv3f3Vg7a59FhqjMbe0jJSk5MS/llX2ce3Yt71w5n8x/e59OGFzLxyMFkZLeNdVkLbvmc/ryzfzIu5m1n4xZZvOxzedk5PxmbW7g6HtVlaSj0uGdSJiwd25KONRcxeuI4nF69n1sJ1nNqjNVdmZ3Bqj9Z16u65aJ7ltb78tZm1AE4AKn7NWf8vGx29q4GXg9fLgF+aWTpQDJwLLDnENlOAeSHWcEj7DpTRsXmDhGkLPZI+HZrywo2RXvUTHl3M/15+Emf3bRfvshLKnn2lvLaigPkf5/PWqgL2H3C6pjfkpqDDoc4caw4zY2CXFgzs0oKfntebuYs38uTi9Vw16wMy0hsyaXgG47I60TQtJd6lHrOqPMvrGmAqkTOIj4FhwCLg9DAKMbPTiATKKQDuviJozlpA5NpKLlB60DY/DeY9eYT9XgdcB9ClS5ejrm9v6QE6ttDzrcp1btmQZ28YzpTZS7jhiaX88qITuXzI0f/7SuX2lh7g7VVbmJ+bz2uffU3x/gO0a5rG5OEZjB3QgRM7NtMXnhquTZM0pp55AjeOPJ5Xln/F7IXruOcvn/G7Vz/n4oEdmTw8o1Y/faAqV4imEhlYK8fdTzOzXsDPwyjCzPoDjwKj3X1r+Xx3fwx4LFjnV0BehW0mE2mOO8Pd/XD7dvcZRK7LkJWVddj1KrOvtKxOPsPrWKQ3TmXutUP5/pMfcscLn1KwYy//fkb3eJdVp5QeKCPny2+Yn7uJV5Z9xY6SUlo0TOHigR05P7MDQzJa1qkmk0RRPzmJsZkdGJvZgWWbtjNr4TqeWZLHEzkbOLl7OpOHZ3BG77bUq2X/basSKCXuXmJmmFmqu680s57HWoCZdQFeACa5+6qDlrVx94JgnYuB4cH8UUQuwp9afo0llsrKnP0HvM49ZTgMDesn84crsrj9+U954LVVFO4qwd31TfkYlJU5H23cxvyP83kp6HDYODWZs/tGBqc6uXsrdTisQ/p1bMZ94zK5Y3Qvnv5gI0/krOe6x5fSqUUDJg3ryvjBnWvNbfpVCZQ8M2sO/B+RMea3AfmVbWRmc4GRQCszywPuInLHGO4+HbgTSAceCj6ESt09K9j8+eAayn7gpgpDDj9IZLCvBcE2Oe5+QxWOpUr2HUjsW4Yrk1IvifvG9ad1k1Smv/UFLRqm0L1143iXVatEOhxuD/qKbGZTUTGpyUmc0bsNYzM7MLJnG3U4rOPSG6dy02nduX7EcSz47GtmLVzHr19eyf0LVnHhgI5Mzs6gT4ea3ewedaC4+0XBy/80szeAZsArUWx3eSXLryEyTv2hln3nMPOrtV1lr24ZrpSZcfvoXrRpksrdf/mMT/O3c/mMnHiXVSus2LyDfQfKOG/auyQnGd85oRW3ntODM3u3pUkduFBrPkN4AAAMFUlEQVQrVZNcL4nRJ7Zn9IntWbF5B3MWredPH+Uxb8lGhmS0ZHJ2Bmf3bVsjz1KPqpeNu78VdiE1mfqgRG/KKd146v0NfL2jhANlR33JKqG4Q1pyPe4c05dR/dol/K3p8g+92zfl1xefyO2jevHMko3MyVnHTU99SLumaUwc1oXLh3QhvXFqvMv8Vt3uthmS8jOUds3UKSwa6Y3qk96oPvOuHx7vUmqF8Y8sAuB7Q3WXnBxas4YpXDviOKac0o03VhYwe9E67nt1FdNeX8OYzPZcmZ1B/07N412mAiUa+w+UkVLPNMa0iMRVvSTjzD5tObNPW9YU7GLOonU8vzSPFz7cxEldmnNldgaj+7WP22eVPiGj0K1VIzJrQPqLiJTr3qYxd1/Qj5yfnMFd5/ehaM9+pj79MSff+3ceWLCKgh0l1V6TzlCiVNvuBxeRxNAkLYWrTu7G5OEZvL26kNkL1zHt76v5/RtrOPfE9kzOzqi2W/kVKCIidUBSkjGyZxtG9mzDui27mbNoPc8u2cj83Hwa1a9H1/TYP5BSgRICXXwWkZoko1Uj7jy/D7ec3YMXPtrEr15aQXI1tLLoGoqISB3VKDWZScO6cmLHptUyNLECRUSkjquuRyEpUEREJBQKFBERCYUCRUREQqFAERGRUChQREQkFAoUEREJhQJFRERCoUAREZFQKFBERCQUChQREQmFAkVEREKhQBERkVAoUEREJBQKFBERCYUG2BKRWkUD2tVcOkMREZFQKFBERCQUChQREQmFAkVEREKhQBERkVDEPFDMbKaZFZjZssMsn2BmnwQ/C80ss8KyqWa2zMyWm9kPK8xvaWYLzGx18LtFrI9DRESOrDrOUGYBo46wfC1wqrv3B+4BZgCYWT/gWmAIkAmMMbMTgm1uB1539xOA14NpERGJo5gHiru/DXxzhOUL3X1bMJkDdApe9wZy3H2Pu5cCbwEXBcsuAGYHr2cDF4ZeuIiIVElNu4ZyNfBy8HoZMMLM0s2sIXAu0DlY1tbdNwMEv9scbodmdp2ZLTGzJYWFhTEsXUQksdWYnvJmdhqRQDkFwN1XmNm9wAJgF5ALlFZ1v+4+g6AZLSsry0MrWERE/kmNOEMxs/7Ao8AF7r61fL67P+buA919BJFms9XBoq/NrH2wbXugoLprFhGRfxb3QDGzLsALwCR3X3XQsjYV1rkYmBssmg9MDl5PBv5cPdWKiMjhxLzJy8zmAiOBVmaWB9wFpAC4+3TgTiAdeMjMAErdPSvY/HkzSwf2AzdVuHj/G+AZM7sa2ACMi/VxiIjIkcU8UNz98kqWXwNcc5hl3znM/K3AGcdenYiIhCXuTV4iIlI3KFBERCQUChQREQmFAkVEREKhQBERkVAoUEREJBQKFBERCYUCRUREQqFAERGRUChQREQkFAoUEREJhQJFRERCoUAREZFQKFBERCQUChQREQmFAkVEREKhQBERkVAoUEREJBQKFBERCUXMx5QXkSObd/3weJcgEgqdoYiISCgUKCIiEgoFioiIhEKBIiIioVCgiIhIKHSXl4hIHVdddxLqDEVEREKhQBERkVBUS6CY2UwzKzCzZYdZPsHMPgl+FppZZoVlN5vZcjNbZmZzzSwtmH+GmX1oZh+b2btm1r06jkUqN+/64eqsJ5KAqusMZRYw6gjL1wKnunt/4B5gBoCZdQT+Hchy935APeCyYJuHgQnuPgB4CvhZbEoXEZFoVMtFeXd/28wyjrB8YYXJHKBThelkoIGZ7QcaAvnlmwFNg9fNKswPnb5ti4hUribe5XU18DKAu28ys/uADUAx8Kq7vxqsdw3wVzMrBnYAw+JRrIiIRNSoi/JmdhqRQPlxMN0CuADoBnQAGpnZxGD1m4Fz3b0T8Efg/sPs8zozW2JmSwoLC2N9CCIiCavGBIqZ9QceBS5w963B7DOBte5e6O77gReAbDNrDWS6++JgvXlA9qH26+4z3D3L3bNat24d46MQEUlcNSJQzKwLkbCY5O6rKizaAAwzs4ZmZsAZwApgG9DMzHoE650VzBcRkTiplmsoZjYXGAm0MrM84C4gBcDdpwN3AunAQ5HcoDQ4q1hsZs8BHwKlwEfADHcvNbNrgefNrIxIwEypjmMREZFDM3ePdw3VJisry5csWRLvMkREahUzW+ruWZWtVyOavEREpPZToIiISCgUKCIiEoqEuoZiZoXA+qPcvBWwJcRyaptEPn4de+JK5OOveOxd3b3SfhcJFSjHwsyWRHNRqq5K5OPXsSfmsUNiH//RHLuavEREJBQKFBERCYUCJXoz4l1AnCXy8evYE1ciH3+Vj13XUEREJBQ6QxERkVAoUKJgZqPM7HMzW2Nmt8e7nlg61HDNZtbSzBaY2ergd4t41hgrZtbZzN4wsxXBsNNTg/mJcvxpZva+meUGx//zYH43M1scHP88M6sf71pjxczqmdlHZvaXYDqRjn2dmX0aDKu+JJhXpfe+AqUSZlYP+D0wGugDXG5mfeJbVUzN4l+Ha74deN3dTwBeD6brolLgFnfvTWTAtpuC/9aJcvx7gdPdPRMYAIwys2HAvcADwfFvIzJmUV01lX9+cnkiHTvAae4+oMLtwlV67ytQKjcEWOPuX7r7PuBpIoN+1Unu/jbwzUGzLwBmB69nAxdWa1HVxN03u/uHweudRD5YOpI4x+/uviuYTAl+HDgdeC6YX2eP38w6AecRGZeJYMiMhDj2I6jSe1+BUrmOwMYK03nBvETS1t03Q+RDF2gT53pizswygJOAxSTQ8QdNPh8DBcAC4AugyN1Lg1Xq8vv/v4EfAWXBdDqJc+wQ+fLwqpktNbPrgnlVeu/XxDHlaxo7xDzdGleHmVlj4Hngh+6+IxijJyG4+wFggJk1B/4E9D7UatVbVeyZ2RigwN2XmtnI8tmHWLXOHXsFJ7t7vpm1ARaY2cqq7kBnKJXLAzpXmO4E5Meplnj52szaAwS/C+JcT8yYWQqRMHnS3V8IZifM8Zdz9yLgTSLXkpqbWfmXz7r6/j8ZGGtm64g0a59O5IwlEY4dAHfPD34XEPkyMYQqvvcVKJX7ADghuNujPnAZMD/ONVW3+cDk4PVk4M9xrCVmgjbzx4AV7n5/hUWJcvytgzMTzKwBcCaR60hvAJcGq9XJ43f3O9y9k7tnEPl//O/uPoEEOHYAM2tkZk3KXwNnA8uo4ntfHRujYGbnEvm2Ug+Y6e6/jHNJMVNxuGbgayLDNf8f8AzQBdgAjHP3gy/c13pmdgrwDvAp/2hH/wmR6yiJcPz9iVx4rUfky+Yz7n63mR1H5Ft7SyLDcE90973xqzS2giavW919TKIce3Ccfwomk4Gn3P2XZpZOFd77ChQREQmFmrxERCQUChQREQmFAkVEREKhQBERkVAoUEREJBQKFJEjMLMDwdNXc83sQzPLjndN5cxslpmtNbMbDrN8V/D7+OAYdh1qPZGw6LZhkSMws13u3jh4fQ7wE3c/tQrb1wseZxKL2mYBf3H35w6z/NvaDzUtEjadoYhErymRR5hjZiPLx8wIph80syuD1+vM7E4zexcYZ2Zvmtm9wVgjq8zsO8F6V5rZgxX28Zfy50iZ2S4z+11wVvS6mbWurLjgaQ6LzOwDM7snzAMXiYYCReTIGgTNRSuJPNY82g/qEnc/xd2fDqaT3X0I8EMiTx+oTCPgQ3cfCLwV5Tb/Azzs7oOBr6KsUyQ0ChSRIysOBhzqRWTgsTkW3eOH5x00Xf6gyaVARhTbl1XYxxPAKVFsczIwN3j9eBTri4RKgSISJXdfROQZZ62JjO5Y8f+ftINW333QdPnznw7wj2EjKtvHP/35aMuMcj2R0ClQRKJkZr2IPDhxK7Ae6GNmqWbWDDjjKHa5jsjYI0lm1pnI48LLJfGPp9x+D3g3iv29R+RJuQATjqIekWOiAbZEjqxBMIIhRAZcmhzctbXRzJ4BPgFWE3kSbVW9B6wl8nTjZcCHFZbtBvqa2VJgOzA+iv1NBZ4ys6lExnQRqVa6bVikBormFt/Kbhs+mn2KHAs1eYnUXtuBew7XsbFcecdGIuPbiMSMzlBERCQUOkMREZFQKFBERCQUChQREQmFAkVEREKhQBERkVAoUEREJBT/Hxc+c+qWJzcJAAAAAElFTkSuQmCC\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAY0AAAEKCAYAAADuEgmxAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy8QZhcZAAAgAElEQVR4nO3deXxV9Z3/8dcnARIgYU+AACECIjsCASRWR7GuVGwVEUUWN1ymzkxlumjHqqNtZ2htO7+xIlgXXOoGbrhVrdpRA0hQFkVUZBPCEpZIZElI8vn9cW80YpBzMXdJ7vv5ePjIvSfnnPs5l3jf93vO93u+5u6IiIgEkRLvAkREpOFQaIiISGAKDRERCUyhISIigSk0REQkMIWGiIgE1iTeBURDhw4dPC8vL95liIg0KEuWLNnu7lnftk6jDI28vDyKioriXYaISINiZusPt45OT4mISGAKDRERCUyhISIigSk0REQkMIWGiIgEptAQEZHAFBoiIhKYQkNERAJTaETgglkLuGDWgniXISISNwoNEREJTKEhIiKBKTRERCQwhYaIiASm0BARkcAUGiIiEphCQ0REAotZaJjZQDNLjdXriYhI/YvJzH1mNhJ4DWgPVNVaPgG4FugITHb3QjObBJQD/YA57r7WzC4DSoFewAp3fyEWdYuIyNfFJDTcfZGZldReZmbNgSp3P97MLgJuNLOLgQvd/Swz6wz8GTgXuNjdTzazVsDDgEJDRCQO4nlN4wAwL/z4PWAHoZZEBYC7bwaGhn9fYmY/BS4E/lTXzsxsmpkVmVlRSUlJXauIiMh3FJOWRl3cvbLW0xOBGcBmYFC4FVIJpIV/fy3wKlAGnHOI/c0GZgPk5+d7lMoWEUlqcQuNGmbWA9jg7svDz6cDtwEbgQ3h1WYAI4EpwF3AeXEoVUQk6cX89JSZpZhZdvhxNtDH3V80s3Qzy3b3p9x9OpBBuOUAdHX3ve4+E+gQ65pFRCQkVr2n8oEs4DRCrYcbzGwq8AyQaWYzAAeGhNefAGS4+z3hXcw1sysJ9ar6YyxqFhGRb4pV76kioGWtRePDP0cdvK6ZnQGsdPdHa20/M7oViohIEHG/pnEwd38p3jWIiEjddBsREREJTKEhIiKBKTRERCQwhYaIiASm0BARkcAUGiIiEphCQ0REAlNoiIhIYAoNEREJTKEhIiKBKTRERCQwhYaIiASm0BARkcAUGiIiEphCQ0REAlNoiIhIYAoNEREJTKEhIiKBKTRERCQwhYaIiASm0BARkcAUGiIiEphCQ0REAlNoiIhIYAoNEREJTKEhIiKBKTRERCSwmIWGmQ00s9TvsH1LM7vEzE6uz7pERCS4mISGmY0EFgJND1o+wczeNrPVZlYQXjbJzMab2c1mdlR4WQfgKeA1d389FjWLiMg3xSQ03H0RUFJ7mZk1B6rc/XjgV8CNZtYeuNDdHwdmAbeHV78dmOPu62NRr4iI1C2e1zQOAPPCj98DdgC9gAoAd98MDDWzpsD5QGcze8DMbolHsSIiAk3i9cLuXlnr6YnADGAzMCjcCqkE0oAsYJ27/x7AzD4ws7vdfWPt/ZnZNGAaQG5ubgyOQEQk+cS995SZ9QA2uPtydy8BpgO3AT8GNgClQFWtTT4Gcg7ej7vPdvd8d8/PysqKQeUiIskn5qFhZilmlh1+nA30cfcXzSzdzLLd/Sl3nw5kALPdfS9QYmaZ4V00Bz6Jdd0iIhKj01Nmlk/oNNNphFoPN5jZVOAZINPMZgAODAmvPwHIcPd7wrv4OXCLmRUBD7r7rljULSIiXxeT0HD3IqBlrUXjwz9HHbyumZ0BrHT3R2ttvxhYHNUiRSThXDBrAQCPXfmNjwqJk7hdCD8Ud38p3jWIiEjd4n4hXEREGg6FhoiIBKbQEBGRwBQaIiISmEJDREQCU2iIiEhgCg0REQlMoSEiIoEpNOQ7uWDWgi9H7YpI46fQEBGRwBQaIiISWMLdeyrevu0Gae5Otce6IhGRxKGWRgS27C7n3Q27eP2jbfEuRUQkLhQaEdhXUUm1wxVzipi3ZOPhNxARaWQUGhEor6ymedNURhzVjulPLGPWPz7FXeerRCR5KDQiUF5ZTfNmqdx3yXDGDOrMb19cxW3Pf0i1LnSISJLQhfCAqqudiqpq2jVJIa1JKv87YQhZGWnc89ZaSsrK+f35g2nWRBksIo2bQiOg7XvKcefLYEhJMW46ux/ZrdKY8dJH7NxTwV2ThpGRprdUDk3Tl0pDp6/GARWX7gcgrVZrwsy45qRe/G7cIBas2cGE2QsoKSuPV4kiIlGn0Aho0659ADRL/eZbdn5+N/4yOZ9Pt+3hvJmFrNu+J9bliYjEREShYWYDolVIoisuDYVG2iGuW5zcJ5u/XjGSsv0HGHdXISs2fh7L8kREYiLSlsbjZtbezM41s+yoVJSgNpXuI8UgNcUOuc6Q3LbMvbqAtCapTJi9gDc/KYlhhSIi0RdpaLQFpgMDgLvM7Pj6LykxbSrdR1qTVMwOHRoAPbMyePKaArq1a8Gl9y/mmaWbYlShiEj0RRoaa4H/5+7/6e7nAl2jUFNCKi7dd8hTUwfr2Cqdx64cxdDctvzro0v5y5trolydiEhsRBoa/wG8ZmYXm1lvoGMUakpIm0r3RTQOo3Xzpsy5dARnDujEbc9/yG9e0CBAEYmuWMxvE1FouPtrwHnASOB3wJZoFJVo9pRXUrr3QOCWRo30pqnccdFQLj4ul9n/t4bpTyzjQFV1lKoUEYm+IxmJ9ilwP7DG3XfVbzmJqabn1JGM+E5NMW49ZwAdM9O5/ZWP2bGngpkTh9JSgwBFpAEK9CloZj81s5fN7HxgCXA18EszGx3V6hLEpsN0tz0cM+PaU47mv84dyFuflHDR3QvZ8YUGAYpIwxP0U/BU4HSgGFjk7pe7+78DaUFfyMwGmlnqEdQYd5u+Q0ujtgkjcpk1KZ9VW8oYd9cCPtu5tz7KExGJmaCfgis95G3g17WWnxdkYzMbCSwEmh60fIKZvW1mq82sILxskpmNN7Obzeyog9afa2Z5AWuuN8Wl+0hNsTpHg0fq1H4defjykezcU8G5Mwv5oFiDAEWk4Qj6KXiTmR0L4O5ray0PNBORuy8CvjbSzcyaA1XufjzwK+BGM2sPXOjujwOzgNtrrf8jImjZ1Kfi0v10apV+2DEaQeXntWPuVaNokmJcMGshhau318t+RUSiLVBouPvn7r4UwMxOqbX85trPI3QAmBd+/B6wA+gFVIT3vRkYGn7NIcBn4XXqZGbTzKzIzIpKSup3JPamXfvo0qZ5ve7z6I6ZPHlNATlt0pl632KeW15cr/sXEYmGIznfMv0wzwNx90p3r+l/eiIwA1gDDDKz5mbWFEgzs7ZAL3cvOsz+Zrt7vrvnZ2VlHUlJh7SpdB9d2tZvaAB0bt2cJ64sYHC31lz7yHvc//baw28kIhJH9XGX2+90zsbMegAb3H25u5cQCqHbgB8DG4AxwMVm9jQwGphtZl2+Y82BVVZVs2X3fnLapEdl/61bNOXBy0by/b4duXn+Sma8tEpTyIpIwgocGmZ2hZndBww0s3vD/50FRPQJZ2YpNTc7DP/s4+4vmlm6mWW7+1PuPh3IAGa7+0Pufo67/xB4DZjm7jG7odO2snKqqp0ubVpE7TXSm6Yyc+JQLhyRy51vfMpP5y7XIEARSUiBR5i5+93A3Wb2ortfWrPczH58uG3NLB/IAk4j1Hq4wcymAs8AmWY2g1D4DAmvPwHIcPd7IjiWqKjpbhutlkaNJqkp/OZHA8jOTON//v4JO74o588Th9KimQYBikjiqI9PpMOengpfj2hZa9H48M9vzHlpZmcQ6uL7aB37mXqENR6xmtHgXaNwTeNgZsZPTu1NVmYav3rmfS66exH3Th1Ou5bNov7aIiJBBB0Rfr+ZpZlZC2DOQb8++Pl34u4vufvy+tznd1HT0ujcOvqhUePi47pz58RhrNy8m3F3FbJxlwYBikhiCHpN4w13Lwd+ULsFYGbH1tUiaEw27dpHmxZNY36vqDMGdOLBS0dQUlbOeTMLWbVld0xfX0SkLkFDo4WZrQJmmVlx+L/NQGEUa0sIxaX1P0YjqJE92vPEVaEzeOfftYBFaw45TEVEJCaCDu670937ABe4e074v86E7knVqG0q3UdOnEIDoE+nVsy7uoDszDQm3fsOL72/OW61iIhEdE0DeLP28vC9qBotd4/KaPBIdW3bgrlXFdA/pxVXP/wuDy5cH9d6RCR5RXpN4+zaC2vuR9VY7d5XyZ6KqriHBkDbls346+XHMfqYbG58+n3+8PJHGgQoIjF3JNc0NifLNY2anlPRuIXIkWjeLJVZk4YxPr8r/++11dzw1AoqNQhQRGIoUJcgd78TuNPMTgNecXcP35G2T1Sri7PiLwf2JUZoQGgQ4H+fN4jszHTueH01JWUV3HHRENKbNsipSkSkgYn03lMFwMPhx32A7vVbTmL5sqWRQKEBoUGA/376Mdwytj9/X7WViX9ZROneiniXJSJJINLQqASehi8vgk+t74ISSXHpPpo1SaF9go7InlKQxx0XDmXFxs85/64FX7aMRESiJdLQ2EHoduUtzOwaQveTarQ2lu4jp3U6KSn1M/lSNIwZ1Jn7Lx3Ols/3c97MQj7eWhbvkkS+s4rKal5duZVPS75g/Y69rN+xJ94lSVikoTEXGBT+ORiYXO8VJZDiKM2jUd8KenbgsStHUVntjJtZSNG6nfEuSSRiVdXO26u384t5yxn+61e5/IEidu09wNbd+znp929w6f2LeeOjbVRXq9dgPAW6EG5mw919cXi+i5/WWn47RzgJU0NQXLqPE49uGI2pfjmtePLqAqbc+w4T/7KIOy4ayqn9Osa7LJFv5e68u6GU+cuKeX7FZkrKymnRLJXT+nVk7LE5zHzjUyqrnBN6Z/HXRRuYet9ienRoyaRR3Rk3rCuZ6U3jfQhJJ+gNlf7LzM509y+vtprZ74B/o5GGRkVlNdvKyhtES6NGt3YteOKqUVw6p4grHyziNz8ayIQRufEuS+Rr3J0PN5cxf3kx85cVs3FX6NrhycdkMXZwF0b3yaZ5s1BvwFn/WEOzJsZ1p/bmn0/uyYsrtnB/4Tpumb+S3//tI84b1pXJo/LolZ0R56NKHkFD4wngFjO7Kfz8ISCXRnwhfMvn+3FPrO62QbTPSOOvl4/kmoff5RdPrmBbWTnXju6FWeJel5HksHb7HuYvK+bZZcWs3vYFqSnG8b068G/f781p/TvS6jCthrQmqfxwSBd+OKQLyz4rZU7hOh595zMeWLCeE47uwJRReZzcJ5vUBL4G2RgEDY37CM2k91vgOGALcBJQFZ2y4m9jaeh25F0bWGgAtExrwl+m5PPzecv5wysfs61sP7eMHaD/mSTmNn++j+eWbebZZcWs2PQ5ACPy2nHrDwdw1oBOtM9IO6L9Du7Whj9ccCw3jOnLI4s28NCi9Vz+QBHd2jVn8nF5jM/vRusWOnUVDUFD43pCU60uBL4P3AGMAE4Hfhmd0uKruHQ/0PBaGjWapqZw+/mDycpMY9Y/1rC9rII/TThWgwAl6nZ8Uc4L729h/tJi3gl3yhjYpTW/PKsvYwZ1rtf/pzpkpHHtKUdz1Uk9+dsHW5hTuI5fv/Ahf3jlY344pAtTCrrTp1Orens9CR4alwAnEpqlbyfwq/DynjTS0Ni0KzTmoVPr6E7zGk1mxvVn9iU7M51bn1vJ5Hvf4e7J+bRurm9gUr927z/Ayx9s5dllxby9ejtV1U6v7AyuO7U3PxjUmR5Z0b3m0DQ1hR8MyuEHg3L4oPhzHihcz5PvbuSRdzZwXI92TC3I4/t9O9IkNdIOo3KwoKFxpruvPHihmfWv53oSRnHpPrIy0xrFN/PLvncUWZlpTH98KRfMWsD9l4xo0GEoiWFfRRWvrdrGs8s28fpHJVRUVtO1bXOmndiDsYNz6NMpMy7X0vrntOa/xw3iF2f24bGiz3hwwXqueuhdclqnc/Go7kwYnqsplL+DoPeeWglgZt2A3UA1MAn4R/RKi6/iz+M7j0Z9Gzs4h3YtmnHlg0WcN7OQOZeOUI8TiVhFZTVvrS7h2aXFvLJyK3sqqsjKTOOiEbmMPTaHId3aJEyni7Ytm3HVP/XkihN68OqHW5lTuI4ZL33En179hLGDc5hakMeALq3jXWaDE+kcptOBXwCPACuAc4EP6ruoRLBp1z76dm5c50K/d3RoEODU+95h3F2F3Dt1OENz28a7LElwVdXOorU7mL+smBff30Lp3gO0bt6UswfnMHZwDiN7tE/oThapKcbp/Ttxev9OfLy1jDmF63jy3U3MXbKRYd3bMqUgjzMHdKKpTl0FEmlofABcCaS5+6/M7LIo1BR37s6m0n2c0jc73qXUuwFdWjPv6gIm3/sOF929kDsnDmV0Hw0ClK9zd5Z+Vsqzy4p5fvlmtoUH3Z3aryNjB+dwwtFZNGvS8D5ke3fM5Nc/GsjPzujDE0Wf8eDC9fzLI++RnZnGxJHduWhkLlmZR9ajK1lEGhpLCXW5HWdmg4HO9V9S/FVWO+WV1Ql3d9v60r19S+ZdXcAl9y3migeW8NtzBzI+v1u8y5IEsGrLbp5dWsz85cV8tnMfzVJTOOmYLMYem8PoPtm0aBbpR0Ziat28KZef0INLjz+KNz7exv2F6/njqx9zx+ufMGZgZ6YU5DFErfA6RfoXUAIMAB4DFgC/r/eKEkB5ZWhio8Z0TeNgHTLSeGTacVz90BJ+Nnc5JWXlXHNSz4Q5Hy2xsy486G7+8mI+3hoadFfQsz3/MvpoTh/Q6bCD7hqylBRjdJ+OjO7TkU9LvuDBBeuZu2QjTy8tZnDX1kwpyGPMoM6kNWn4HWLqS6Sh8ThwL3An0A64CvhTfRcVbxVJEBoAGWlNuGfKcH46dxm/+9tHlJSV86sf9Evou/pK/djy+X6eC9/GY9nG0KC74XltufWc/pw5sDMdjnDQXUPWMyuDm8f2599PP4Z5SzYyZ8E6rnt8Gb954UMuHJHLxJHd1euQyENjmbvfVfPEzBrlyfCalkbXBnTfqSPVrEkKfxx/LFkZafzlrbWUfFHOH8YP1jerRmjnngpeWLGZ+ctCg+7cYUCXVtxwVh/GDMpptKdjI5WR1oQpBXlMHtWdt1ZvZ07hOu54fTUz3/iU0wd0YmpBHvnd2yZtq/ywoWFm5wNnhp92N7Ongb3h502BR6NUW9xUVFbRollq0gyCS0kx/uMH/chulcZvXljFzi8qmDV5WKM+LZEsysKD7uYvL+atT7ZTWe30zGrJv53Sm7MHR3/QXUNmZpxwdBYnHJ3Fhh17eXDhOh5b/BnPL99Mv86tmFLQnXOO7dIoxnJFIkhLYyfwJFDX7D7V9VtOYqi5CJ5s3ySmndiTDhlp/Gzuci6YtZA5lwwnu5Wa4w3N/gOhQXfzlxXz2qptX/49X35CD84e3Jl+nVsl3d/2d5XbvgW/HNOPn5zam6ffK2ZO4Tp+Pm8Fv31xFRcM78ak47rTtW2LeJcZE4cNDXf/e81jMzsbOIfQ5E0phC6K50etujipqKxu9NczDuXcoV1p17IZ1zz8LufOLOSBS0fo22gDcKCqmrc+2c78ZcW8vHIrX5RX0iEjjQtH5HL24ByG5ibOoLuGrEWzJlw0MpcLR3Rj4ZqdzClcx93/t4a7/28N3+/bkakFeYzq2b5Rv9eRXtPoD/wv0BX4GPhe0A3NbCCw0t0T/s645ZXVDWoejfp20jHZPHLFcVxy/2LG3bWA+6YOZ3C3NvEuSw5SXe0sWruT+cuLeXHFZnbtPUCr9CaMGdiZscfmMPKodrrXUpSYGaN6tmdUz/ZsKt3HQwvX8+g7G3h55VZ6d8xg8qg8zh3apdF0Ua4t0iNqDrQgFBotgGmEbpv+rcxsJKG75Lan1u3UzWwCcC3QEZjs7oVmNgkoB/oBc9x9bV3rRVh3YFXVTmW1J/1FwcHd2oQHAS5iwuyFzLx4KCcd0/gGOzY07s7yjZ/z7LJinltezNbd5TRvWmvQXe8O6sQQY13aNOfnZ/ThX085mvnLipmzYB3/8fT7/PdLqxif343Jo7rTvX3LeJdZbyINjQeBNsAcQrdLvz/IRu6+yMxKai8zs+ZAlbsfb2YXATea2cXAhe5+lpl1Bv5sZhMPXo+vLszXu5rutskeGgBHdQgNApx672Iun1PEjHGDOHdo13iXlZQ+3lr25aC79Tv20iw1hX86Jouxg3M4pW/jGXTXkKU3TeX8/G6MG9aVdzfs4v7C9cwpXMe9b6/l5GOymVKQxwm9OjT4Lu0R/aW5++paT2865IrBHADmhR+/B5wF9AIqwq+12cyGHmK9bzCzaYRaPuTmHvkUp8kwsC8S2ZnpPHblcVz54BKue3wZJWXlTDuxR6M+Z5soNuzYy/zlxTy7tJiPtpaRYnB8rw7888m9OL1/p6Tp3dfQmBnDurdjWPd2bB3Tl4cXbeCvizYw5d536NGhJZNHdee8Bjy/edy+nrh7Za2nJwIzgM3AoHArpJLQPa7qWq+u/c0GZgPk5+f7kdZVURU6e5bTRr2GamSmN+W+S4Zz3ePL+O2Lq9hWVs4vz+rb4L8xJaKtu/fz3PLQTHfLPisFIL97W/7znP6cOaCz7ovUwHRslf6N+c1vnr+S3/3tI8YN68rkgjx6NrCOJnFv05pZD2CDuy8PP58O3AZsBDYcar1oqWlpdFJX069Ja5LK/04YQlZGGve8tZbtX5Tzu3GD411Wo7BrTwUvvr+FZ5dtYtHa0KC7/jmtuP7MPowZ1DlpunI2ZnXNb/7IO58xJzy/+dSCPE46pmHMbx7z0DCzFKCDu28zs2ygj7u/YGbpQCt3fwp4ysxuJNxyOMR626JRX0VlNc1SU9TrpA4pKcZNZ4cGAc546SN27qmgqtobxB96ovmivJJXVm7h2aXFvBkedNcjqyX/esrRnD04p8F9+5Tg6prf/LI5ReS2a8HkUd05f1hiz28ek9Aws3wgCziNUOvhBjObCjwDZJrZDMCBIeH1JwAZ7n6PmbU41HrRUF5ZTVoDvOVzrJgZ15zUi6yMNH7x5ArSmqTQsVU6jy/+LN6lNQhbd+9n974DDLv1lS8H3V12wlGcPSiH/jkadJdMas9v/vIHoUmibnv+Q25/OTS/+dSCPI7plBnvMr8hJqHh7kVA7T5n48M/Rx28rpmdQWg8x6PhbffWtV60VFRWk5EW97N2Ce/8/G50yEjjsjmLWbt9Dz+bF9Wzho1KkxRj4siaQXdtdW0oyTVNTWHMoM6MGdS5QcxvnnCfju7+Urxeu6raqaisJq1lYvzjJLqT+2QzNLctldXV/HnisHiX0yD888NLaJaawi3nDIh3KZKADjW/eZc2zZl4XG5CzG+ecKERTyVl5Tg0yBnJ4iU1xUhNSdW4loA08E6C+Lb5zc8ZnMOUOM5vrtCopWVaKj06tCQzXW+LiMTfoeY3f2LJRvLD85ufEeP5zfXpWEtmelP1gxeRhFTX/ObXPvIeHVuF5je/cMSRD2qOhEJDRKQBqWt+8z+88jF3vLaazPQmUR9jptAQEWmA6prf/IEF674coBwtCo0IPHZlzHr+iogEVjO/+fubPudAlUJDREQCqOnNGE3qWyoiIoEpNEREJDCFhoiIBKbQEBGRwBQaIiISmEJDREQCU2iIiEhgCg0REQlMoSEiIoEpNEREJDCFhoiIBKbQEBGRwBQaIiISmEJDREQCU2iIiEhgmk9DRBKWJj5LPGppiIhIYAoNEREJTKEhIiKBKTRERCQwhYaIiAQWs9Aws4Fmlhqr1xMRkfoXky63ZjYSeA1oD1TVWj4BuBboCEx290IzmwSUA/2AOe6+1sxGAwMAAxa6+6JY1C0iIl8Xk9Bw90VmVlJ7mZk1B6rc/Xgzuwi40cwuBi5097PMrDPwZzM7H5gBDA9v+ndgdCzqFhGRr4vnNY0DwLzw4/eAHUAvoALA3TcDQ4FcYLuHAQfMrMfBOzOzaWZWZGZFJSUlB/9aRETqQdxCw90r3b06/PREQq2JNcAgM2tuZk2BNKATUFZr0zJCp7MO3t9sd8939/ysrKwoVy8ikpzifhuRcKthg7svDz+fDtwGbAQ2EGqBZNTaJAPYHus6RUQkDi0NM0sxs+zw42ygj7u/aGbpZpbt7k+5+3RC4TDb3T8GMi0MyHD3T2Jdt4iIxK73VD6QBZxGqPVwg5lNBZ4hFAgzAAeGhNefQCgc7gnv4npgeq3HIiISB7HqPVUEtKy1aHz45zduYWlmZwAr3f3RWtu/CbwZ1SJFROSw4n5N42Du/lK8axARkbrpNiIiIhKYQkNERAJTaIiISGAKDRERCUyhISIigSk0REQkMIWGiIgEptAQEZHAFBoiIhKYQkNERAJTaIiISGAKDRERCUyhISIigSk0REQkMIWGiIgEptAQEZHAFBoiIhJYws3cJ9KYPXblN2Y4FmlQ1NIQEZHAFBoiIhKYQkNERAJTaIiISGAKDRERCUy9p0REGolY9M5TS0NERAJTaIiISGAKDRERCSxm1zTMbCCw0t2rYvWaEn0a4SySXGISGmY2EngNaA9U1Vo+AbgW6AhMdvdCM7sMKAV6ASvc/YW6lkWrVn0IiogcWkxCw90XmVlJ7WVm1hyocvfjzewi4EbgTOBidz/ZzFoBDwMvHGKZiIjEWDy73B4A5oUfvwecFX5cYmY/BXYDf/qWZV9jZtOAaQC5ubnRqllEJKnFLTTcvbLW0xOBGeHH1wKvAmXAOd+y7OD9zQZmA+Tn53sUShYRSXpx7z1lZj2ADe6+PLxoBjASeBC461uWiYhIjMU8NMwsxcyyw4+zgT7u/qKZpYefd3X3ve4+E+gQ3qyuZSIiEmOx6j2VD2QBpwEbgBvMbCrwDJBpZjMAB4YAc83sSqAc+GN4F3UtExGRGItV76kioGWtRePDP+vq3zqzju2/sUxERGIv7tc0RESk4VBoiIhIYObe+HqnhgcSrv8Ou+gAbK+nchoaHXvySubjT+Zjh6+Ov7u7Z33bio0yNL4rMyty9/x41xEPOvbkPHZI7uNP5mOHyI5fp6dERCQwhcvAaiEAAARdSURBVIaIiASm0Kjb7HgXEEc69uSVzMefzMcOERy/rmmIiEhgammIiEhgCg3BzAaaWWq86xCR2DOzzEjWV2iEmVkTM7vVzH5kZjeYWVK8N+FZFRcCTZPtPTCzVmb2iJmtMbP7zaxpshy/mbUxs/8xs1fN7GfJ9m8PYGbDzGxWkh77TWa22sw+BNpGcvyN/s2JwBXAJnd/CtgFnB/nemLC3RcBNbMqJtt7cBpwKdAXGAbcQPIcfw/gJ4Teg9NIsn97M2sDnAykkXzHngE0Bwa4e19gDBEcv0LjK8cBS8OPlxJ6I5NNsr0Hz7r7PncvB1YCvUmS43f3d929GigA7ib5/u3H8dXMocl27L2BY4FNZnYpER5/PKd7TTSdCM0MSPhnxzjWEi9J9R64ewWAmaUDG4EBJNHxhydAu4TQh8ZGkuTYzWwc8BRQcy4/2f7u3wXOMLO+wN+BFURw/GppfGUHkBF+nEFy3ocmWd+DC4CbSLLjd/c17n4ZsAioJnmO/RLgHkJjE0YTmm46WY79S+7+ITAXqCKC41dofOVlYHD48aDw82STdO+BmZ0FvODuXwAfkWTHH1YKvEqSHLu7j3H3HwLTgNeAq0mSY4cvW9Y10oFnieD4FRpfeQDINbPxQC7wUJzriYmDZlVMqvfAzCYAs4DXw71ISkiS4zezW8zsXjMbA7xAaEbMpDj2OiTV3z1wm5k9YWaTCB3rbCI4fo0IFxGRwNTSEBGRwBQaIiISmEJDREQCU2iIiEhgCg0REQlMoSEiIoEpNEREJDCFhkgDY2btzOx5M+sT71ok+Sg0RA7BzI43sz3h0dPXm9k8M+saw9fPM7NFZja69nJ330noZqMpZvYbM7s5VjWJKDREDsHd3yZ0a5H73P23wGLguhiX8aG7v1Z7QfjeQfvdfSWN/D5Jknh0a3SR4NoBn5jZvxCah+LHwHPALwhNanQS0Ax4EziFUMiMA04ALq9jm37AqcAqQnMYTAgHQZ3M7ITwNp2Ad+r96EQCUEtD5PCuNrM7CYXCC8ByAHffDqwLr7MO6OjuEwhN6ES4dbKB0B1E69rmw9Aivx74E/CzQxUQPi12nbvPAoxQMInEnEJD5PBmuvs1hOYeuPcQ61QTmioTwIGK8ONyQlOK1qX2ekuADt9Sw/XA78OPR6GWhsSJQkMkuE8JzfZWRWiOZQjNRxDE4bbpSGgypEMZAawws2GEJsppEfB1ReqVrmmIHIKZfQ/IJnR6aivwfeAnwPtATzO7lVDroifQHuhhZp0JnY46KnxKqTehiW3m1LHNp8DRZjYVOIqvWhJ1eYfQ3B9PEvqy1wHYWa8HLBKA5tMQiRMzOwm4KnwdpK7f5wG3uPuUw+zjJHe/uf4rFPkmnZ4SiZ+RhFokXQ7x+y+AUjM7ra5fmlk/oD/hi+wisaCWhoiIBKaWhoiIBKbQEBGRwBQaIiISmEJDREQCU2iIiEhgCg0REQlMoSEiIoEpNEREJLD/D25jd5/r76sIAAAAAElFTkSuQmCC\n",
       "text/plain": [
        "<Figure size 432x288 with 1 Axes>"
       ]
      },
-     "metadata": {},
+     "metadata": {
+      "needs_background": "light"
+     },
      "output_type": "display_data"
     }
    ],
@@ -383,27 +364,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<matplotlib.axes._subplots.AxesSubplot at 0x7ff3d0925c50>"
+       "<matplotlib.axes._subplots.AxesSubplot at 0x7fa54cf86d50>"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYQAAAEKCAYAAAASByJ7AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvOIA7rQAAIABJREFUeJzt3Xl8VPW5x/HPk4WEkJAACWsIi8gWCCGEVVQEVFyKa6uIiAtFvbd1aWuttRVFbUWtrVxvi4qAXi1ia63WFVERUBBRQUURkDWIbJHITiC/+8c5SYaYZQKTTMJ836/XvDJzzu+ceebAzHPObzvmnENERCQq3AGIiEjdoIQgIiKAEoKIiPiUEEREBFBCEBERnxKCiIgASggiIuJTQhAREUAJQUREfDHhDqA6UlNTXfv27cMdhohIvfLRRx9td86lVVWuXiWE9u3bs2TJknCHISJSr5jZ+mDKqcpIREQAJQQREfEpIYiICFDP2hBEJHIVFhaSl5fH/v37wx1KnRUfH096ejqxsbFHtb0SgojUC3l5eSQlJdG+fXvMLNzh1DnOOXbs2EFeXh4dOnQ4qn2oykhE6oX9+/fTrFkzJYMKmBnNmjU7pisoJQQRqTeUDCp3rMdHCUFEjluXPLqQSx5dGO4w6o3ISAjTz/EeIiI1IDExMeiyM2bM4Gc/+xkARUVFjB07lquvvprK7m8/f/58MjMzyc7OZt++fdxyyy1kZmZyyy23HHPsgYJqVDazacC5wFbnXI9y1p8H3A0UAYeAm5xzC/x1Y4Hf+UXvcc496S+fC7QC9vnrznDObT36jyIiUn8457juuusoLCxk+vTplVb3PPPMM/zqV7/iqquuAuDRRx9l27ZtxMXFhTSmYK8QZgAjKln/FtDLOZcNXA1MBTCzpsAEoD/QD5hgZk0CthvtnMv2H0oGIlLnnX/++fTp04fMzEwee+yxkuW//OUvycnJYdiwYWzbtg2AyZMn0717d7Kysrj00kuP2M+NN97Ijh07eOqpp4iK8n6KZ8+ezcCBA8nJyeHHP/4xu3fvZurUqTz33HNMnDiR0aNHM3LkSPbs2UP//v2ZNWtWSD9bUFcIzrl5Zta+kvW7A142Aoqvfc4E3nTO5QOY2Zt4iWXm0QQrIgJw13+W88U331dZ7ovNXplg2hG6t27MhB9lVllu2rRpNG3alH379tG3b18uuugi9uzZQ05ODn/605+YOHEid911F4888gj33Xcfa9euJS4ujp07d5bs4+9//zvdunVj7ty5xMR4P8Pbt2/nnnvuYc6cOTRq1IhJkybx0EMPcccdd7BgwQLOPfdcLr74YsCrolq6dGmVsVZXyNoQzOwCM1sBvIJ3lQDQBtgYUCzPX1ZsupktNbPfm7oPiEg9MHnyZHr16sWAAQPYuHEjq1atIioqiksuuQSAyy+/nAULFgCQlZXF6NGjefrpp0t++AFycnJYv349ixcvLlm2aNEivvjiC0466SSys7N58sknWb8+qDnpQiZkA9Occy8AL5jZKXjtCcOB8n7ki68eRjvnNplZEvA8MAZ4qmxhMxsPjAfIyMgIVbgiUo8FcyYPpVcGs64dGJL3nTt3LnPmzGHhwoUkJCQwZMiQcvv9F5/fvvLKK8ybN4+XXnqJu+++m+XLlwPQtWtXJk6cyE9+8hPeeOMNMjMzcc5x+umnM3Nm+CpQQt7LyDk3DzjBzFLxrgjaBqxOB77xy23y/+4C/o7XxlDe/h5zzuU653LT0qqczltEpMYUFBTQpEkTEhISWLFiBYsWLQK83kL//Oc/Aa86aPDgwRQVFbFx40ZOO+007r//fnbu3Mnu3aW164MGDWLKlCmcc845bNiwgQEDBvDee++xevVqAPbu3cvKlStr9fOF5ArBzDoBXzvnnJnlAA2AHcAbwB8CGpLPAG4zsxggxTm33cxi8XowzQlFLCIiNWXEiBFMmTKFrKwsunTpwoABAwBo1KgRy5cvp0+fPiQnJzNr1iwOHz7M5ZdfTkFBAc45br75ZlJSUo7Y37nnnsu2bdsYMWIE8+fPZ8aMGYwaNYoDBw4AcM8999C5c+da+3xWWd/XkkJmM4EhQCqwBa/nUCyAc26Kmd0KXAEU4nUjvSWg2+nVwG/9Xd3rnJtuZo2Aef4+ovGSwS+cc4criyM3N9cd1Q1yiscgXPVK9bcVkTrhyy+/pFu3btXaJtRVRvVBecfJzD5yzuVWtW2wvYxGVbF+EjCpgnXTgGlllu0B+gTz3iIiRyuSEkEoRMZIZRERqZISgoiIAEoIIiLiU0IQERFACUFEjmea6bhalBBERGrAnXfeyYMPPgjAlVdeWTJwLT8/n969ezN9+vRKt588eTLdunVj9OjRHDhwgOHDh5OdnR3yCe0C6Z7KIiK1pKCggDPPPJPx48eXTGVdkb/+9a+89tprdOjQgUWLFlFYWFgjE9oF0hWCiEg1PPXUU2RlZdGrVy/GjBnD+vXrGTZsGFlZWQwbNowNGzaUu93u3bs566yzuOyyy7j++utLlj/wwAP07duXrKwsJkyYAMB1113HmjVrGDlyJJMmTeLyyy9n6dKlZGdn8/XXX9fYZ9MVgojUP6/9Br79rOpy337q/Q2mHaFlTzjrvkqLLF++nHvvvZf33nuP1NRU8vPzGTt2LFdccQVjx45l2rRp3HDDDfz73//+wba/+MUvGDduHDfffHPJstmzZ7Nq1SoWL16Mc46RI0cyb948pkyZwuuvv84777xDamoq/fv358EHH+Tll1+u+nMcA10hiIgE6e233+biiy8mNTUVgKZNm7Jw4UIuu+wyAMaMGVMy9XVZQ4cO5cUXX2Tr1tJ7gc2ePZvZs2fTu3dvcnJyWLFiBatWrar5D1IBXSGISP1TxZl8iRDPY+acq/RWl0CF6y+99FIGDx7M2WefzTvvvENSUhLOOW677TauvfbakMR3rHSFICISpGHDhvHcc8+xY8cOwOsxNGjQIJ599lnAu/fx4MGDK9z+pptuYtiwYVxwwQUcPHiQM888k2nTppVMi71p06YjriBqm64QRESClJmZye23386pp55KdHQ0vXv3ZvLkyVx99dU88MADpKWlVdmddNKkSVx11VWMGTOGmTNn8uWXXzJwoDcJX2JiIk8//TTNmzevjY/zA0FNf11XaPprkch1NNNfR+J3v8anvxYRqZciKBGEgtoQREQEUEIQkXqkPlVxh8OxHh8lBBGpF+Lj49mxY4eSQgWcc+zYsYP4+Pij3ofaEESkXkhPTycvL49t27aFO5Q6Kz4+nvT09KPeXglBROqF2NhYOnToEO4wjmuqMpIf0hzyIhFJCUFERAAlBBER8SkhgKpIRERQQhAREZ8SgoiIAEoIIiLiU0IQERFACUFERHxKCCIiAighiIiITwlBREQAJQQREfEpIYiICKCEICIiPiUEEREBlBBERMSnhCAiIkCQCcHMppnZVjP7vIL155nZp2a21MyWmNnggHVjzWyV/xgbsLyPmX1mZqvNbLKZ2bF/HBEROVrBXiHMAEZUsv4toJdzLhu4GpgKYGZNgQlAf6AfMMHMmvjb/A0YD5zoPyrbv4iI1LCgEoJzbh6QX8n63c45579sBBQ/PxN40zmX75z7DngTGGFmrYDGzrmF/nZPAecf7YcQCSvdYEmOEyFrQzCzC8xsBfAK3lUCQBtgY0CxPH9ZG/952eUiIhImIUsIzrkXnHNd8c707/YXl9cu4CpZ/gNmNt5vl1iybdu20AQrIiI/EPJeRn710glmlop35t82YHU68I2/PL2c5eXt7zHnXK5zLjctLS3U4YqIiC8kCcHMOhX3EjKzHKABsAN4AzjDzJr4jclnAG845zYDu8xsgL/dFcCLoYhFRESOTkwwhcxsJjAESDWzPLyeQ7EAzrkpwEXAFWZWCOwDLvEbi/PN7G7gQ39XE51zxY3T1+P1XmoIvOY/REQkTIJKCM65UVWsnwRMqmDdNGBaOcuXAD2Cef9jdmA3FO6tlbcSEamvgkoI9d6eLbB7Cxw+BNGR8ZFFRKorMqauiGsMrgi+XRbuSERE6qwISQjJ3t/1C8Mbh4hIHRYZCSGmAcTEwwYlBBGRikRGQgCv2mj9+1BUFO5IRETqpMhJCPHJsC8ftq8MdyQiInVS5CSEuMbe3w3vhzcOEZE6KnISQkw8JLZQw7KISAUip1O+GWQMLLdhefnmAgAyazsmEZE6JHKuEADaDYKCjbBzQ7gjERGpcyIrIWQM9P6q2khE5AciKyG0yPQGqalhWUTkByIrIURFQ0Z/XSGIiJQjshICeNVG27+CPTvCHYmISJ0SeQmh3SDvr6axEBE5QuQlhNa9ITpOCUFEpIzISwgxcZCeC+vfC3ckIiJ1SuQlBPDaETZ/6t1JTUSkrpt+jveoYZGZENoNAncY8haHOxIRkTojMhNC235gUep+KiISIDITQlwStMxSw7KISIDITAjgVRvlfQiHDoY7EhGROiFyE0LGQDi0H775JNyRiIjUCZGdEEDzGomI+CI3ISSmQWpnNSyLiPgiNyGAd5WwcRE4F+5IRETCLrITQrtBsL+AOLc/3JGIiIRdZCcEvx2hkdsb5kBERMIvshNCSgY0bkOC2xPuSEREwi6yE4IZZAwkoWiP2hFEJOJFdkIAaDeQWA4RiwaoiUhkiwl3AGHX7iQAWhzeAu89DA0aQYNEiE3wn/uP2ARvefHzKOVSETm+KCGkdmGfxZNcVABv3hH8drEJAUkjERr4z2MbHZlISpJJ2WUVlIuKrrnPKiJSCSWEqCjWxJ4IzpH5qzfg4B4o3OP9PbgXDu72lxU/3+uv2+0v23PkY8/2I8sVVrPBOqZhaXKp6kqlQUKZMuUlpgTvebT+qUWkcvqVKGYGcYneI5SKiuDQviOTRmFAoilOOoUBiSYwmRSX2Zv/wyRENRrCY+IDkklCOVcqAYmmYCNExcKGRdC8O8Q3Du0xEZE6SQmhpkVFlf74hpJzULgv+Cuawj0/vJop3Av78gK29cu5Iu89pp3p/U3OgBbdveTQItN7NOsE0bGh/UwSES551JsuZta1A8MciZSlhFBfmfln9QlAWuj26xxMOwuKCuGUX8GW5bD1C9jyBax607vTHHhXEGld/CTRHVr08J43bu3FJiL1jhKCHMnMa9iOioYuZ3mPYocOwPaVXnLYutz7u24BfPZcaZn4ZGie6SeJTO95826qdhKpB6pMCGY2DTgX2Oqc61HO+tHArf7L3cD1zrll/robgZ8CBjzunPuLv/xOf/k2f7vfOudePbaPIjUuJg5a9vQegfbmw9Yv/SuJ5d5j2Sw4uKu0THG1U4vM0qonVTuJ1CnBXCHMAB4Bnqpg/VrgVOfcd2Z2FvAY0N/MeuD96PcDDgKvm9krzrlV/nZ/ds49eEzRS41YvrkAgMxgN0hoCu1P8h7FnIOdG0qTRPHfwGqn6AbeFOSBbROqdhIJmyoTgnNunpm1r2R94B1mFgHp/vNuwCLnvJnjzOxd4ALg/qMNVuoRM2jSzntUWu20vJxqp5SAJNFd1U4itSTUbQjXAK/5zz8H7jWzZsA+4GxgSUDZn5nZFf6yXzrnvgtxLCUqO+N1zvGbPZfR0A5y89c7GNCxKaaz05oTVLXT517CWPZsOdVOmUf2eFK1U71zx45b/GcLwhqH/FDIEoKZnYaXEAYDOOe+NLNJwJt4bQvLgEN+8b8Bd+N1pL8b+BNwdQX7HQ+MB8jIyAhVuCVWb93NZ4fbEcNhRj2+iB5tGvPTkztyds9WxEZreopaU2W1k58ktn4Bq2aXqXbqcmSSULWTyFEJSUIwsyxgKnCWc25H8XLn3BPAE36ZPwB5/vItAds+Drxc0b6dc4/htUuQm5sb8ilJF6/LB+DhRtMpOONhpi5Yw43PLmXSayu46qQOXNKvLY3jdQYaFlVWOy0vbZ9YOx8+nVVaJj4loAFb1U4iwTjmhGBmGcC/gDHOuZVl1jV3zm31y1wIDPSXt3LObfaLXYBXvRQWH67NJ8V20y5qGz36Z3Bp37a889VWHp+/hntf/ZKH31rFpX3bctXgDrRJaRiuMCVQpdVOXxzZLXbZTG+AXrGUjNJusc398RPNOh3T1B7VboQXqaOC6XY6ExgCpJpZHjABiAVwzk0B7gCaAX/1694POedy/c2f99sQCoH/DmgnuN/MsvGqjNYB14bqA1XXh+u+IzN6Y0ntQlSUMaxbC4Z1a8FneQVMXbCG6e+vY/r76zinZyt+enJHeqYnhytcqUxCU2g/2HsUKyqCgg1HJokqq516eM+TWqnaSSJKML2MRlWxfhwwroJ1J1ewfExQ0dWwTTv3sWnnPs6Nyyt3fc/0ZB6+tDe/HtGVGe+tZebijby07Bv6d2jKT0/uyNCuzYmK0g9GnRYVBU3ae4+uZ5cuP3QAtn11ZLfYSqudirvFdoO4pNr+FCK1IqJHKn+41ms/yIzZWGm5NikNuf2c7tww7ERmfbiR6e+tY9xTS+iY1ohrBnfgopx04mM1bXW9EhMHrbK8R6DqVju1yCTO7ecAcbUbv0SU2qqWjOiEsHhdPklxMbSP2hpU+aT4WMad3JGxg9rz6mebmTp/Lbe/8Dl/mr2SMQPaMWZgO1IT9cNQrwVb7bRleUm1UyfgMFEw/yEY8F8QGx+28EWORUQnhA/X5pPTrgnR31av81JsdBTnZbdhZK/WfLA2n6nz1/DwW6v427tfc1FOG64Z3JFOzUM8jbaET0XVToX7YftK8qaOIrmogKS37oIl02DYBOhxke6qJ/VOxP6P/W7PQVZt3U2/Dk2Peh9mxoCOzZg6ti9zfnEqF+Wk86+PNzH8oXe5esaHLPx6B86FvKes1BWx8dAqi4LoJmyIbQ9j/+NdYfxrHEwdBuveC3eEItUSsQnhQ3/8Qd/2R58QAnVqnsgfL+zJ+78Zyk3DT2TZxp2MenwRP3pkAS8u3UTh4aKQvI/UYR1OgZ/OhfOnwK5vYcbZ8Oxo2L463JGJBCWiE0KD6CiyQtyFtFliHDcN78x7vxnKHy7oyd6Dh7nx2aWcev87PDbva77fXxjS95M6JioKskfBzz+Cob+DNXPhr/3h1V/Dnh1Vbi4SThGbEBav+45ebZNrrHdQfGw0l/XPYM7Np/LE2FwymiXwh1dXMOiPb3PPy1+waee+GnlfqSMaJMApt8ANn0DvMfDh4zC5N7w32Wt7EKmDIjIh7D14iOWbCkJWXVSZ4oFuz44fyH9+Nphh3Zoz/f11nHL/O/x85id8mrezxmOQMEpsDj/6C1y/EDL6w5u/h//tC5/905urSaQOiciE8MmGnRwqcvQ9hgblo1E80G3er0/j6pPa886KrYx85D1+8uhC5nyxhaIi/UAct5p3hdH/gDH/hrhkeP4amDocNiwKd2QiJSIyISxem48Z9GnXJCzvXzzQbeFtQ/ndOd3Y9N0+xj21hOF/fpdnPljP/sLDYYlLasEJp8G178J5/wvfb4JpZ8KsMZC/JtyRiURGQpjY7AEmNnug5PWH6/Lp1rJx2GcxLR7oNveWITx8aTaNGsRw+wufM+i+t3nozZVs330grPFJDYmKht6Xew3PQ34Lq9+CR/rB67d5I6VFwiQiEkKgwsNFfLJh5zGNPwi14oFuL/3sJJ4dP4CcjBQmv7WKQfe9zW3/+pTVW3dXvROpfxo0giG3wg0fQ/Zl8MEUmJwN7z/izbV0HCoqcnxT1IRlhzJ0wlMHRdxI5c83FbCv8HCtNChXV/FAtwEdm/H1tt08sWAtz3+Ux8zFGxnatTk/Pbmj7uh2PEpqCSMnQ/9r4c07YPbtXq+k4XdC9/Pr5Yyrzjm27jrAV9/u8h5bdrHSf+wvvA6A394zh/QmDenVNoXebVPo1TaFHq2TadhA84KFS8QlhJIBaR3C034QrBPSEvnDBT355emd+b9F6/m/het1R7fjXYtMuPx5rwpp9u/hH1dCej84815o2y/c0VWoYG8hX23xfvS/+vZ7Vn67m6+27KJgX+mYm+ZJcXRpmcTo/u1IXPIIqVG72D/kLpbm7WTphp288ql3e5ToKKNLiyR6tU0hu20y2W2b0Kl5ItGaVbhWRFxCWLz2O9o3S6B5Uv2YgKx4oNt1p57AC59sYur80ju6XXlSey7tlxH2thAJsU7DoOMQWPoMvH0PPHE6ZF7gzZHUtEPYwtp38DCrtnpn/Cu37OKrLbv56tvv2fJ9adVPUnwMXVsmcW5WK7q0TKJziyS6tEiiSaMGJWWWf/opAJmndCxZtm3XAZZt3MmyvJ0s3biTVz79hpmLNwCQ0CCanm2Syc5IITs9heyMFFo2jteVcg2IqIRQVORYsj6f07u1CHco1RYfG82ofhlcktuWuSu38ti8Nfzh1RVMfmu17uh2PIqKhpwrIPNCeP9/4P3JsOIV6DceTvkVNKy5K9zCw0Ws277HP+MvTQDr8/eWDJ2Ii4nixBaJnNQpla7FP/wtk476hzotKY7h3VswvLv33SwqcqzbsYelG3eybONOluYVMH3BOg76U8A0T4rzryK8R8/0ZJ0YhUBEJYTV23azc29hrY8/CKWoKGNo1xYM7dqCzzcV8Pj80ju6nd2zFT89uQNZ6SnhDlNCJS4RTrsN+oyFd+6Fhf/rXTmceivkXgMxDareRwWKihybdu47oo7/q2938fW23RQe9n75o6OM9s0SyGydzAW90+nSMpHOLZJo16xRjVbjREUZHdMS6ZiWyIU56QAcOHSYLzfv8hKEnyje/MK7PbuZV83aK720qqlLyyQaxKhatToiKiEs9m+I068ONigfjR5tvIFut47oyoz31zHzgw38Z9k39OvQlPG6o9vxpXFrb+xC/+tg9u/g9d/A4sdg+F3Q7UeVNjw759i++yArt+xixbe7WOkngFVbdrHnYOmYlzYpDenSMokhXZqXnPV3TGtUZ27+FBcTXXJFMNZfVrC3kGV5O0uSxNyvtvL8x94dEBvERJHZunHJNtltU8homqCqpkpEVEL4cF0+aUlxtGuWEO5QQqp1SkN+e3Y3fj60k+7odrxr2dMb7bx6jpcYnhsDGQPhjHshvQ/f7y9k1ZZdfPXtbj8BfM/KLbvJ33OwZBfNGjWgS8skfpzbtqSev3OLRJLqYZVLckIsp3RO45TOaYCX/Dbt3FdyBbFsYwHPLva+EwApCbH+VYT3yEpPpplualUishLC2nz6tT9+u20WD3S7clB7Xv38W6bOX1NyR7fLB7TjCt3R7fhgxv72Q/n6vFc5sPhJunwxmUZThzI76mQm7ruYPOf9ODZqEE3nlkmc0b0FXVp6jbudWyYd1/8HzIz0JgmkN0ng3KzWABw6XMTKLbu9BusNXsP1/7y9iuKZYjKaJtCrbQq90pPpnZFCZuuam/SyrouYhHCg8DDfFOxnfPu63d00FGKioxjZqzU/ymrF4rX5PD5/DZPfWsUU3dGt3jl0uIj1+XtLqnmK6/vXbd/j/6B1oUn0Q9yS9DoXH/g3Q+M/IK/LWGKH/JLWLVoetyc/1RETHUX31o3p3roxo/plALDnwCE+21RQUtX00bp8/rPsG698lNGlZRLZ/tiI3m1T6JgWGV1fIyYh7DpwCKBeNyhXl5nRv2Mz+lcw0G3cyR0Y2LGZfjTqAOccmwv2lzbwFtfzb93NwUNezxozaN+sEZ1bJHJuVmu6tEiiS8tE2jVrRGz0hVAwAd6+h/bLpsL652HIbZB7FUTXv6qgmtYoLqZkEGixrd/v96qa8ryqppeWfsMzH3hdXxPjYkq6vhZXObVMrh9d16sjchLC/kMkxcXQtWXjcIcSFoED3Z5etIGnFq7jssc/0EC3MMjfc7CkK+cK/+/Kb3eVnLQAtEqOp3OLJE7qlErnFkl0bZnECWmJlY/iTW4DF/wNBlwHb9wOr90Cix+F0ydCl7Pr5Yjn2tS8cTxnZLbkjMyWgNcLa8320q6vy/J2MnX+mpIeWC0bx9OrbXJJ99eebZLrZTtMoIhKCP07No2Iy77KNEuM48bhJ3LtqR2PGOh232sruMof6CahsefAoZLpGkobeXcdMYdPcsNYurRM4oKcNiV9+Ts3TyI54Rh+WFr18u7vvPIN7/4Lz14G7QbDGXdDm5wQfLLIEBVldGqeSKfmiVzcx+v6ur/wMF9s/v6Irq9vLC/t+topLbGkqim7bQpdWibVqxOtiEgIhYeL6uz8ReFSdqDb4/PWlgx0G+6GMTz2UxJ37Al3mPXC5qIU9rkGrF66KWAU7y425pfeFa9hbDSdWyRyWpc0r4HXb+RNS4qrmSo7M+gyAjoNh49nwDt/hMdPg6xLYOjvIaVt6N8zAsTHRpOT0YScjNK2yO/2HCypZlq68TveWrGVf3zkdX2Ni4miR5vk0iSRnkLbpg3rbDVtRCSEXfu9S/G6NMNpXVHeQLeXluby74P94IG54Q6vnrje+/PsUmKijI5pjchu24RLctuWnPW3bZIQnjEh0THQdxz0/Aks+DMs+it88SIM+C8YfDPER2YVaig1adSAIV2aM6RLc8BrD8r7bh+flHR93cnTi9bzxIK1ADRt1IBe6aVVTb3SU46Y2iOcIiYhmEFWenK4Q6nTige6XbD6t3x2KIM2I38f7pDqhU0v3UOsHeK0a/9Mh9RGdXN0bHxjGD4Bcq+Gt++GBQ/Bx095o6BzrvQSh4SEmdG2aQJtmyYwspfX9bXwcBFffbvriPaIuSu3lUwF0q5ZQklyyM5IoXurxkd2fa2l261GxP+C5IaxNIgx4mIis29xdaVF7WJog+Vk+lMGSOWWv/45AF1aJoU5kiCktIULHysd8fzKL+GDR+H0u6HzmWp4riGx0V7VUY82yVw+oB0Au/YX+l1fvaqmD9bk8+JSr+trctR+zk39llMbbSDTreKEwpXkRdd8NV9EJISUhFhSqN+t/yIh1SYHrnwFvnrVuwfDzEugwylwxj1eo7TUuKT4WAadkMqg9imwdQ9sWs/etR9weONHJH6/GvvewfewtqgFr7m+FBFPpxqOKSISQlUyW6kqSSKQGXQ9B048A5ZMh7l/hEdPhV6jYOjvvG6sElrOQcFG2PQR5C3x/n6zFA55HRASGjaFNn0g52Jok8vhVr05tKfva5DDAAAQaElEQVQB6//2a/rFrK7x8JQQRCJddCz0Hw+9LoH5f4JFU2D5CzDoZ3DSjRBXD6rC6qr9BbDpY9i0xPubtwT2bPXWRcdBqyzoc6WXBNL7QJMOR1TbRQMnJsLpDT6rlXCVEETEE5/sDWLLvQbemgjzHoCPnoTTfgu9x6jhuSqHC2HL5/7Z/0deEti+snR9sxO9mx+16eM9WvQ4punLa4L+hUXkSE3awcVPwIDrvYbnl2/yGp7PuNsb16CGZ6/qZ+f60mqfTR/B5mVwaL+3PiEV0nO97r5tcrxHDd7UKFSUEESkfOm5cNVr8OV/YM4EeOZi79aeZ9zjTcMdSfZ951f9BNT9793urYuJh1bZ3pVVeh9okwspGfUycSohiEjFzKD7SOg8ApZMg3fvgyknQ/Zor+G5catwRxh6hw7Cls/8ah+/6mdHcYOuQWpnr4tuSdVP5nEzgaASgohULaaBN2leccPzB4/C8n/BoJ/DoBu8W33WR85B/prSht+8JfDtp3DYv6FQYgvvjL/XKO+KqXVvr63lOKWEICLBa9jEqzLKvQbeugveneQ1PA+93btqiKrjgz/35h9Z7bPpI9jn3VqX2ASv6qf/tV4SaNMHktPrZdXP0VJCEJHqa9oBfjzDmxPpjdvhpZ973VXPuNvrSVOJWhv3c+gAfPuZ/+PvJ4D8Nf5Kg+bdvHEYbfp4Z/9p3SK+J1WVn97MpgHnAludcz3KWT8auNV/uRu43jm3zF93I/BTwIDHnXN/8Zc3BWYB7YF1wE+cc98d64cRkVrWth9cM9ubMG/OBHj6QjhhmHcV0aJ77cXhHOz4uvSHP2+JlwyKCr31Sa29nj45V3hn/62zNb6iHMGkwxnAI8BTFaxfC5zqnPvOzM4CHgP6m1kPvGTQDzgIvG5mrzjnVgG/Ad5yzt1nZr/xX99awf5FpC4zg8zzoctZ8OFUePd+mHIS9L4cTvsdJLUI/Xvu2R5Q9eMP+tq/01vXINGr6x/436Vn/41bhz6G41CVCcE5N8/M2ley/v2Al4uA4hnRugGLnHN7AczsXeAC4H7gPGCIX+5JYC5KCCL1W0yc9yPcaxTMexAWPwafPQ+Db/KWN2h0dPst3AebPz3y7H/nem+dRUHzTOh+nvfD3yYX0rrU/baMOirUFWbXAK/5zz8H7jWzZsA+4Gxgib+uhXNuM4BzbrOZNQ9xHNVz1SthfXuR40pCUxjxB+h7Dcy5E9651+uyOvT30OvSyrctKoIdq448+9+yHIr824s2Tvf6+vcd5539t84++kQjPxCyhGBmp+ElhMEAzrkvzWwS8CZe28Iy4FDFe6hwv+OB8QAZGbq9o0i90ewEuOT/YMMir+H5xf+CRX/z6vsbpnhldm8N6PGzBDZ9AgcKvHVxjb2qn0E3+Gf/fSCpZfg+TwQISUIwsyxgKnCWc25H8XLn3BPAE36ZPwB5/qotZtbKvzpoBWytaN/Oucfw2iXIzc2tnbtEiEjoZAyAcXO8cQtz7oSdG6BBEvy5JxRs8MpYtDfAq+dFpV0+UztDVB282dBx7JgTgpllAP8CxjjnVpZZ19w5t9UvcyEw0F/1EjAWuM//++KxxiEidZgZ9LgIupwD/9sf9mzzzvr7X+v9bZkFDRLCHWXEC6bb6Uy8BuBUM8sDJoB3txnn3BTgDqAZ8Ff/xtGHnHO5/ubP+20IhcB/B3QtvQ94zsyuATYAPw7ZJxKRuis23hvslZwOP54e7mikjGB6GY2qYv04YFwF606uYPkOoPLRKyIiUqtUQSciIoASgoiI+JQQREQEUEIQERFfZE/tJ+Wa2OwBwJt9UEQih64QREQEUEIQERGfqoxEjlGt3fBFpIbpCkFERAAlBBER8anKSESkjqutakklBJFjpRssyXFCCUF+YNa1A6suJCLHnYhICPqBExGpmhqVRUQEUEIQERGfEoKIiABKCCIi4lNCEBERQAlBRER8SggiIgIoIYiIiE8JQUREACUEERHxKSGIiAighCAiIj4lBBERAZQQRETEp4QgIiKAEoKIiPiUEEREBFBCEBERnxKCiIgASggiIuJTQhAREUAJQUREfEoIIiICKCGIiIivyoRgZtPMbKuZfV7B+tFm9qn/eN/MegWsu9nMlpvZ52Y208zi/eUzzGytmS31H9mh+0giIseZq17xHjUsmCuEGcCIStavBU51zmUBdwOPAZhZG+AGINc51wOIBi4N2O4W51y2/1h6NMGLiEjoxFRVwDk3z8zaV7L+/YCXi4D0MvtvaGaFQALwzdGFKSIiNS3UbQjXAK8BOOc2AQ8CG4DNQIFzbnZA2Xv9aqY/m1lciOMQEZFqCllCMLPT8BLCrf7rJsB5QAegNdDIzC73i98GdAX6Ak2Lt6lgv+PNbImZLdm2bVuowhURkTJCkhDMLAuYCpznnNvhLx4OrHXObXPOFQL/AgYBOOc2O88BYDrQr6J9O+cec87lOudy09LSQhGuiIiU45gTgpll4P3Yj3HOrQxYtQEYYGYJZmbAMOBLf5tW/l8DzgfK7cEkIiK1p8pGZTObCQwBUs0sD5gAxAI456YAdwDNgL96v+8c8s/oPzCzfwIfA4eAT/B7IAHPmFkaYMBS4LpQfigREam+YHoZjapi/ThgXAXrJuAlkLLLhwYboIiI1I4qE4KISEjVwgArOTqaukJERAAlBBER8SkhiIgIoIQgIiI+JQQREQGUEERExKeEICIigBKCiIj4lBBERAQAc86FO4agmdk2YP1Rbp4KbA9hOKGiuKpHcVWP4qqeuhoXHFts7ZxzVU4XXa8SwrEwsyXOudxwx1GW4qoexVU9iqt66mpcUDuxqcpIREQAJQQREfFFUkJ4rOoiYaG4qkdxVY/iqp66GhfUQmwR04YgIiKVi6QrBBERqcRxlxDMbISZfWVmq83sN+WsjzOzWf76D8ysfR2J60oz22ZmS/1HuXehC3FM08xsq5mVe09r80z2Y/7UzHJqOqYg4xpiZgUBx+qOWoqrrZm9Y2ZfmtlyM7uxnDK1fsyCjKvWj5mZxZvZYjNb5sd1Vzllav37GGRctf59DHjvaDP7xMxeLmddzR4v59xx8wCiga+BjkADYBnQvUyZ/wKm+M8vBWbVkbiuBB6p5eN1CpADfF7B+rOB1/DufT0A+KCOxDUEeDkM/79aATn+8yRgZTn/jrV+zIKMq9aPmX8MEv3nscAHwIAyZcLxfQwmrlr/Pga89y+Av5f371XTx+t4u0LoB6x2zq1xzh0EngXOK1PmPOBJ//k/gWFmZnUgrlrnnJsH5FdS5DzgKedZBKSYWas6EFdYOOc2O+c+9p/vAr4E2pQpVuvHLMi4ap1/DHb7L2P9R9lGy1r/PgYZV1iYWTpwDjC1giI1eryOt4TQBtgY8DqPH34xSso45w4BBUCzOhAXwEV+NcM/zaxtDccUjGDjDoeB/iX/a2aWWdtv7l+q98Y7uwwU1mNWSVwQhmPmV38sBbYCbzrnKjxetfh9DCYuCM/38S/Ar4GiCtbX6PE63hJCeZmybOYPpkyoBfOe/wHaO+eygDmUngWEUziOVTA+xhuK3wv4H+DftfnmZpYIPA/c5Jz7vuzqcjaplWNWRVxhOWbOucPOuWwgHehnZj3KFAnL8Qoirlr/PprZucBW59xHlRUrZ1nIjtfxlhDygMBMng58U1EZM4sBkqn56okq43LO7XDOHfBfPg70qeGYghHM8ax1zrnviy/5nXOvArFmllob721msXg/us845/5VTpGwHLOq4grnMfPfcycwFxhRZlU4vo9VxhWm7+NJwEgzW4dXrTzUzJ4uU6ZGj9fxlhA+BE40sw5m1gCv0eWlMmVeAsb6zy8G3nZ+C0044ypTzzwSrx443F4CrvB7zgwACpxzm8MdlJm1LK43NbN+eP+Pd9TC+xrwBPClc+6hCorV+jELJq5wHDMzSzOzFP95Q2A4sKJMsVr/PgYTVzi+j86525xz6c659ni/EW875y4vU6xGj1dMqHZUFzjnDpnZz4A38Hr2THPOLTezicAS59xLeF+c/zOz1XiZ9dI6EtcNZjYSOOTHdWVNx2VmM/F6n6SaWR4wAa+BDefcFOBVvF4zq4G9wFU1HVOQcV0MXG9mh4B9wKW1kNTBO4MbA3zm1z8D/BbICIgtHMcsmLjCccxaAU+aWTReAnrOOfdyuL+PQcZV69/HitTm8dJIZRERAY6/KiMRETlKSggiIgIoIYiIiE8JQUREACUEERHxKSFInWJmh/3ZJZeZ2cdmNijcMRUzsxlmttbMrvNf32lmzsw6BZS52V+Wa2Y3mtlfAtY9amZzAl7/3Mwml/M+d5rZrwJeDzSzx82bgfORasQ7xMrMmOl/hov958+YWX7xaxElBKlr9jnnsv0pFm4D/lidjf2+5TXpFr9ff7HPOLIv+MXAF/7z94HAhJYNJAfEOAh4L4j3HAG8fnThVsw5N5ofDtyUCKaEIHVZY+A7+OHZrpk9YmZX+s/XmdkdZrYA+LGZzTWzSebNeb/SzE72yx1xhm1mL5vZEP/5bjP7k39V8paZpQUZ47/xZ641s454k41t89d9AnQ2s4Zmlow3UG0p0NNfPwgvaWBmt5t3v4w5QJcy7zEMbz6dEmZ2jpktNLNUMzvBzBaZ2YdmNtHMdiNyFJQQpK5p6FcZrcCbAvjuILfb75wb7Jx71n8d45zrB9yEN9K5Ko2Aj51zOcC7QW4D8D2w0bzJ0UYBs4pX+LNRLgX64t8bAVgEDDKz1ngDQzeaWR+8q4zewIV+eQDMm2+o0DlXELDsAuA3wNnOue3Aw8DDzrm+1IG5pqT+UkKQuqa4yqgrXlXJU8Vz8FRhVpnXxRO8fQS0D2L7ooB9PA0MDmKbYs/i/aCfD7xQZt17eFcCg4CF/mMQ3nQT7/tlTgZecM7t9WcpDazGOQOYHfD6NOBW4Bzn3Hf+soHAP/znfw8oW9E0BJqeQMqlhCB1lnNuIZAKpOHNKRP4/zW+TPE9ZV4Xz1R5mNI5u6raxxFvX41Q/4M3l9CGcqadLm5HGIiXDL4EuvPD9oOK3u8sjmw/WIN3V7TOQcS1A2hSZllTYHsQ20oEUkKQOsvMuuJNBrgDWA90N++essl49erVtQ7INrMo82540i9gXRRegzDAZcCCYHfqnNuHd9Z+bzmr38erLkpzzm31J5TbhtfuUHyFMA+4wG9rSAJ+BCWzmGbhVTsVW49XrfSUld7kZhFwkf88sIF7FdDazLr5+2sH9CqzP5ESx9Vsp3JcaBgwY6cBY51zh/Hq6Z8DPsX7ofvkKPb9HrAWr2fQ53g3jSm2B8g0s4/wGoYvqc6OA9ouyi7/zsy2AcsDFi/EqzJa5pf52Mxm4f1Qrwfm++X6AJ+UnZXUOfeVmY0G/mFmP8JrJ3nazH4JvOLHj3PugJldDkw3s3igEBgX2B4hEkiznYrg9TJyziVWUWYG3o3P/1lLMf0O717c5SabgHIJeG0vzswuBUY554K6Z3dtfyap23SFIBK8AuBuM0stMxahRjjn7gmyaB/gEb+KaSdwdTAbmdkzeG0ZSgYC6ApBRER8alQWERFACUFERHxKCCIiAighiIiITwlBREQAJQQREfH9PxHi/J94+OkaAAAAAElFTkSuQmCC\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXoAAAEKCAYAAAAcgp5RAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy8QZhcZAAAgAElEQVR4nO3deXxV1bn/8c+ThExkgoxACAGZZJApMihQ0aqIbdVWFMdqtVq19d7WodVbW4eqV6xtbweraB1+aqutVq1VWxWUIiCTzMigghCZQpjClHH9/tg7yQESMpDkJDvf9+uV1znZZ+9znrMJz1nnWWuvZc45REQkuCLCHYCIiDQvJXoRkYBTohcRCTglehGRgFOiFxEJOCV6EZGAiwp3ADVJS0tzubm54Q5DRKRNWbRo0Q7nXPqR21tlos/NzWXhwoXhDkNEpE0xsy9q2q7SjYhIwCnRi4gEnBK9iEjAtcoavYjIkUpLS8nPz+fQoUPhDiXsYmNjyc7OpkOHDvXaX4leRNqE/Px8EhMTyc3NxczCHU7YOOcoLCwkPz+fnj171usYlW5EpE04dOgQqamp7TrJA5gZqampDfpmo0QvIm1GQ5P8xY/P5eLH5zZTNOHT0POgRC8i0kAbNmzggQceCHcY9RasRP/0ud6PiEgz6tq1K7/73e+Ouc/u3bu55pprGDlyJBs2bCA/P58+ffrw9NNPU1JSUuMxL7/8Mk8++SSTJk1i27Zt3H///Vx++eXMmzfvuOKtV2esmQ0GVjnnyo/nxcwsyTm393ieQ0Qk3KKjo4mJiTnmPikpKYwbN47y8nJyc3N55JFHeOmllxg+fHitx9x3333MmzePyy67jMcee4zU1FSeeuopoqKOb9xMnUeb2ShgBpAKlIdsnwx8DTgBmOyc22JmpwODAAM+cs7NM7NUYA4QCfwFuOu4IhaRdu+eN1ayanPdbcZVW7x96lOnH9A1iZ9/fWCtj69bt47nnnuO2NhYBg0aBMCDDz7Ia6+9xne+8x2uv/56HnzwQQYMGMD8+fO5//77q4594IEHOPvssw9L8u+99x6bNm1i+vTp3HzzzZSUlLB582b+9re/MX78eGbPnk1KSgrDhg1j1KhRdcZ/LHWWbpxz84CC0G1mFgmsc859G3gZONnfNhX4HfBb4EF/96uB85xzvZ1zSvIi0ibt2rWLs88+m0mTJvH6668DcP311/P222/z05/+lNLSUl5//XVGjx7NjTfeWHXc3LlzmTp16mHlmoqKCn77298SFxfH4MGDWbBgAWPHjqVjx45MnjyZHj16MGjQIPLy8o47yUMjx9H7JZwlZhYFpAOPAznADuevNm5mpWbWy3/8n2aWD3zLOVdY03Oa2XXAdQA5OTmNCUtE2oljtbxDVbbkX7p+zHG/5uDBg3n22WfJzs6mvNwrbsTHxxMbG0u3bt3YvXs3t99+O6NHj+aRRx7hm9/8JgBjxozh3HPP5YILLmD27NmccMIJFBQUEB0dzZQpU447rvpodGeseeN7rgQuBKYAWUBRyC5FQKZz7sdAP2AJcE9tz+ecm+acy3PO5aWnHzXLpohIWD344IN06tSJvn374rdnq3Tu3Jn09HR69uzJhx9+yM9+9rPDHp88eTK33XYbkyZNorCwkM6dOzNnzhy2bNkCwKuvvtqssTc60TvPU8CZeMm+EEgI2SUB2OHvWw7ci9fqFxFpc7p27cqvfvUrPvzwQ5YvX06fPn2YNm0aTz75JA899BAAt9xyC4sXL+aCCy5g9+7dzJw5k2XLlrF+/XouvfRS9u/fz1lnncXKlSu5++67GTduHJdccglDhgxh9erVFBYWMmPGDPbs2cOKFStYtGgRe/bsOe7Y7chPphp3MtsA9AdKgDTn3PaQx7KAHzrnfmxmHwLj/IdmOefGmlmMc67YzPoD33TO1Tn4NC8vzzVqPvrKoZVXv9nwY0WkVfvkk0848cQTG3RMU5ZuWpuazoeZLXLO5R25b31G3eTh1dnPAjYCd5rZDXgjcR7B+1Zwn7/7HcAtlffNrCfwhplNw/uQeKRR70hEpBGCmOAbo85E75xbCHQM2XSRfzukhn1nAbOO2Dyo0dGJiMhxC9aVsSIichQlehGRgFOiFxEJOCV6EQmuFpzocO/evTzzzDPMmnVkN2X4KdGLiDSBpKQklixZwsqVK1vVzJWgpQRFRJpMSkpK1W1rmbkSlOhFROrlwIEDPPXUU8THxzNr1izOPPNMYmNjmT9/PmPGjOG8886r8bhwz1wJSvQi0ha9/RPYurzu/bYu827rU6fPGgzn/G+tD0+dOpVrr72W7OxsCgoKePHFF/nHP/7BpEmTGDBgAOecc85Rx8ydO5fXXnuNCRMmVG2rnLny0ksvrZq58qabbqqaubJyGuSsrKwmSfKgRC8iUi8LFy7k1ltvBWDChAnMnDkTgNjYWDIyMti2bdtRx7SGmStBiV5E2qJjtLwP04TzX2VnZ/P888/zve99j6ioKD755BPKysqIiooiKiqKrl271njc5MmT2bhxI5MmTWLOnDmHzVzZpUsXXn31VS644ILjju9YNOpGRKQefvKTnzBt2jTGjh3Lhg0buO+++/jFL37BM888w1133cXBgwdZunQpK1asYNu2ba1m5kqo5+yVLU2zV4rIkRoze2WQc0JDZq9Ui15EJOBUoxeR4ApgS74x1KIXEQk4JXoRaTNaY59iODT0PCjRi0ibEBsbS2FhYbtP9s45CgsLiY2NrfcxqtGLSJuQnZ1Nfn4+BQUF4Q4l7GJjY8nOzq73/kr0ItImdOjQgZ49e4Y7jDZJpZv2rAXn6haR8FGiFxEJOCV6EZGAU6IXEQm49pXoVZMWkXaofSV6EZF2SIleRCTglOhFRAJOiV5EJOCU6EVEAk6JXkQk4JToRUQCToleRCTglOhFRAJOiV5EJOCU6EVEAk6JXkQk4JToRUQCrl6J3swGm1lkcwcjIiJNr841Y81sFDADSAXKQ7ZPBr4GnABMds5tMbPTgUGAAR855+bVtK3p34aIiNSmzkTvJ+vDll33W/frnHPfNrP/Bk42szeBqcDJ/m7TzezMI7cBpzdZ9CItqXItg6vfDG8cIg3UqBq9c67cObfEzKKAdOBdIAfY4XxAKZB75DYz69VEsYuISD00ujPWzAy4ErgQmAJkAUUhuxQBGTVsy6zl+a4zs4VmtrCgoKCmXUREpBEanej9RvpTwJl4yb4QSAjZJQHYWcO2HbU83zTnXJ5zLi89Pb2xYYmIyBEalOjNLMLMMo7YXAKscM6tBRLNByQ459bUsG1d04QuIiL1UZ9RN3l4dfizgI3AnWZ2A95InEfwPizu83e/A7gl5H5t20REpIXUZ9TNQqBjyKaL/NshNew7C5hV17Zm4xy48rr3ExFpR+pM9G3K5o8hJqHu/URE2pFgTYEQHQ+H9oY7ChGRViVYiT4mCcqLYU9+uCMREWk1Apbok73bL+aGNw4RkVYkWIk+uiNYJGycE+5IRERajWAlejOvfKMWvYhIlWAleoDYJCj4BA7sDHckIiKtQvASfUySd7vxo/DGISLSSgQw0SdCZHSNdfqVW/awcsueMAQlIhI+wUv0FgHdRsAX6pAVEYEgJnqAnDGwZSmU7A93JCIiYRfMRN/jVKgog/wF4Y5ERCTsgpnou4/0SjgaZikiEtBEH5sEmYN04ZSICEFN9AA9ToFNC6CsJNyRiIiEVXATfc4YKDvodcqKiLRjwU30PU7xblW+EZF2LriJPiEDOp+gDlkRafeCm+jBa9VvnAsVFeGORETk2J4+1/tpBsFP9Id2Q8HqcEciIhI2wU70OWO8W9XpRaQdC3ai75QLiV00742ItGvBTvRmXqv+i7ngXLijEREJi2AnevDq9EWbYfcX4Y5ERCQs2keiBw2zFJF2K/iJPv1EiE1Rh6yItFvBT/QREZAzWi16EWm3gp/oweuQLVxHpCsNdyQiIi2ufSR6v04f7w6EORARkZbXPhJ9l6EQFUfHCi0tKCLtT/tI9FHRkJ1HvFOiF5H2p30keoAepxDrDhHtDsG+Aig5oIuoRKRdiAp3AC0mdyw28yH6lK6DX/b2NxpEd/R+OsRDdAJEx4ds82+j/cc6VD4Wsl/VPiE/UXHeaB8RkVagHSX6cXwRlUukKyP77P+Gkn1eq75kP5Tu924rfw7thaKth+9TdrBhr1frh0THY3y41LZfyP76ABGRBmo/id6MfRGJAGSP/G7Dj68oh9IDh38gHPYhccD/YNh/9H6llY/tg33bvdvKfUobOBKoQ3z9v1kc60MjuqO3nm5k+/kTEGmv9L+8viIiISbR+2lKFRUhSX9/DR8kBw7/ZhH6IRH6s3/H0d9S6sXg0TGQMQAyB0DGQO82ubs3KZxII138uHeR4kvXjwlzJKJEH24RERCT4P00pYoKr9xU44eG/w1k5kNQVuwl9U3zYMXL1cfHJEPGiX7yHwCZA73buJSmjVNEmp0SfVBFRFSXaGrz8f/zbi/7q3d7cDds/wS2r4Rtq2D7Klj+MhTvrT4mKfvw5J85EFL7eENYRaRVUqKXanEp0GOM91PJOdiT7yX9bSurbz+bARVl3j4RUZDWt7r8kznIu5+crfKPSCtQr0RvZoOBVc658uN5MTNLcs7trXtPaTXMIKW799P37OrtZSVQuM5v+fvfADZ+VHv5J3OgV//POFHlH5EWVmeiN7NRwAwgFSgP2T4F+AGQCVzpnJtjZlcAxcAA4Fnn3HozSwXmAJHAX4C7mvxdSKOs3LIHgIGNOTgqurp0w+Tq7UeWf7at9Mo/C5+q3qey/FOZ/DMHqPwj0ozqTPTOuXlmVhC6zczigHLn3Klmdilwl5ldDlzinJtkZl2APwDfBK4GznPOrW6G+A9zrMR1qLScPxefytDIDY1LbFI/9Sn/VJaADiv/dIC0PtWdvpW3Kv+IHLfG1uhLgVf8+4uBSUBvoATAObfFzIb7j6cD/zSzfOBbzrnCmp7QzK4DrgPIyclpZFi1m7F6Oy8Uj+cFxvPnR2fz3XG9OHtgFpERSiLNrt7ln5XeugHL/1a9T0xySOdvyPDP2OSWfx/SID8rvM2/92FY45BGJnrnXFnIr+OBqcAW4CS/tV8GxPj7/tjM7gQeAe4Bvl/Lc04DpgHk5eU1+SQ089fvJIZSrop9n3/tP58bX/iY7p3juObUnkzO607HGPVLt7h6lX/8EtDyv8HCkO6d5O5HJ3+Vf0RqdFzZzcx6ARudc8v8328BfgHkAxsr93POlZvZvcAzx/N6x2PBhp30i/ySb0Qv4vZbfsO7q7byxKz13P3GKn717louG92Dq07JJTMpNlwhSqU6yz8rqod/fjb9iPJP36PH/qv8I+1cgxK9mUUAac657WaWAfR3zr1lZrFAknPuVeBVM7sLv3VuZjHOuWIgA/ioieOvl6JDpXyyZS8Xd8gHIDLCmDioCxMHdeHjjbt4ctbnPD7zM56c9TlfH9KV747rxYldksIRqtSmzvJPSO2/mco/x9V5LRJG9Rl1k4dXZz8Lr5V+p5ldBbwOJJrZVMABw/z9pwAJzrk/mVlP4A0zm4ZXv3+kWd5FHRZ9sYsKBwOjNh312PCcTjx62Qg2Fh7gqdnr+evCTfz94y8Z1yeNa8f1YnyfNEytwdbrsPJPiIO7vPJP1dj/+pR/BnodwpEdWvY9iDSz+oy6WQiEXl55kX971AQWZjYRb7z9i/6x64FBTRDncVmwYSeREUb/yC9r3ScnNZ67vzGQH361Ly/M/4JnZm/g20/Np19mIteM68l5Q7sSExXZglHLcYnr5C0h6S8jCfjln02Hj/2vs/wzyLuf1C0870OkCTRpD6Rz7l9N+XxNZcH6XQzqmkTc3roXB0+O78CNp/Xm2rG9eGPpZp6Y9Tm3v7yMh/+9hqtOyeWyUTmkxKvDr00yg5Qc76ffxOrtZSWwY+3hV/8eWf6JTSa3tJT9luBNYx2r0p40reYsDQZ+qElxWTlL8ndz5egesKz+x0VHRfCtEdl8c3g3Pvx0B0/MWs/D/17D72d8yuS8bK4Z25MeqceYR0bajqhoyBrk/YQ6ovxji14ko2I7/HYYTLgDhl+laZ6lTQj8X+my/D2UlFVwcs/ODUr0lcyMcX3SGdcnnTVbi3hy1ue8OH8Tz330BWcNyOS68b0Y0aNz0wcu4XdE+Wf9sgXEVhzghPQsePMWmPc4nHmf1zmsfhxpxQK/XNH89TsBODn3+JNxv6xEHp48hA9/PIEbTzuBjz7fybf+OJcLHp3NW8u3UF6hNWiD7lBEPFz1Jkz5M7gK+MvF8OzXYcvScIcmUqvAJ/oFG3bSOyOBzh2brq6ekRTLbWf3Z+4dp3PveQPZub+EG1/4mNN++T5Pz17P/uKyup9E2i4z6H8u3PgRnPOwV9p5/Cvw6g2wp/YOf5FwCXSiL69wLNqwq0la8zWJj47iyjG5zLjlNB67fAQZibHc88Yqxjw4nYf+tZptew81y+tKKxHZAUZdB/+1BE69GVa8Ar8bAdPvg+KicEcnUiXQiX711r0UFZcxsmenZn0d7wKsLF654RT+fuMpjO2TxuMzP2PsQzP40V+X8MkWzcwcaLHJcOa98P0FXkt/1i+9DtuFT0G5vt1J+AU60S9owvp8fVVegPXBrRO4bFQP/rViK+f83ywuf3IeH6zZjnOq4wdWpx5w4Z/g2umQ2hv++UN47FRY9643hl8kTIKd6DfsomtyLNmd4lv8tSsvwJr7kzO4fWI/1m0v4qqnFzDxN7P468JNFJcd1xou0ppl58HVb8NFz0F5CbxwITx3PmxdHu7IpJ0KbKJ3zjF/w05vWGUYVV6ANev203lk8hDM4PaXlzH2off5/Yx17NpfEtb4pJmYwYBvwI3zYOJD3qicx8bBazfB3i3hjk7amUCNo7839WEAXgK+KDxAQVFxi5ZtjiX0AqzZnxbyxKzP+eU7a/nD+58xOS+b75zak9w0XYAVOFHRMPp7MORimPWIN/Z+5d/hlB/AKTdDTEK4I5R2IFCJPtT8DV59fmSYW/RHMjPG9kljbJ+0Gi/A+u64Xozo0UkTqQVNXCc46xeQdw1MvwdmPgSLnoEJ/wPDLoeItj2PUkWFI3/XQdZsK2LttiLWbC1i6b5rOOSiGf78IoZ0T2Fo9xQGd0vW2g9hENgzvmD9TlLiO9A7vfW2mCovwLptYj/+35wveH7eF/x75TaGdk/xV8DKJCoysNW19qlzT5j8DIy+Ef79P/DGzTDvMTjrPuj91XBHVyfnHAX7ilmz1Uvma7cVsWbbPtZtK+JASXW/U3anOLpG7CGWUlZu7srbK7YCEGHQJyORod1TqpJ/38wE/Z03s+Am+g07yevRmYg2sFRgRmIst57djxsnnMDLi/L504fruenP3gpY3zm1JxdpBazg6T4SrnkHVr0O7/0cnv8WnHCG1+rPHBDu6ADYc7CUdduKWOO30CsT+64D1ZMDpiXE0C8rgYtP7k6/zET6ZSXSJzORhJgoVj7wMwAG3n4bO/eXsHTTbpZs2s3S/N28s2orLy30pg2P7RDB4G7JVcl/SHYK2Z3i9K22CQUye2wvOsSGwgNcOqrp155tTpUXYF02qgfvrtrGk7M+5543VvHrd9dy6ShvBaysZK2AFRhmMPB86HcOLHgSZk71hmMOu9wr6SRmtUgYh0rL+XT7vpAWupfUt+ypvuAvISaKvpkJTBzUhX6ZCfTNSqRfZiKpCTH1eo3OHaOZ0D+DCf0zAO+bwcadB1hSmfw37ebZuV9QMms9AGkJ0QzJrm71D8lOITle6wQ0ViAT/YL1u4CWHT/flCovwJo4KKtqBaxp//mMP334OV8/qSvXjuvFgK6aJjcwomJgzE0w5BL4z8Mw/wlY/gqc+l9wyvchumk66cvKK9hQeIC124pYvbWItX5i31C4n8ppmqKjIuidnsDoXqn0zUykf1YifbMS6Zoc26QtbDOjR2pHeqR25Lyh3lz/JWUVrNlaxJL83SzZ6LX8Z6zZXnUJQq+0jn6LP5mhOZ04sUui1oiop2Am+g07iesQyaBuDVsqrjWqcQWsxV8ytnca147ryVf6pusrblDEd4aJD8LJ18J7d8MHD8Cip+H0n3ofAvXssHXO8eXug36n6L6qxP7Z9n2UlFcAXq08N7Uj/bIS+fqQrvTLSqRvZiK5qfFhq5dHR0UwODuZwdnJXDG6BwB7D5WyPH9PVat/9qc7eHWxN59Qh0hjQJek6pJP9xR6pnZsE+XalhbIRD9//U6G5aTQIUAdPEeugPXsnA1c9fQC+mYmcO3YXpw3TCtgBUbqCXDxc7DxI6/D9vWb4CO/w/aECYftWrivuKrUsrbqdh/7QibW65ocS9+sRMb3SatK6L0zEojt0Pr/XpJiO3Bq7zRO7Z0GeB9iW/ceYumm3Sz2k//Li/J5du4X/v5RVXX+yg+A9MT6lZeCLHCJvqyigk+27uXm0/uEO5RmUeMKWK8s4+F31vDtMT24bFQPOjXhTJ0SRjmj4dr3YOXfqXj3biKeO5/N6eN4Lf16PtyTztptRezYV33BXaf4DvTLSuRbw7tV1dD7ZiWSFBuc2raZ0SU5ji7JcUwc1AXwJi/8dPu+w5L/H2d+VjVteLeUOD/pJzO0eycGdUsiPjpwqe+YAvdu9x0qw7nWN36+qdV2Adbv3/+UySO6c81YXYDVFhWXlfN5wX5vlMs2r46+ZlsnCnbdy5WR7/CD7a9x/fYr6BU3kfm9r6dbdm8/oSeQnhDTLst4kRFGvyxvxM9FJ3cH4GBJOSs276ka6bNk027eXO5dkRxh0DczkWE5KVUdvn0zE4kMcMkncIm+6FAZURHGsJyUcIfSImq6AOulBZt4ft4XnHli5QpYugCrtSmv8EadhJZc1mwrYv2O/VUt0Q6RxgnpCQzP6US/kTn0zTyFouQ7SVz6OyYu/BMTP58FXf8betwE0RqNFSouOpKTczsfNiBjx75ilvot/iX5e3hr+Vb+Mt8b4hkf7fXpDe1eXfJp6g7ocApkoh/YLbndfTWDmi/AemeVLsAKJ+cc2/YWs3rr3sM6R9dtL+JQqdcxagY5nePpm5nIOYOy6OuPR89N7Uh0VA3/Xt2mwsjrvPH3M34BC5+G0++Cky6GCP371iYtIYYzTszkjBMzAe/fZkPhgcNa/c/M3lDVYZ2eGOPX+r2Sz+DsZJLj2mYZLFDZsKLCsa+4jJG5zTv/fGtX2wVY2Z38C7BO7k6CLsBqcrsPlFS10FeHtNT3HqruGM1MiqFvZiKXj+pB3yxv+GLvjISGN0zSesOUF2DDbHjnf+C178FHj8LZ90PP8U38zoLJzOiZ1pGeaR05f5g3xLO4rJzVW4pY6g/xXJK/m/c+2VZ1TK/0jtWt/uwUTuySVPOHcSsTqP/t+0rKcLTd8fNNraYLsO795yp+/d5aLhvVgzEVCaRF7At3mG3OgZIy1m3bF1JD9xL69qLiqn2SYqPol5XIN4Z29Wro/k+Td5TnngrXzvBWt5p+j7d+bd9zvIVQ0vs27Wu1AzFRkVVDNa8c423bc7CUZfm7q1r+/1lbwN8/9oZ4RkdGMKBr0mEln9zU+FZX8glUoi/yW05K9IcLvQBr8cZdPDlrPdP+8xlPuBs5IWIbHR+dHe4Q24SD+69kT0U8W3/+76qLeGKiIuibmci4Pun0y0qgX1YS/TITyUxqwY7RiAg4aTKc+HWY90eY9St4dDTkXQ2n3QEd01omjoBKjuvAuD7pjOuTDngln817DlVd1LVk025eWrCJZ+ZsqNp/SPcUhmYnM9Tv8K3vFcTNJXCJPq5DpIYXHsOwnE784bJObNp5gEd+8xAby9M0j049GcWkR+7hkgmjquroOZ3jW89ojQ6xMPaHMOwK+OB/vaUMl74E434Eo2+ADnHhjjAQzIxuKXF0S4nj3JO8IZ5l5RWs84d4Vtb7f/9+QdUVx9md4g5r9Q/qmkxcdMtdxxC4/+FJcYF7S82ie+d4vhs7HYCB1/wgzNG0DSsfuAWAgWfcFuZI6tAxDc79ZXWH7fR7vKR/xs9g0IXqsG0GUZERnNgliRO7JDFlpDfH1v7iMlZ8uaeq1b94427+ucwb4hkZYfTLTGRoTgpDuyVxcsIOksp3EecOHetlGh9fszxrmPTPStSarCKV0vvCJX+B9f+Bd34Kf/+u12F71v1ebV+aVceYKEb1SmVUr9SqbduLDvHJ2nXsXDuXyM2LyFi6ggFLPiPJDgKw38Wwp3AryalNO6FdoBI9cMy66MAubX/uG5EG6zkevvsBLP8rTL8XnpkE/b8GX73HG70jzadkP2xeAl8ugi8XkpG/iIy9+d5jEVG4LgPZ2/lCFnbox9uLPmVhRW9e7ZTZ5GEELtGLSA0iImDIFBhwHsz9A3z4a3h0lLfi1Vd+DB1T634OObaKcihYA18uhPyF8OXHsH0VOH9BlpQcbx2C7Buh2wjoMgTrEEcykAfErRrLN1lERETTl1KV6EXakw5xMP5WGH4lfPAgLHgClr4I42+Bkdd7HbpSP3s3+wl9kfezeTGU+MOVY5O9ZN7vFu+22whISA9bqEr0Iu1RQgZ87ddecn/3Z97PgifhjJ/DoG95l+tKteIivwQT0lov2uw9FtEBsgZ7U0ln50G3POjcq1V1eivRi7RnGf3hsr/C5x/Av38Kr1xT3WHbY0y4owuP8jIo+MRrpVe22AtWg/OmRqBTT68zu9sIL6lnDW7134SU6EUEep0G18+EZS/B9Pvg6YneBVhfvcebHz+onIO9X/oJ3W+pb14MpQe8x+M6eQn9xG94rfWuw9tkf4YSvYh4IiJh6KUw4HyY+3v48Dew5l8w8rsw/jZvBay27tBe2Pyx31r3RsKwz5/LJjIask7y+i8q6+qdewWijKVELyKHi46Hr9wOw78N798P8x6DJS/A+Nu9pB/VRlZsKi/1Rr2EdpgWrAH8a21Se3vfZLrlQfYIyBzUdt5bAynRi0jNEjPhG7+FUd+Dd+/yZslc8AR89W6v1d+aWrrOwe6N1eWX/IWwZSmUeRciEZ/qJfRB34Juw70STBC+odSTEr2IHFvmALj8Ffh0OrxzF/ztKsge6U2J3GmAv/4AAA0uSURBVH1krYc16wWKB3d7JZj8RVUXI7G/wHssKha6DPEmdes2wqutp/RoXR9MLaxeid7MBgOrnKsc+S8i7U7vM7xSx5I/ewue/OlMGHiBNySzc8/me92yEti2orr8kr8QCtdVP57WF3qf6ZVfuvklmMi2uUBIc6kz0ZvZKGAGkAqUh2yfAvwAyASudM7NMbMrgGJgAPCsc269mZ0ODAIM+Mg5N6/p34aItIiISBh+hZfg5/wO5vwWVr/pTaA2/lZvlMrxcA52bTh8aOOWpVDuz/XfMcNroQ+52CvFdBvuXZwkx1RnonfOzTOzgtBtZhYHlDvnTjWzS4G7zOxy4BLn3CQz6wL8wcwmA1OBk/1DpwOnN+1baICr3wzbS4sESkwCTLgDRlwF7//Cm1ZhyQvedAp510BUPacKP7DTq6lXll++XAQHCr3HouKg61CvAzg7z2utJ3dv1yWYxmpsjb4UeMW/vxiYBPQGSgCcc1vMbDiQA+xw/pSSZlZqZr2cc58f+YRmdh1wHUBOTk4jwxKRFpXUBc77A4y6wZsh818/gfnTvPH3zh2elMuKYeuKkKtLF8HOz/wHDdL7Q79zqi9EyhgAkepGbAqNOovOubKQX8fjtdq3ACf5rf0yIAbIAopC9i3CK/Ucleidc9OAaQB5eXmaa1ikLckaBFe86nfY/hT+egXEJHmllrdu95L71uVQXuLtn5DltdKHXe7ddhkKsUnhfQ8Bdlwfl2bWC9jonFvm/34L8AsgH9gIFAIJIYckADuO5zVFpJUygz5f9Ttsn4c3b4Wdn8LiLdB1mLfKVWVrPblbuKNtVxqU6M0sAkhzzm03swygv3PuLTOLBZKcc68Cr5rZXcA059xaM0u06kniE5xz62p7fhEJgMgor3a/5EWvE/Xa97xOXAmb+oy6yQPSgbPwWul3mtlVwOtAoplNxbvUbJi//xS8hP4n/ynuAG4JuS8i7UFEJETEK8m3AvUZdbMQ6Biy6SL/9qip7cxsIt54+xdDjp8FzDrOOEVEpJGatEvbOfevpnw+ERE5fq1nZnwREWkWSvQiIgGnqxHasXtTHwbgpTDHISLNSy16EZGAU6IXEQk4lW5E6qlZ51cXaUZq0YuIBJwSvYhIwKl0IyLSCjRnaVCJXqS+tHCNtFFK9O3YS9cfNV2RiARQoBK9EpeIyNHUGSsiEnBK9CIiAadELyIScEr0IiIBp0QvIhJwSvQiIgGnRC8iEnBK9CIiAadELyIScEr0IiIBp0QvIhJwSvQiIgGnRC8iEnBK9CIiAadELyIScEr0IiIBp0QvIhJwSvQiIgGnRC8iEnBK9CIiAadELyIScEr0IiIBp0QvIhJwSvQiIgFXr0RvZoPNLPJ4X8zMko73OUREpGGi6trBzEYBM4BUoDxk+xTgB0AmcKVzbo6ZXQPsBnoDy51zb5lZKjAHiAT+AtzV5O9CRKStu/rNZnvqOhO9c26emRWEbjOzOKDcOXeqmV2Kl7zPAS53zk3wW+4vAG8BVwPnOedWN334IiJSl8bW6EuBV/z7i4FC/36Bmd0GXAL8xt+WDvzTzD7wW/ciItKCGpXonXNlzrkK/9fxwFT//g+AK4FvA8v8fX8M9AOWAPfU9pxmdp2ZLTSzhQUFBbXtJiIiDXRco27MrBew0Tm3zN80FRgFPAc8Vrmfc64cuBfIqe25nHPTnHN5zrm89PT04wlLRERCNCjRm1mEmWX49zOA/s65t80s1v892zl3wDn3RyDN3y/GPzwD+KgJYxcRkXqoz6ibPLw6+1nARuBOM7sKeB1INLOpgAOGAS+b2fVAMfBrM+sJvGFm04AS4JFmeRciIlKr+oy6WQh0DNl0kX87pobd/1jDtkGNiEtERJpInYleRKRRmnFcuDSMpkAQEQk4JXoRkYBTohcRCTglehGRgFOiFxEJOCV6EZGAU6IXEQk4JXoRkYBTohcRCThzzoU7hqP4C5180cjD04AdTRhOU1FcDaO4GkZxNUxQ4+rhnDtq+t9WmeiPh5ktdM7lhTuOIymuhlFcDaO4Gqa9xaXSjYhIwCnRi4gEXBAT/bRwB1ALxdUwiqthFFfDtKu4AlejFxGRwwWxRS8iIiGU6MPEzJLC9LqDzSwyHK99LHXFFa7z1VbpfDVM0M9Xm030ZhZlZveZ2QVmdqeZRYQ8drqZ3Wxm/2Vmo1pRXKlmtsbMPgVua8m4/NcfhbdAe4cjtoftfNURV9jOl5klmdlfzOxzM3vGzCzksXD+fR0rrnCerxQz+z8ze8/Mbj/isXCer2PFFdb/j34MI8zs8SO2Nf35cs61yR/gBuB7Ifcv9u9HAgsB839mtIa4/N9vBfqH+bxtAGJDfg/r+aotrnCfL+BCIA6IAZYDo1rD+aotrlZwvobjNRwjgPday99XbXGF+3z5r5/ix/BMc5+vNtuiB0YDS/z7S4Bz/fs5wA7nA0rNrFcriAsgHfinmX1gZqktGNOxhPt8HUs4z9c/nHMHnXPFwCqg0N8e7vNVW1wQxvPlnPvYOVcBnAI8EfJQWM/XMeKC8P9/vBB45YhtzXK+2nKizwKK/PtFQGYN2498LJxx4Zz7MdAP7wPgnhaM6VjCfb5qFc7z5ZwrATCzWCDfOfep/1BYz9cx4gr735efkK4GfubHB63g76uWuMJ6vszsQuBV4Mhhj81yvtpyoi8EEvz7CVTPDxG6/cjHwhkXAM65cuBevE/u1iDc5+uYWsH5uhj4ecjvreV8HRkXEN7z5Zz73Dl3DTAPGOxvDvv5qiWuysfCdb6uBv6EN27+dDO7xd/eLOerLSf6d4Ah/v2TgHfMLMM5txZINB+Q4JxbF+64AMwsxt+egdf5GDZmFtFKzleNcfn3w3q+zGwS8JZzbp+Z9Wgt56umuPztreXvazfweWs5XzXFBeE9X865c51z5wPXATOAXzfn+WqzF0z5o1nuBZbhJdRXgR875y4ys3FAZW/1POfcrHDH5f+8gfcJXgI87ddZW4yZ5QEzgUuAjcCd4T5ftcVFmM+XmU0BHgb24HWQPQcMDff5qi0uwn++7gG649Wci/FaoWH/+6otLlrB/0c/vlzgbuA3NOP5arOJXkRE6qctl25ERKQelOhFRAJOiV5EJOCU6EVEAk6JXkQk4JToRUQCToleRCTglOhFWoiZdTazN82s/xHbbzazB8IVlwSfEr20KmZ2qpntN7N7zOwOM3vFzLJb8PVzzWyemZ3u/z7IzErM7OSQfU43s1Izm2De/PAzzewRf37zt83sN/5UDpPNmzM+EsA5txOIAtaaWbSZveA/5UG8K6mPFddJfhxX+L93MrN3/PP1gJnd3QynQwJCiV5aFefcbKAA75L0B4EFwI9aOIxPnHMz/PsHgXygG1TNGnkDMN85975zbi/wAbDWOVcIrAY2+FPjJgG3+BNnVR57yH/sTGC6/xqjgDl1xLQXWO+cew7AObcLmOmfr3ea4D1LgEWFOwCROnQG1pnZzXhzin8f+CfwE6AXcBoQDcwCzsD7YLgQGAdcW8MxA/CS7Gq8tQKmOOdWHeP1xwN/Ayq/VVwHrPePr7QRyDWzeLzZEYv9CbNinHOF/twlA/CmoJ3vH3MecId/PwcoMLPngIf897QHGAksds495b+39ypf0J8/fcsxz5yITy16aa1uMLNH8ZLeW/ilDefcDrzVqPBvM51zU/AW4cD/FrARbwbRmo75xNvk7sCbSOqw5eVqkAisA7qZ2Ul4rftheDMOVtqE1+I/H3gcL6FfDLzkl51+5Jx7HG/FoFlmFgUk+x8CnYBdwES8lclWABf6LfdUYLH/GqcTkuiBCcC7dcQuAijRS+v1R+fcjcDLwFO17FOBlyTBW8ChxL9fjLfUXk1C91sEpNUWgFWv9/slXqv7m3jfDIZzeKllE9ATb83bdf6+Hf1Szh3AL/39xuC16M8A3ve3nYK3sMRpzrn9/rb3zexc4Fnn3OKQYz8Iec2ezrlNtcUuEkqJXlq7z/Ba1eV4a6UCxNa++2HqOiYTbzGK2uQBS/Fa8ZOAZ/Hq6UuOmNJ2E17y/wfeh0Ie8Ff/sZHAcjMbgbeIRDxwAd701eAl+juBkWYWb2YpeN8Gkqmu4YNXnioCMLNueKUdkXpRopdWxczG4i0EcYOZ/Qi4BvghXhnmBDO7D68VfwJeEu1lZl3wSjU9/VJJX7y1AGo6BqCPmV0FnIpXvqkpjo54rfF0vOT9v8A+P5ZiC1lj1Dm3D5jqd5DuAH7lt+bBa8E/jtefEOE/X5pzbpv/+Ai8bxbT/FjG43X2juPwNU5vBx4zs58A36H2bzkiR9F89NKumNlpeLXwKbU8ngvc45z7dguGFfr6Dzjn7vTv/8E5d1M9jjkNr/RzdzOHJ22UWvTS3ozCa/l3q+XxfcBuMzurBWMKtdPMzjWzc4A/17WzmQ0ABlLHOHxp39SiFxEJOLXoRUQCToleRCTglOhFRAJOiV5EJOCU6EVEAk6JXkQk4JToRUQCToleRCTg/j84JABdjZzYrQAAAABJRU5ErkJggg==\n",
       "text/plain": [
        "<Figure size 432x288 with 1 Axes>"
       ]
      },
-     "metadata": {},
+     "metadata": {
+      "needs_background": "light"
+     },
      "output_type": "display_data"
     }
    ],
@@ -420,27 +403,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<matplotlib.axes._subplots.AxesSubplot at 0x7ff3d08a9550>"
+       "<matplotlib.axes._subplots.AxesSubplot at 0x7fa54cf1c4d0>"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZYAAAEjCAYAAAAR/ydQAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvOIA7rQAAIABJREFUeJzt3Xl8VPW9//HXJwuBQEhYwpqERQRl30TFFaXWrSJqq9RdUWuv1S7XqrVq69LW9nbzZ1sruNRbr9rW1tqqdd8BBZRdBZRd9rCvCfn8/jgnyRCzTPTMEvJ+Ph7zyMw5Z2Y+c2DOZ767uTsiIiJRyUh1ACIicmBRYhERkUgpsYiISKSUWEREJFJKLCIiEqmsVAeQCjNnzuyUlZU1GRiIkquISEMqgHnl5eUTR4wYsa6hg5tlYsnKyprcpUuXQwsLCzdlZGSov7WISD0qKips/fr1/desWTMZOKOh45vrr/WBhYWFW5VUREQalpGR4YWFhVsIankaPj7B8aSrDCUVEZH4hdfMuHJGc00sIiKSIEosIiISKSUWERGJlBJLE3Duuef2SHUMItI8nH322T2/6GsoscRp3L1v9Rt371v9onzNp556Ku/MM8/sVXP79773va6XXnpp8Xe+851u27dvt8WLF7f87ne/2+3000/vXVFRweLFi7PPO++8HldeeWXRU089lRdlTCKSAveP6cf9YxJ+fSkrK2PixIlFV1xxRdGdd97Zafv27TZx4sSiCy+8sOTaa6/ttm3btozc3NyKL/rezXIcS7p4//33c4cOHbozdtuSJUuyy8rKrKCgYN/06dNbT506NXfcuHGbbr311nVf//rXe5SWlmbOnTu3VXZ2tl9//fXrDj744L2pil9E0ldt15ef//znncaPH7/5tNNO2w7wwx/+sPNFF11Ueuyxx+48+eSTe0+ZMiV3+PDhO2t/xfgpsaTQnDlzWl122WUbd+3aZRdccEGPrl27lq1ZsyZ70qRJy1evXp21cuXKFlOnTm09dOjQXQA7d+7M6Nix477x48dv7dmz596rrrqq5IEHHljWq1evslR/FhFJL3VdX77//e9XjZxfsGBBq5tvvnnd7t27rVWrVhXTpk3LPfnkk7d90fdWYkmhBQsW5Hbt2nXNcccd1/eSSy5Z/81vfrP0tttu63z77bd32bhxY9bQoUN3zp07t9WaNWuyH3/88XYTJ07cAHD11Vd337dvnxUVFe3t1q1beao/h4ikn9quL3/+858Lzj///B7t2rXbd/vtt6/+2te+tun888/v0apVq4pbbrllzd1339355ptvbnDKloZYc1xBcvbs2UuHDBmyAeD6v80uXrhmW25Dz1m8bnsrgD6d2uxq6Ni+XfJ2/uKcISvqO2bPnj3WsWPHIV27dt37+9//ftnYsWN3xBu/iDQRT/1XMesWNHh9YcPCVgB07Nvg9YVO/Xdy5u9Scn2ZPXt2xyFDhvRs6Dg13qfIe++913LQoEE7s7KyPDMzs/lldxFJmFRfX5p9VVhDJYtKlT3C/nnN0R9F8b4zZ87MHTVq1PbLLrts41lnndXn1Vdf/ai4uLjWaq2bbrqpy8aNG7M6dOhQvnHjxqyrr756w7Bhw3ZHEYeIJFADJYsqlT3Crnz1gLi+qMSSIrNnz241cODAXYMHD95zxx13rDzrrLMO2rNnj11zzTXdL7vssuILLrigBOCVV15p/eSTT7bPy8vb9+STT7bv1avXHiUVEalPqq8vzb7EkiqTJk1aWXl/woQJWyZMmLDlpz/9aeGuXbsyCgoK9i1ZsqQFwKBBg3aPHj1624033rhu48aNWTfddNP61EUtIk1Bqq8vSixpZNasWbkPP/zw8latWlXViU6bNi13yJAhuyr/pjI+EWm6knl9UWKJU1RtK/UZN27c5q997Ws9u3fvXjZ27Nit55xzztb333+/1ZgxY7a/+uqrbcaMGbM90TGISApE1LZSn2ReX5p9d2MREYmPuhuLiEhKKLGIiEiklFhERCRSzTWxVFRUVFiqgxARaSrCa2ZcU+o318Qyb/369flKLiIiDauoqLD169fnA/PiOb5ZdjcuLy+fuGbNmslr1qwZSPNNriIi8aoA5pWXl0+M5+Bm2d1YREQSR7/WRUQkUkosIiISqWbZxtKxY0fv2bNnqsMQEWlSZs6cucHdCxs6rlkmlp49ezJjxoxUhyEi0qSY2bJ4jlNVmIiIREqJRUREIqXEIiIikVJiERGRSCmxiIhIpJRYREQkUkosIiISKSUWERGJlBJLYzx0WnATEZE6KbGIiEikkppYzOxBM1tnZrUuFmNm48xsjpnNMrMZZnZ0zL6LzWxReLs4ZvtrZvZR+JxZZtYpGZ9FRERql+y5wh4G7gUeqWP/y8DT7u5mNhj4C3CImbUHbgNGAg7MNLOn3X1T+Lzz3V2Tf4mIpIGklljc/Q2gtJ7927165bHWBEkE4MvAi+5eGiaTF4GTExqsiIh8LmnXxmJm483sQ+AZ4LJwc3dgRcxhK8NtlR4Kq8FuMbNa17E3syvD6rUZ69evT0jsIiKShonF3f/h7ocAZwJ3hJtrSxaVpZnz3X0QcEx4u7CO173f3Ue6+8jCwgaXExARkc8p7RJLpbDa7CAz60hQQimO2V0EfBoetyr8uw34P2BUkkMVEZEYaZVYzKxPZVWWmQ0HWgAbgeeBk8ysnZm1A04CnjezrDDxYGbZwOlArT3OREQkOZLaK8zMHgOOBzqa2UqCnl7ZAO5+H3A2cJGZlQG7gHPDxvxSM7sDmB6+1O3uXmpmrQkSTDaQCbwETErmZxIRkf0lNbG4+4QG9t8N3F3HvgeBB2ts2wGMiCxAERH5wtKqKkxERJo+JRYREYmUEouIiERKiUVERCKlxCIiIpFSYhERkUgpsYiISKSUWEREJFJKLCIiEiklFhERiZQSi4iIREqJRUREIqXEIiIikVJiERGRSCmxiIhIpJRYREQkUkosIiISKSUWERGJlBKLiIhESolFEueh04KbiDQrSiwiIhIpJRYREYmUEkuUVPUjIqLEIiIi0VJiERGRSCmxiIhIpJRYREQkUkosIiISKSUWERGJlBKLiIhESolFREQipcQiIiKRUmIREZFIKbGIiEiklFhERCRSSiwiIhIpJRYREYmUEouIiEQqqYnFzB40s3VmNq+O/ePMbI6ZzTKzGWZ2dMy+i81sUXi7OGb7CDOba2aLzeweM7NkfBYREaldskssDwMn17P/ZWCIuw8FLgMmA5hZe+A24HBgFHCbmbULn/MH4Erg4PBW3+uLpC8tFCcHiKQmFnd/AyitZ/92d/fwYWug8v6XgRfdvdTdNwEvAiebWVegrbtPDZ/3CHBm4j6BiIg0JO3aWMxsvJl9CDxDUGoB6A6siDlsZbite3i/5vbaXvfKsHptxvr166MPXEREgDRMLO7+D3c/hKDkcUe4ubZ2E69ne22ve7+7j3T3kYWFhdEEKyIin5F2iaVSWG12kJl1JCiJFMfsLgI+DbcX1bJdRERSJK0Si5n1qezVZWbDgRbARuB54CQzaxc22p8EPO/uq4FtZnZE+LyLgH+mKHwREQGykvlmZvYYcDzQ0cxWEvT0ygZw9/uAs4GLzKwM2AWcGzbKl5rZHcD08KVud/fKTgBXE/Q2awU8F94SY892KNuZsJcXETkQJDWxuPuEBvbfDdxdx74HgQdr2T4DGBhJgA3ZsRa2r4V95ZCZ1FMnItJkpFVVWNrLaQteAWtmpzoSEZG0pcTSGDn5wd9lU1Mbh4hIGlNiaYysFpDVEpYrsYiI1EWJpbFy2sKyKVBRkepIRETSkhJLY7XMh12lsGFhqiMREUlLSiyNldM2+Lt8SmrjEBFJU0osjZXVEtp0VgO+iEgd4k4sZnZbIgNpMsyg5MhaG/Dnr97C/NVbUhCUiEj6aMwov9vMLBdoD7wHPB5OYd/89BgNC56CzcuhoCTV0YiIpJXGVIU5sJtg3q5iYIqZDUlIVOmu5Mjgr6rDREQ+ozGJ5UN3v83d/+buPwDGAb9OUFzprfOAYLCkGvBFRD6jMYllg5mNqHzg7guB5rmwSUYmlByuEouISC0a08ZyLfC4mc0E5gJDgCUJiaopKDkSFr0AOzZC6w6pjkZEJG3EXWJx99nAUOCxcNMrQL2zFR/QeowO/mp6FxGR/cSVWMxslJkd5u57CEop5cCn7r4jodGls27DIDNHiUVEpIYGq8LC8SunAFlm9iIwCngduNHMhrn7XQmOMT1l5UDRSFj2dqojERFJK/G0sZxDUAWWA6wBitx9q5n9AngHaJ6JBYJ2lrd+HawsmdMm1dGIiNTvodOCv5c+k9C3iacqrNzd97n7TuBjd98K4O67gOY9xW+P0eD7YOW7qY5ERCRtxJNY9oYj7gGquhubWT7NPbEUjwLLULdjEZEY8VSFHRs22uPusYkkG7g4IVE1FTl50GWwGvBFRGI0WGKpTCq1bN/g7nOjD6mJ6TEaVk6H8r2pjkREJC00atp8M/tSfY+bpZIjoXw3fPp+qiMREUkLjV2P5e4GHjc/lRNSat4wERHgiy/0ZZFE0ZS1KYSOfdWALyISimuuMDN7iGDa/BIzexDA3S9LZGBNSsmRwfosXhwsBCYi0ozFW2J5GPgTsCn8+6dEBdQk9RgNu7eQ47tTHYmISMrFVWJx99cBzGxb5f3KXQmJqqkJ21la+0720CrFwYiIpFZj21hq9qlVH1sIlidu253cZjwnp4hIpUYlFnc/or7HzZYZlBxJbsUOcBXiRKR5+6K9wqRSjyPJppxsFeJEpJlrzAqSUp8eRwHQed9aePu30KI1tGgD2bnh/fCWnRtsr7yfodwuIgcWJZaodOzHLmtJfsUWePHW+J+XnRuTfNpAi/B+duv9E1JVUqq5rY7jMjIT91lFROoRd2Ixs2uAR919UwLjaboyMvgk+2BwZ8B/Pw97d0DZjuDv3p2wd3u4rfL+znDf9nDbjv1vOzbsf1xZIzsGZLWqTlINlZxa5NY4prYElxvcz9RvERGpX2OuEl2A6Wb2HvAg8Ly7Wqo/wyxY9Cvqhb8qKqB81/7JpywmYVUmr7KYhBWblCqP2Vn62WTWmF7jWS1jklJuLSWnmIS1ZQVkZMPyadCpP7RsG+05EZG0FHdicfcfmtktwEnApcC9ZvYX4AF3/zhRAUooI6P6Ih4ldyjbFX8Jq2zHZ0tXZTth18qY54bHVa6y8OCXg7/5JdC5f5BkOg8Ibh36QGZ2tJ9JmoVz/xhMo/TEVUemOBKpqVH1Gu7uZraGYInicqAd8Dcze9Hdv5+IACXBzMJSRi5QGN3rusODp0BFGRz737B2PqxbAGsXwKIXg5U3ISjRFPYLk01/6DwwuN+2m6bHEWmiGtPGci3Bwl4bgMnA9e5eZmYZwCJAiUWqmQUdCDIyod8pwa1S+R7YsDBIMuvmB3+XvgVz/1J9TMt86DQgTDYDgvudDlV1mkgT0JgSS0fgLHdfFrvR3SvM7PRow5IDWlYOdBkU3GLtLIV1H4Qlm/nBbfYTsHdb9TGV1WmdB1RXqak6TSStNCax5NRMKmZ2t7vf4O4fNPTkcFbk04F17j6wlv3nAzeED7cDV7v77HDfdcAVBNP0T3L334TbfxRuXx8+7wfu/mwjPpMk0PzVWwAYEO8TcttDz6OCWyV32Ly8OtlU/o2tTstsESxdENt2o+o0kZRpTGL5EtUX/kqn1LKtLg8D9wKP1LF/CXCcu28ys1OA+4HDzWwgQfIYRTA32X/M7Bl3XxQ+79fu/j/xfwxpUsygXY/gVm912vxaqtMKYpJNf1WniSRJg4nFzK4Gvgn0NrM5MbvygLfjfSN3f8PMetazP3YJxmlAUXj/UGCau+8M43kdGA/8PN73jkp9v8DdnRt3fJ1WtpfvfLyRI3q3x/RrOXHiqk6bFySe2Y/XUp02YP8eaqpOa3Ju3Xh9eO+tlMYhnxVPieX/gOeAnwI3xmzf5u6lCYkKLg/fE2AecJeZdQB2AacCM2KOvcbMLgq3fa+uAZxmdiVwJUBJSUnkAS9et525+3qQxT4mTJrGwO5tueKY3pw6qCvZmZq2JWkarE4Lk826BbDohRrVaf32TzaqThP5XBpMLO6+BdgCTEh8OGBmYwgSy9Hh+39gZncDLxK0vcwm6OoM8AfgDoIRfncAvwRqXdnS3e8nqF5j5MiRkQ/sfHdpkGN/2/ohtpz0Wya/9QnXPT6Lu5/7kEuP6sW5o4pp21K/iFOiweq0+dXtN0vehDlPVB/TsiCmo4Cq00TiEU9V2FvufrSZbSO4gMf+fHN3j+wbZmaDCboyn+LuG2Pe5AHggfCYnwArw+1rY547Cfh3VLE01vQlpRTYdnpkrGfg4SWcd1gxr360jklvfsJdz37Ab19exHmHFXPp0b3oXqDFwNJCvdVpC/bvDj37sWCgaKWCkuru0J3C8Tcd+nyhKW8a3dlBJE3FU2KpLDnkJTIQMysB/g5c6O4La+zr5O7rwmPOAo4Mt3d199XhYeMJqs1SYvrSTQzIXFFVa5KRYZx4aGdOPLQzc1duYfJbn/DQlKU8NGUppw3qyhXH9GZQUX6qwpX65LaHnkcHt0oVFbBl+f7JpsHqtIHB/byuqk6TZiWeEktlSaVW8ZZYzOwx4Higo5mtBG4DssPXuA+4FegA/D5s9C5395Hh058M21jKgP+KaUf5uZkNDeNbClwVTyxRW7V5F6s27+L0nJW17h9UlM9vzxvG908+hIffXsJj767g6dmfcniv9lxxTG9OOKQTGRm68KS1jAxo1zO4HXJq9fbyPbD+o/27Q9dbnVbZHfpQyEnobzWRlImnxBLJ/353r7eNxt0nAhPr2HdMHdsvjCC0L2z6kqB9ZUDWinqP617QiptP68+1Jx7ME9NX8NDbS5n4yAx6F7bm8qN7cfbwIlpma7r7JiUrB7oODm6xGlud1nkAOb6bPeQkN35pVpJV3dqoCmEzawccDLSs3Obub0QdVFPz7tJS8nKy6JmxLq7j81pmM/GY3lw8uifPzl3N5DeXcPM/5vHLFxZy4RE9uPDIHnRsowtMkxZvddra+VXVaX2AfWTAm7+CI74J2S3rfHmRdNaYucImAtcRjC+ZBRwBTAVOSExoTcf0JaUM79GOzDWN62yWnZnBuKHdOWNIN95ZUsrkNz/hty8v4g+vf8zZw7tz+dG96dMp4un3JXXqqk4r2w0bFrJy8gTyK7aQ9/KPYcaDcOJtMPBsrTIqTU5j/sdeBxwGLHP3McAwqqdSabY27djLonXbGdWr/ed+DTPjiN4dmHzxYbz03eM4e3gRf39vFWN/9TqXPTydqR9vREvfHMCyW0LXwWzJbMfy7J5w8b+CEs/fJ8LkE2Fp3OOQRdJCYxLLbnffDWBmOe7+IdAvMWE1HdPD8SuH9fz8iSVWn05t+OlZg5hy4wl8e+zBzF6xmQmTpvGVe9/in7NWUbavIpL3kTTW61i44jU48z7YtgYePhUePx82LE51ZCJxaUxiWWlmBcBTwItm9k/g08SE1XRMX1pKi8wMBkfcdbhDmxy+PbYvb994Aj8ZP4ide/dx3eOzOO7nr3L/Gx+zdXdZpO8naSYjA4ZOgG/NhBN+CJ+8Br8/HJ79PuzY2ODTRVIp7sTi7uPdfbO7/wi4hWDA4pmJCqypeHfpJoYU5yesN1fL7Ey+fngJL33nOB64eCQlHXL5ybMfMvqnr3DnvxewavOuhLyvpIkWuXDs9XDt+zDsQpg+Ce4ZBm/fE7TNiKShz9Uq6O6vu/vT7r436oCakp17y5m/aktk1WD1qRxw+fiVR/Kva47mxEM78dCUpRz781f51mPvM2fl5oTHICnUphN85Tdw9VQoORxevAV+dxjM/VswF5pIGok7sZjZn8KqsMrH7cI1Vpqt95dvprzCOewLNNx/HpUDLt/4/hguO6onr364jjPufZuv/XEqLy1YS0WFLjQHrE6HwPl/hQufgpx8ePJymDwWlk9LdWQiVRpTYhns7lU/i8PR78OiD6npeHdJKWYwoke7lLx/5YDLqTedwA9PO5RVm3Yx8ZEZjP316zz6zjJ2l+1LSVySBAeNgateh3G/g62r4MEvwxMXQuknqY5MpFGJJSMcIAmAmbWnkQMsm7rbO/yC2zv8ourx9KWlHNqlbcpnLa4ccPna9cfz2/OG0rpFFjf/Yx6jf/YKv3pxIRu270lpfJIgGZkw7IKggf/4H8Dil+HeUfCfm4KR/yIp0pjE8ktgipndYWa3A1NIwWJb6aJsXwXvL9/8hcavRK1ywOXT1xzF41cewfCSAu55eRGjf/YKN/19DovXbW/4RaTpadEajr8Brn0Phn4d3rkP7hkKU+4N5jI7AFVUOJ9WtGN2eYl+OKWhuEsc7v6Imc0ExhBMnX+Wuy9IWGRpbt6qLewq25eUhvvGqhxweUTvDny8fjsPvLWEJ2eu5LF3V3DCIZ244pjeWuHyQJTXBc64Bw6/Cl68FV64OehFNvZH0P/MJjnDsruzbtsePlqzLbit3cbC8La77BsA/ODOlyhq14ohxQUMKy5gSHEBA7vl06qF5t1LlUZVZbn7fGB+gmJpUqoGRvZKTftKvA4qbMNPxg/ie1/qy/9OW8b/Tl2mFS4PdJ0HwAVPBlVjL9wCf70EikbBl++C4lGpjq5OW3aW8dHaIHl8tGYrC9ds56O129iyq3rMVqe8HPp1yeP8w3vQZsa9dMzYxu7jf8yslZuZtXwzz8wJVtHIzDD6dc5jSHEBQ4vzGVrcjj6d2pCpWcST4vMs9FW1i4gX+mpK3l2yiZ4dcumU1zQmCqwccPmN4w7iH++vYvKb1StcXnJUT84bVZLytiKJWJ8ToffxMOtReOVOeOBLMGB8MAdZ+14pC2vX3n0sWheUQBau3cZHa7fz0ZqtrN1aXaWV1zKLQ7rkcfrgrvTrkkffznn065xHu9Ytqo6ZP2cOAAOO7V21bf22PcxesZnZKzcza8VmnpnzKY+9uxyA3BaZDOqez9CSAoYWFTC0pIAubVuq5J4AabPQV1NSUeHMWFbKlw7tnOpQGq1ldiYTRpVw7shiXlu4jvvf+ISfPPsh97y8WCtcHogyMmH4RTDgLJjy/2DKPfDhMzDqSjj2v6FV4krcZfsqWLphR1gCqU4ky0p3Vg29ycnK4ODObTiqT0cOqUwgXfI+9wW/MC+Hsf07M7Z/8N2sqHCWbtzBrBWbmb1iM7NWbuGht5ayN5waqVNeTliqCW6DivL1AysCjZnd+G53v6Ghbc3B4vXb2byzLOnjV6KUkWGccEhnTjikM/NWbWHSm9UrXJ46qCtXHNOLwUUFDb+QNA05bWDMTTDiYnj1Lpj6u6Akc9wNMPJyyGrR8GvUoaLCWbV5135tIB+t2cbH67dTti/IIJkZRs8OuQzols/4YUX069KGvp3z6NGhdUKrpzIyjN6Fbehd2IazhhcBsKd8Hx+s3hYkmjDhvLggWOXcLKg+HlJUXYXWr0seLbJUXdwYjWlj+RJQM4mcUsu2A9674cJeo9Kw4f7zGNg9GHB5w8mH8PCUpTz2znL+NftTRvVqz5Va4fLA0rZbMPbl8G/ACz+E/9wI794PY38Mh36l3gZ+d2fD9r0sXLuND9dsY2GYSBat3caOvdVjproXtKJflzyO79epqhTSu7B12ixil5OVWVVCuTjctmVnGbNXbq5KNq99tI4n3wtWhG2RlcGAbm2rnjO0uICS9rmqQqtHPG0sVwPfBA4yszkEbSsAeUCznM97+tJSCvNy6NEhN9WhRKpbQSt+cOqhfOuEPlrh8kDXZVAwen/xS0GC+cuFUHIknHQXFI1g6+4yFq3dxkdrtoeJZCsL126ndEf1LE4dWregX5c8vjqyuKodpG/nNuQ1waqk/Nxsju1byLF9C4Egia7avKuqRDN7xRYefzf4TgAU5GaHpZrgNrgonw5anK9KPCWWR4HngJ8ANxI22gPbYtaeb1amLyllVM8Dt7tu5YDLS0b35Nl5a5j85idVK1xecEQPLtIKlwcGM3b3PIGPxz3Lnnf/RL8F99B68gm8kHEMt+86h5UeXGRbt8ikb5c8TurfmX5dgkb0vl3yDuj/A2ZGUbtcitrlcvrgbgCU76tg4drtQceA5UEHgf/3yiIqZ1AqaZ/LkOIChhTlM6ykgAHdEjc5bbqLJ7E8G/YKOwM4PWa7mVmz6xW2p2wfn27ZzZU907ubcRSyMjM4Y0g3vjK4K+8uKWXSm59wz8uLuE8rXDY55fsqWFa6s6r6qrI9ZOmGHeGFsR/tMn/F9Xn/4Zw9T3FCy3dY2e9iso//Ht06dzlgf0Q1RlZmBv27taV/t7ZMGFUCwI495cxdtaWqCm3m0lL+NTtYTSQrw+jXJY+h4diaYcUF9C5sHl2eG9MrTFcQYNuecoAm3XDfWGbG4b07cHgdAy4nHtOLI3t30MUnDbg7q7fsrm5Ir2wHWbedveVBTygz6NmhNX07t+H0wd3o1zmPfl3a0KNDa7Izz4Itt8Erd9Jz9mRY9iQcfxOMvBQym14VV6K1zsmqGoxcad3W3UEV2sqgCu3pWZ/y6DtBl+c2OVlVXZ4rq9K65DeNIQuNEVfjvQVXjCJ3X5HgeNLett3l5OVkcUiXZlVQqxI74PLP05bzyNSlfH3SOxpwmQKlO/ZWdeH9MPy7cM22qh8/AF3zW9K3cx5H9elI3855HNIlj4MK29Q/Kj2/O4z/AxzxDXj+Znjuenj3j/Cl26HfqU1yBH8ydWrbkpMGdOGkAV2AoNfcJxuquzzPXrmZyW9+UtVjrkvblgwpzq/q9jyoe36TbKeKFVdicXc3s6eAEQmOJ+1t213O4b3bN4vibH06tMnhurEHc9VxvfcbcPmz5z7k0nDApURjx57yqmlMqhvTt+03R1Z+q2z6dclj/PDuVWNB+nbKIz/3C1ygug6Bi/8FC58P1n95/OvQ42g46Q7oPjyCT9Y8ZGQYfTq1oU+nNpwzIujyvLtsHwtWb92vy/Pz86u7PPcpbFNVhTa0uIB+XfKa1A+2xnQ3nmZmh7n79IRFk+bK9lWk7fxgqVJzwOWkN5ZUDbgc6ycyNnsObTbuSHWYTcLqigKI1TAiAAATi0lEQVR2eQsWz1oVMyp9GytKq1cJbZWdSd/ObRjTrzBoSA8b0wvzchJTFWkG/U6GPmPhvYfh1Z/CpDEw+Fw44RYoKI7+PZuBltmZDC9px/CS6rbaTTv2VlWfzVqxiZc/XMdfZwZdnnOyMhjYPb862RQVUNy+VdpWPzcmsYwBrjKzZUDVlcLdB0ceVZratjuoYkinGY3TRW0DLp+eNZKn9o6CX7yW6vCaiKuDP4/PIivD6F3YmqHF7Th3ZHFVKaS4XW5qxhRlZsFhE2HQ1+CtX8O038OCf8IR34SjvwMtm2fVcJTatW7B8f06cXy/TkDQXrZy0y7er+ryvJk/T1vGA28tAaB96xYMKaquQhtSVLDflDepFM84lj5AZ4LBkLF6AJ8mIqh0tW13OWYwuCg/1aGktcoBl+MX/4C55SV0P+OWVIfUJKx6+k6yrZwxV/2aXh1bp+do75ZtYextMPIyeOUOeOtX8N4jwaj+4ZcECUgiYWYUt8+luH0uZwwJujyX7avgozXb9muveW3h+qopcnp0yK1KMkNLCujfte3+XZ6TtIx1PP8LfgP8wN2XxW40s0Lg18BXEhFYOspvlU2LLCMnq3n2TW+swoxtnNBiPgPCqTSkfvP/Mw+Afl2awLR8BcVw1v3VI/if+R6880f40h3Q98tq4E+Q7MygSmxg93wuOKIHANt2l4VdnoMqtHc+KeWfs4Lf/PkZuzm94xqOa72cAb6Ig8oWsjIz8dWX8SSWnu4+p+ZGd59hZj0jjyiNFeRmU0DT7q0hEqnuw+GSZ+CjZ4M1YB47F3odCyfdGTT+S8Lltcxm9EEdGd2zANbtgFXL2LnkHfatmEmbrYuxrQ5bYUlFZ57zw6igJX0SHFM8iaW+TtaaBjfGgK6qIpNmyAwOOQ0OPglmPASv/RT+eBwMmQAn/DDovizRcoctK2DVTFg5I/j76SwoDzp65LZqD91HwPBzoPtI9nUdRvmOFiz7w/cZlbU44eHFk1imm9kV7j4pdqOZXQ7MTExYItLkZGbD4VfCkHPhzV/CtPtg/j9g9DVw1HWQ0wSq+NLV7i2w6j1YNSP4u3IG7FgX7MvMga6DYcQlQTIpGgHteu1XHZkJHNwGvtRiblLCjSexfBv4h5mdT3UiGQm0AMYnKjARaaJa5geDKUdeDi/fDm/8Amb+Ccb8AIZdqAb+huwrg7XzwtLIzCCZbFhYvb/DwcEibt1HBLfOA7/QsgeJEM+ULmuB0WY2BhgYbn7G3V9JaGQi0rS16wHnPABHXB008P/720ED/0l3BONi1MAfVGltXlZdnbVqJqyeDeW7g/25HaFoZNDNu/vw4JbAxdmiEvdPB3d/FXg1gbGIyIGoaCRc+hx88C946TZ49JxgyeST7gym729Odm0Kq7Ri2kZ2bgj2ZbWErkODkl7RCOg+EgpKmmQCVplURBLPDPqfAX1PhhkPwus/g/uOgaHnBw38bbumOsLole+FtXPD6qywSmtjZcO5Qce+QdfsqiqtAQfMRJ9KLCKSPFktgsktKxv43/kjzP87jP4WjL42WEK5KXKH0k+qG9hXzoA1c2BfuDBam85BCWTIhKAE121Y0BZ1gFJiEZHka9UuqAobeTm8/GN4/e6ggf+Em4NSTEaaD0LeWbp/ddaqmbArWLKc7NygSuvwq4Jk0n0E5Bc1ySqtz0uJRURSp30v+OrDwZxjz98MT38r6KZ80h1Bz6d6JG3cWPkeWDM3TCJhIin9JNxp0OnQYBxP9xFBaaTw0Gbf8615f3oRSQ/Fo+DyF4KJLV+6Df58Fhx0YlCq6dw/eXG4w8aPqxPIyhlBUqkoC/bndQt6Zg2/KCiNdBuq8Tm1SFpiMbMHCZY2XufuA2vZfz5wQ/hwO3C1u88O910HXAEYMMndfxNubw88AfQElgJfc/dNif0kIpIQZjDgTOh3CkyfDK//HO47CoZdAGN+CHmdo3/PHRtiqrTCwYe7Nwf7WrQJ2kKO/K/q0kjbbtHHcABKZonlYeBe4JE69i8BjnP3TWZ2CnA/cLiZDSRIKqOAvcB/zOwZd18E3Ai87O4/M7Mbw8c31PH6ItIUZOUEF/MhE+CN/4F374e5T8LR3w62t2j9+V63bBesnrN/aWRzOLeuZUCnAdB/XJBAuo+Ewn7p39aTppKWWNz9jfomrXT3KTEPpwGVU+IeCkxz950AZvY6wYj/nwPjgOPD4/4EvEYqE8ulz6TsrUUOOLnt4eSfwGGXw0s/glfvCroqn3ALDDmv/udWVMDGRfuXRtbOh4pw2ea2RcFYkcMmBqWRbkM/f8KSz0jXNpbLgefC+/OAu8ysA7ALOBWYEe7r7O6rAdx9tZl1qusFzexK4EqAkhItmyvSZHQ4CM79X1g+LWjg/+c3YdofgvaQVgXBMdvXxfTQmgGr3oc9W4J9OW2DKq3R14alkRGQ1yV1n6cZSLvEEk4dczlwNIC7f2BmdwMvErS9zAbKG/u67n4/QfUaI0eOTM5qNyISnZIjYOJLwbiXl34Em5dDizz49SDYsjw4xjKDgYaDzq7u6tuxL2Sk4aJpB7C0SixmNhiYDJzi7hsrt7v7A8AD4TE/AVaGu9aaWdewtNIVWJfsmEUkicxg4NnQ7zT43eGwY31QCjn8quBvl8HQIjfVUTZ7aZNYzKwE+DtwobsvrLGvk7uvC485Czgy3PU0cDHws/DvP5MYsoikSnbLYNBhfhF89aFURyM1JLO78WMEDe0dzWwlcBsEyzG6+33ArUAH4PcWjFAtd/eR4dOfDNtYyoD/iulS/DPgL+HaMMuBrybp44iISB2S2StsQgP7JwIT69h3TB3bNwL1D88VEZGkUouWiIhESolFREQipcQiIiKRSpteYXLgub3DL4BgMjcRaT5UYhERkUgpsYiISKRUFSaSJpK2cJVIgqnEIiIikVJiERGRSKkqTESkmUhWdasSi0i60EJxcoBQYpGEeeKqIxs+SEQOOEosjaALpYhIw9R4LyIikVJiERGRSCmxiIhIpJRYREQkUkosIiISKSUWERGJlBKLiIhESolFREQipcQiIiKRUmIREZFIKbGIiEiklFhERCRSSiwiIhIpJRYREYmUEouIiERKiUVERCKlxCIiIpFSYhERkUgpsYiISKSUWEREJFJKLCIiEiklFhERiZQSi4iIREqJRUREIpWV6gBERCRJLn0mKW+TtBKLmT1oZuvMbF4d+883sznhbYqZDYnZ9x0zm29m88zsMTNrGW5/2MyWmNms8DY0WZ9HRERql8yqsIeBk+vZvwQ4zt0HA3cA9wOYWXfgWmCkuw8EMoHzYp53vbsPDW+zEhK5iIjELWlVYe7+hpn1rGf/lJiH04CimMdZQCszKwNygU8TEaOIiHxx6dp4fznwHIC7rwL+B1gOrAa2uPsLMcfeFVaf/drMcup6QTO70sxmmNmM9evXJzJ2EZFmLe0Si5mNIUgsN4SP2wHjgF5AN6C1mV0QHn4TcAhwGNC+8jm1cff73X2ku48sLCxM4CcQEWne0iqxmNlgYDIwzt03hpvHAkvcfb27lwF/B0YDuPtqD+wBHgJGpSJuERGpljaJxcxKCJLGhe6+MGbXcuAIM8s1MwNOBD4In9M1/GvAmUCtPc5ERCR5ktZ4b2aPAccDHc1sJXAbkA3g7vcBtwIdgN8HeYLysOrqHTP7G/AeUA68T9hjDHjUzAoBA2YB30jW5xERkdqZu6c6hqQbOXKkz5gxI9VhiIg0KWY2091HNnRc2lSFiYjIgUGJRUREIqXEIiIikVJiERGRSCmxiIhIpJRYREQkUkosIiISKSUWERGJlBKLiIhEqlmOvDez9cCyz/n0jsCGCMOJiuJqHMXVOIqrcdI1LvhisfVw9wanh2+WieWLMLMZ8UxpkGyKq3EUV+MorsZJ17ggObGpKkxERCKlxCIiIpFSYmm8+xs+JCUUV+MorsZRXI2TrnFBEmJTG4uIiERKJRYREYmUEouIiERKiaUOZnaymX1kZovN7MZa9ueY2RPh/nfMrGeaxHWJma03s1nhbWISYnrQzNaZ2bw69puZ3RPGPMfMhic6pjjjOt7MtsScq1uTFFexmb1qZh+Y2Xwzu66WY5J+zuKMK+nnzMxamtm7ZjY7jOvHtRyT9O9jnHEl/fsY896ZZva+mf27ln2JPV/urluNG5AJfAz0BloAs4H+NY75JnBfeP884Ik0iesS4N4kn69jgeHAvDr2nwo8BxhwBPBOmsR1PPDvFPz/6goMD+/nAQtr+XdM+jmLM66kn7PwHLQJ72cD7wBH1DgmFd/HeOJK+vcx5r2/C/xfbf9eiT5fKrHUbhSw2N0/cfe9wOPAuBrHjAP+FN7/G3CimVkaxJV07v4GUFrPIeOARzwwDSgws65pEFdKuPtqd38vvL8N+ADoXuOwpJ+zOONKuvAcbA8fZoe3mr2Okv59jDOulDCzIuA0YHIdhyT0fCmx1K47sCLm8Uo++wWrOsbdy4EtQIc0iAvg7LD65G9mVpzgmOIRb9ypcGRYlfGcmQ1I9puHVRDDCH7txkrpOasnLkjBOQurdWYB64AX3b3O85XE72M8cUFqvo+/Ab4PVNSxP6HnS4mldrVl7pq/ROI5JmrxvOe/gJ7uPhh4iepfJamUinMVj/cI5j4aAvw/4KlkvrmZtQGeBL7t7ltr7q7lKUk5Zw3ElZJz5u773H0oUASMMrOBNQ5JyfmKI66kfx/N7HRgnbvPrO+wWrZFdr6UWGq3Eoj9ZVEEfFrXMWaWBeST+GqXBuNy943uvid8OAkYkeCY4hHP+Uw6d99aWZXh7s8C2WbWMRnvbWbZBBfvR93977UckpJz1lBcqTxn4XtuBl4DTq6xKxXfxwbjStH38SjgDDNbSlBdfoKZ/bnGMQk9X0ostZsOHGxmvcysBUHj1tM1jnkauDi8fw7wioctYamMq0Y9/BkE9eSp9jRwUdjT6Qhgi7uvTnVQZtalsl7ZzEYRfB82JuF9DXgA+MDdf1XHYUk/Z/HElYpzZmaFZlYQ3m8FjAU+rHFY0r+P8cSViu+ju9/k7kXu3pPgGvGKu19Q47CEnq+sqF7oQOLu5WZ2DfA8QU+sB919vpndDsxw96cJvoD/a2aLCTL9eWkS17VmdgZQHsZ1SaLjMrPHCHoLdTSzlcBtBA2ZuPt9wLMEvZwWAzuBSxMdU5xxnQNcbWblwC7gvCT8OIDgF+WFwNywfh7gB0BJTGypOGfxxJWKc9YV+JOZZRIksr+4+79T/X2MM66kfx/rkszzpSldREQkUqoKExGRSCmxiIhIpJRYREQkUkosIiISKSUWERGJlBKLHJDMbF84m+xsM3vPzEanOqZKZvawmS0xs2+Ej39kZm5mfWKO+U64baSZXWdmv4nZ90czeynm8bfM7J5a3udHZvbfMY+PNLNJFsy4e28j4j3easyQG36Gc8L7j5pZaeVjESUWOVDtcveh4dQjNwE/bcyTw7EJiXR9OC6k0lz2H0twDrAgvD8FiE2MQ4H8mBhHA2/H8Z4nA//5fOHWzd3P57MDiKUZU2KR5qAtsAk+++vbzO41s0vC+0vN7FYzewv4qpm9ZmZ3W7DmxkIzOyY8br9f/Gb2bzM7Pry/3cx+GZaSXjazwjhjfIpwpmoz600wKeD6cN/7QF8za2Vm+QQDJmcBg8L9owmSD2Z2swXr9bwE9KvxHicSzFdVxcxOM7OpZtbRzA4ys2lmNt3Mbjez7Yh8DkoscqBqFVaFfUgwdfgdcT5vt7sf7e6Ph4+z3H0U8G2CkfsNaQ285+7DgdfjfA7AVmCFBZMYTgCeqNwRzj47CziMcG0WYBow2sy6EQx0XmFmIwhKPcOAs8LjAbBgPq8yd98Ss208cCNwqrtvAH4L/NbdDyMN5nKTpkuJRQ5UlVVhhxBUAT1SOcdVA56o8bhyIsaZQM84nl8R8xp/Bo6O4zmVHidIDGcC/6ix722CksloYGp4G00wDcuU8JhjgH+4+85wVuLY6qmTgBdiHo8BbgBOc/dN4bYjgb+G9/8v5ti6pufQtB1SKyUWOeC5+1SgI1BIMGdT7P/7ljUO31HjceXMtPuonluvodfY7+0bEeq/CObqWl7LdPWV7SxHEiSVD4D+fLZ9pa73O4X921c+IVglsm8ccW0E2tXY1h7YEMdzpRlSYpEDnpkdQjBp50ZgGdDfgjW/8wnaHRprKTDUzDIsWLhpVMy+DIKGd4CvA2/F+6LuvougFHFXLbunEFSDFbr7unDix/UE7TKVJZY3gPFhW0we8BWomrV4MEF1WqVlBNVlj1j1Yl3TgLPD+7EdCRYB3czs0PD1egBDaryeSBXNbiwHqlYxM/QacLG77yNox/gLMIfggvn+53jtt4ElBD255hEsflVpBzDAzGYSNMCf25gXjmnbqbl9k5mtB+bHbJ5KUBU2OzzmPTN7guCCvwx4MzxuBPB+zVmI3f0jMzsf+KuZfYWgHenPZvY94Jkwftx9j5ldADxkZi2BMmBibHuNSCzNbiwSITPb7u5tGjjmYeDf7v63JMX0Q2BxXUkr5rhcgrYpN7PzgAnuPi7O93iYJH4mSW8qsYgk3xbgDjPrWGMsS0K4+51xHjoCuDesOtsMXBbPk8zsUYK2HiUVAVRiERGRiKnxXkREIqXEIiIikVJiERGRSCmxiIhIpJRYREQkUv8fNrS+/EF+B2cAAAAASUVORK5CYII=\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYwAAAEoCAYAAABLtMayAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy8QZhcZAAAgAElEQVR4nO3deXxU9b3/8ddnkpCFLEBW1gCyKKCgRFARr0u1Lm21da1b8ap4ta321qrVq63a1utSb/u7t9qK+8/aVq/W9udaFNDihoCAOyCCgBAIe9gSknx/f3xPyIAJnOBkziR5Px+PeczMOWfmfDjG85nvbs45RERE9iYWdQAiItI+KGGIiEgoShgiIhKKEoaIiISihCEiIqEoYYiISCjpUQfQlmbPnl2Snp7+ADACJUcRkb1pAD6oq6u7ZPTo0at339mhE0Z6evoDZWVlBxQXF6+PxWIacCIisgcNDQ1WVVU1rLKy8gHgW7vv7+i/ukcUFxdvUrIQEdm7WCzmiouLN+JrZb68P8nxJFtMyUJEJLzgntlsbujoCUNERBJECSMFbN261a6//vqyqOMQkc6hpqbGrr322p6t/ZwSRhL88pe/LPnBD37Qu6X9ZsaWLVv030JE9tne7jPxMjIy3L7cczp0L6l9cervXh8K8PcfHDk/Ud+ZnZ3dcNBBB21tfL9ixYr0559/Pu/jjz/Ovvzyy9d8+OGHmV27dm248sore5100kmbZs6cmdOrV68dl1xyyfpExSAiKWTSMUMBmDitze4zixYtynjrrbe6rlixIuOcc85ZP23atNzKysqMk08+edPWrVtjI0aM2Nbac+hXbRK88847XY855pgtje9vvPHGnhdddNH66urq2ODBg2unTJmSP3HixLUFBQX1vXr12jFz5syuEyZMULIQkdB2v8/cfvvtpeeee+6Ga6+9tuq6667rffbZZ2/csmVLLDMz07344ov5J598cnVrz6GEkQTLly/v0rNnzx2nnXbagJkzZ2bV1dXZSy+9lLdt27bY+vXrY1u3bo0tXbo0o6KiYutTTz3VraKiYouqqESkNXa/z+Tl5TVMnjw5d8WKFel9+/atnTNnTtagQYNqhgwZUrtixYqMbdu2WWvPYR15AaV58+YtGTly5JrWfCbRVVJVVVVpEyZMKD/77LPXnXbaaZvy8/MbEvG9ItKOJbhKKtH3mXnz5hWNHDmy/+7bO00bxjVPzeu7oLI6Z2/Hfbp6czY0JY49GVKWt/WuM0Yu29MxU6ZMya2qqsqYNm1a3oUXXrghfMQi0u787ft9Wf3RXu8zrFmQDTQljj0pGbaV0+5JiftMp0kYUXnjjTdyf/WrXy2/5ppr+lZXV8dqamqsqKiovnH/E088UVBdXR3Ly8trqK6ujqmhW0RaK1n3mU6TMPZWEmiU6CqpuXPn5tx5550rLrrooqqJEyf2ffjhh5c27mtoaGDOnDnZt912W+UNN9xQdvvtt1cm4pwiEpG9lAR2SnCVVLLuM50mYURl+vTpCwGuuuqqtVddddXaZcuWpT/77LP5ixYtyhw+fPj2WCzGPffcUxiLxdi0aVNMbRwi0lrJus+oJ06S3XjjjT3Ly8trL7300rWVlZXpl1122drq6urYZZddtlbJQkQSoa3uM0oYSVZYWFi/efPmtKysLLdx48a08vLyHY3PUccmIh1DW91n1K02IpMmTepeXFxcX1VVlVZcXFz/7W9/e1PUMYlIx7Kv95lO36021UycOFG9oUSkTSX6PqMqKRERCUUJQ0REQlHCEBGRUJQwREQklI6eMBoaGhpaPSOjiEhnFdwzmx2r0dETxgdVVVUFShoiInvX0NBgVVVVBcAHze3v0N1q6+rqLqmsrHygsrJyBB0/OYqIfFUNwAd1dXWXNLezQw/cExGRxNGvbhERCUUJQ0REQlHCEBGRUDp0o3dRUZHr379/1GGIiLQrs2fPXuOcK959e4dOGP3792fWrFlRhyEi0q6Y2efNbVeVlIiIhKKEISIioShhiIhIKEoYIiISihKGiIiEooQhIiKhKGGIiEgoShgiIhJKUhOGmR1oZmkJ+J78RMTToodP8Q8REdkpaQnDzMYCbwMZu20/08weNbPXzaxnsO1YM7vSzK4KPoeZFZrZfDP7FLgmWXGLiIiXtKlBnHMzzKwqfltQ2ljonPuemf0IONTMngfuBA4NDpsCHAtcBJzqnPskWTGLiEiTSNswnHP1zrm5ZpYOFAMvA/2ANS4A7DCzgcH+58zsVTMrjDBsEZFOKfJGbzMz4ELgDOAcoAyojjukGih1zl0HDAXmArfs4fsmmtksM5tVVVXV0mEiItJKkSeMoCDxEHA8PmmsBXLjDskF1gTH1gO34kshLX3fJOdchXOuorj4S7PziojIPookYZhZzMxKdttcC3zgnFsA5FkAyHXOLTSzzOC4EnzjuYiIJFHSGr3NrALfDnECsBS4wcwuB6YCd+OT1y+Cw68Hrm58bWYDgGfNbBI+sdydrLhFRMRLZi+pWUDXuE1nBc8jmzl2OjB9t80j2ig0EREJIfI2DBERaR+UMEREJBQlDBERCUUJQ0REQlHCEBGRUJQwREQkFCUMEREJRQlDRERCUcIQEZFQlDBERCQUJQwREQlFCUNEREJRwhARkVCUMEREJBQlDBERCUUJQ0REQlHCEBGRUJQwREQkFCUMEREJRQlDRERCUcKQr+7hU/xDRDo0JQwREQlFCUNEREJRwhARkVCUMPaF6uxFpBNSwhARkVCUMEREJBQlDBERCUUJQ0REQlHCEBGRUJQwREQkFCUMEREJRQlDRERCUcIQEZFQlDBERCQUJQwREQlFCUNEREJRwhARkVCSmjDM7EAzS0vmOUVEJDHSk3UiMxsLTAUKgfq47WcC3wD2A850zq00s2OBEYABbzvnZjS3LVmxi4hIEhNGcNOvit8WlDYWOue+Z2Y/Ag41s+eBO4FDg8OmmNnxu28Djk1S6CKJ1biWykXPRxuHSCtF2obhnKt3zs01s3SgGHgZ6AescQFgB9B/921mNjCywEVEOqHIG73NzIALgTOAc4AyoDrukGqgpJltpS1830Qzm2Vms6qqqpo7RERE9kHkCSMoNDwEHI9PGmuB3LhDcoF1zWxb08L3TXLOVTjnKoqLi9soahGRzieShGFmMTMr2W1zLfCBc24BkGcBINc5N7+ZbQuTHbeISGeWzF5SFfh2ihOApcANZnY5vufU3fjk9Yvg8OuBq+Net7RNRESSJJm9pGYBXeM2nRU8j2zm2OnA9L1tazPOgavf+3EiIp1I0hJGu7LiXcjM3ftxIiKdSOSN3impSw5s3xR1FCIiKUUJozmZ+VBfAxuXRx2JiEjKUMJoTmaBf/78rWjjEBFJIUoYzenSFSwNlr4ZdSQiIilDCaM5Zr5aSiUMEZGdlDBakpUPVR/D1nVRRyIikhKUMFqSme+fl74dbRwiIilCCaMlmXmQ1qXZdowPV27kw5UbIwhKRCQ6ShgtsRj0Hg2fq+FbRASUMPas3+Gwch7Ubok6EhGRyClh7En5OGiog+Uzo45ERCRyShh70neMr5pS91oRESWMPcrKh9IRGsAnIkIrE4aZjWirQFJW+RGwbCbU1UYdiYhIpFpbwnjSzArN7DvNrJjXMfU7HOq2+cZvEZFOrLUJozt+1bsRwB/MbFziQ0ox5Uf4Z1VLiUgn19qEsRj4b+fcrc657wB92iCm1JJbAj32U8O3iHR6rU0YNwJTzex8MxsClLZBTKmn/AhY+hY0NEQdiYjInj18in+0gVYlDOfcVOB0YCxwF1DZFkGlnPIjYPsGqPok6khERCKzL2t6LwIeAT5zzq1PbDgpqt/h/nnpm1A6LNpYREQiEqqEYWbXmNlkMzsTmA1cDvyHmR3bptGliu79Ia+n5pUSkU4tbAnjeODrwBHADOfcJQBmdlJbBZZSzHwp4/O3wLmooxERiUTYNoyPnPcG8Ku47ae3QUypqfwIqF4BGz6POhIRkUiETRg/N7NRweuBcduXm9lxCY4pNTWOx1D3WhHppEIlDOfcRufc3ODt1XHbb45/36EVHwBZ3TSAT0Q6rURMPmgJ+I7UF4tBv8NUwhCRTit0t1ozuxTf6H2gmT0UbH4K6DytwP0OhwUvkZaxP/WWEXU0IiJJFTphOOfuB+43sxedc//auN3MftAmkaWioB0jx22l2goiDkZEJLlUJdUaPUdBejZdG7Rkq4h0PvuSMB7dy/uOK70L9KkgxylhiEjn0+qE4Zz7y57ed3jlR5DlttPFbYfNVVC7VYP5RKRT2Je5pDq3/kdir93B4B0L4deDgo0GXbr6R0YOdMmFLjlx24LnLsG+jMZ9ccftPCbukZ7te2eJiKQAJYzW6j+ez9P7k+bq6PP1H0HtZl/KqN0CO7b458bH9k1QXbnrMXXbWne+FpNN1z0kqZaOizteiUhEWqlVCcPMLgAed8513oUhzNgcywOgz5hLW//5hnrYsXXXxLJLstkaJJgtXz5uR+O+zbB5tX9uPGbH1tbFkZETvqSzp+TTpatf7zxNvz1EOrrW/l++HrjMzAyY65zTsOfWiqVBZp5/JFJDQ1zy2NJMQtq6a0knPtnEP7as+XKpKRSDew+HkmF+CviS4f65oK+fvFFkH519nx8s+8Rlh0ccibQ2YfwDyAC+B/zRzJ4D5gOPOuc2Jzo4aYVYDDJz/SORGhp8NVqzyScoEb12B9TV+OSwbAZ88FTT5zMLoOSAIIkMg9Lh/jm7W2LjFJE219qE8QLQC3gMGO2cW29mPYBXgMMSHZykgFisqeqpJe/+X/983pP+edsGWP0xrP4QVn0Eqz+C95+Cmk1Nn8nvs2sSKR0OhYN912URSUmtTRj/BG53zu2I21YDvJu4kKTdy+4G5Yf7RyPnYONynzxWfdj0vGgqNNT5Y2LpUDSkqVqrdIR/XdBH1VoiKaC1CWNyfLIws284554DrgjzYTM7EL+2Rn0rz7v79+Q75zbt/UhJGWbQra9/DPl60/a6Wli7MCiJBCWSpW+3XK1VOty3j5QcoGotkSQLlTDMrAj4JTDCzJYGm9OAEcBzIb9jLDAVKATq47afA/wQKAUudM69GfTGqgGG4dtHFptZIfBmcN4/AzeFOa+0vQ9XbgRg+L58OL1LU5UUZzZt371aa9WHvlpr1kNNxzRWazUmkdJhqtYSaUOhEoZzbo2Z/RY4Gvg42NyAb/AOxTk3w8yq4reZWTZQ75wbZ2bnAjeZ2fnAd51zJ5tZT+Ae4DvARcCpzrlPwp5zX+3pBrh9Rz1/qhnHqLQl+3aDlHDCVGs1Vm3tUq2VAUWDmxrXG59VrSXylbVmttpPgF1u1mY2EFj9Fc6/A3g6eD0HOBkYBNQG51xpZocE+4uB58xsOXC6c25tc19oZhOBiQD9+vX7CqE1b+onq3m85ige5yj+dO8bXDp+IF8fXkZaTDejNhe6WutDv27J+//bdExmQVwje1y33yzNOpzqfrb2muDV65HGIeGrpB4HJuDbKn6EXwPDgG5A9309uXOuLu7tUcCdwErgoKD0UQdkBsdeZ2Y3AHcDtwDNTqvunJsETAKoqKhI+CRP7yxeRyY7mJA1jZe2nMYVj79L3x7ZXDxuAGdW9KVrpgawJV2oaq2gauv9/4VZcc1fBX2/nERUrSXSrLB3t+ucczvM7B/AI865jQBmNiYRQQQllaXOufeC91fj20yWA41tJjjn6s3sVuCRRJx3X8xcso6haV/wrS6zufbq3/LyR5XcP30xNz/7Ef/18gLOO6ycCUf0pzQ/K6oQpdFeq7U+aOr2u2jKbtVaQ748dkTVWtLJ7TVhmNk1wI/NrLFU4azpf5p8oNUjxcwsBhQ551abWQmwv3PuBTPLAvKdc88Az5jZTQSlBTPLdM7VACXA2609ZyJUb9/Bxys3cXbGcgDSYsaJI3py4oievLt0PQ9M/4z7XlvEA9M/45sje3Hp+IEc0DM/ilClJXut1oprG2mjaq2v1ElAJEJhShjTgPudcxt232Fm48KeyMwq8O0QJ+BLDTeY2QTg70Cemd2Jr+o6ODj+HCDXOfegmQ0AnjWzSfj2jbvDnjeRZn++ngYHw9OXfWnfIf26c+95o1m6disPvbGYJ2ct46/vfsH4wUVcMn4gRw0uwvTrNHXtUq0VZ9t6X621c+xImGqt4b7hPU3L+ErHsteE4ZybtYfdK8KeKPie+OHCZwXPX5ogxsxOxI/X+Evw2cX4LryRmrlkHWkxY/+0L1o8pl9hDjd/azj//rUhPP7O5zzyxhK+99A7DC3N4+LxAzh1VC8y09OSGLV8Jdnd/dK8wfK8QFCttWzXsSN7rdYa4V/n947m3yGSAK2drfabwKn4hZdi+Jt4RaKDcs69lOjvTISZi9czolc+2Zt27PXYgpwMrjh6EJccOZBn563g/umfce1T73HXP+Yz4Yj+nDe2H91y1LDaLplBt37+MfTEpu11tbBmwa6j2Xev1soqoP+OHWyxXD/9fZaqLCWx2rLKs7VdeoYD/wP0ARYARyY8ohRVU1fP3OUbuPCwcngv/Oe6pMc4fXQfvnNIb17/dA33T1/MXf+Yz++mfsqZFX24+MgBlBfuYZ4maT/Su0DZCP+It1u1ls3+CyUNq+G/D4ZjrodDJmh6eGkXWvtXmg3k4BNGDn68w8OJDioVvbd8I7V1DRw6oEerEkYjM2P84GLGDy5mfmU1D0z/jL+8s4zH3v6cE4aVMvGogYwu75H4wCV6u1VrLX5vJlkNW9mvuAyevxpm3AfH/8I3wqudS1JYa5ddeww/2O5RYBQRdm9NtncWrwPg0P5f/aY+tCyPu84cyevXHcMVR+/H25+t4/Tfv8W3732DF95fSX2D1gjv6LbHcmDC83DOn8A1wJ/Phke/CSvnRR2aSItamzBuAA50zm0HngRWJT6k1DRzyToGleTSo2vi2h1K8rO45uv789b1x3LrqcNZt6WWKx5/l6N/PY2H31jMlpq6vX+JtF9msP8pcMXbcNJdvsrqvn+BZy6HjS13rBCJSmsTxnTn3MMAzrl5wI8TH1LqqW9wzF6yPiGli+bkdEnnwsP7M/Xqo/nD+aMpycvilmc/4vD/nMIdL33Cqk3b2+S8kiLSMmDsRLhqLoy7Ej54Gv5nNEz5BdRURx2dyE6tTRg5ZtbLzHLM7DJ27SbbYX1SuYnqmjrGDNjnWVBC8QMBy3j68iP46xVHcOTgIu57bRFH3jGVHz85l49Xakb3Di2rAI6/FX4w05c8pv/aN4zPegjqVdqU6LU2YTwEXAo8gW/D+E7CI0pBMxPYfhFW40DAV39yDOeNLeelDyo56f9M5/wHZvDq/NU4p3aODqt7OZzxIFwyBQoHwXP/Dn8YBwtf9mNARCLSqoThnNvmnLvFOfdN59zl+LUpOryZS9bTqyCLPt1zkn7uxoGAb/30OK49cSgLV1cz4eGZnPjb6Tw5axk1dV9pLSpJZX0q4KIX4azHoL4WHj8DHjsNKt+POjLppEIlDDN73MwyzOwqM1tsZp+Z2WJgdhvHFznnHO8sWee700aocSDg9GuP5e4zR2IG1z71HkfeMY3fTV3I+i21kcYnbcQMhn0LrpgBJ97he1H9YTz87fuwaWXU0UknE3Ycxk+D2Won41fA2wBgZoe2XWjRubXwLsDXu32+ditV1TVJrY7ak/iBgG98upb7p3/Grycv4J5pizizog//Om4A/Ys6RdNS55LeBQ77Nxh5Nky/24/d+PCvcMQP4YgrIbPVc4CKtFrYFfcaZ9vLd859HLerNPEhpZZ3lvj2izERlzB2Z2YcObiIIwcXNTsQ8NLxAxld3l0THnY02d3hhF9CxcUw5RZ47Q6Y/Qgc8x9w8PkQa9+1xA0NjuXrtzF/VTULVlUzv7KaeZsvZrvrwiF/nM3Ivt0Y1bcbB/Yu0NozEUjamt7t1czF6+iWk8Gg4tT9Bdc4EPCaE4fyf9/8nD/O+Jx/fLiKUX27BSsClpKe1tr+DZLSegyAMx+Bw66Af/wHPHslzPgDnPALGPS1qKPbK+ccVZtrmF/pk8KCVdXMX7WZhauq2Vrb1C7Xp3s2vWIbyWIHH67oxYsfVAIQMxhckseovt12JpEhpbn6O29jSVvTu72auWQdFeU9iLWDJVhL8rL4ydeHcsUx+/HU7OU8+Ppivv8nvyLgv44bwFlaEbDj6TsGLp4MH/0dXvk5/PF02O84XwopHRZ1dABs3LaDhauqmR+UGBoTxPqtTZN4FuVmMrQsl7MP7cvQ0jyGluUxuDSP3Mx0PrztZwAMv/Ya1m2pZd6yDcxdtoF5yzcw+aNKnpjlK0CyMmIc2LtgZxIZ2acbfbpnq5SdQFGv6Z3SVldvZ8narZw7NvFrg7elxoGA540t5+WPVvHA9M+45dmP+M3LCzh3rF8RsKxAKwJ2GGYw/DQYehLMfABeu9N3wz34fF9VlVeWlDC276jn09Wb40oMPjms3Ng08DQ3M50hpbmcOKInQ0tzGVKWx9DSPApzM0Odo0fXLhyzfwnH7F8C+JLK0nVbmduYRJZt4NG3Pqd2+mIAinK7MLJPUylkZJ9uFORonZJ9Fema3qlu5uL1QHLHXyRS40DAE0eU7VwRcNI/F/Hg65/xzYN6ccn4gQzrpem1O4z0TDj8+zDyu/DPu+Cd++H9p2HcVXDED6BLYjpD1NU3sGTtVhasquaTymoWBAliydotNE6D1iU9xqDiXA4bWMiQ0jz2L8tjSFkevQqyEvqL38woL+xKeWFXTh3l1xqprWtgfmU1c5dvYO5SXxKZOn/1ziEsA4u6BiWQAkb1684BPfO0Rk1Ire0lVQsc3NF7STWauWQd2RlpjOjduiU4U1GzKwLO+YIjBxVxyfgB/MuQYhXdO4qcHnDif8Khl8ArN8Ort8Hsh+HYG30yCdkw7pzjiw3bgsbnzTsTxKLVm6mtbwB8W0L/wq4MLcvjmyN7MbQsjyGlefQvzImsPaFLeowD+xRwYJ8CLjisHIBN23fw/vKNO0shb3y6hmfm+Pm6MtKMYT3zm6qy+nZjQGHXdlENnWyt7SU13jn3+7hdS5s7vqN4Z/E6Du7XjYwO1JC2+4qAj765hAkPz2RIaS6XHDmQUw/WioAdRuF+cPZjsPRt3zD+9+/D20HD+H7H7HLo2s01O6uQFux83szmuAkwexVkMaQsj6MGF+1MDINKcsnKSP2/l/ysDMYNKmLcoCLAJ8PKTduZt2wDc4Ik8tTs5Tz61ufB8ek720EaE0lxXrhqs46stS2gO8zsRWB98H4gcFhiQ0oNdQ0NfFy5iSuPHRx1KG2i2RUBn36PuybP53uHl3Pe2HK6J3BmXolQv8Pgklfgw7/S8PLNxB47jRXF4/lb8WW8vrGYBauqWbO5aeBn95wMhpblcfohvXe2MQwpyyM/q+PU/ZsZPQuy6VmQzYkjegJ+ktFPV2/eJYn8/rVFO5cb6N0tO0geBYzq250RvfPJ6dK5OpGEbcNobPWdDbyP7yFVAvRvm7Cit3l7Hc6l3viLRGtpIODvpn3KmaP7cvGRGgjYHtXU1fNZ1RbfK2mVb2eYv6o7Vetv5cK0yfxw9d+4bPUFDMw+kXcGXUbvPoOCxJBLcW5mp6yeTIsZQ8t8D62zDu0LwLbaej5YsXFnz6y5yzbw/Pt+hH3MYEhpHgf367azYX1IaR5pHbgqK2x6XAz8FLjPObcJdo7NOKmtAota9fY60mPGwf26RR1KUjQ3EPCJmcv444zPOf6AxhUBNRAw1dQ3+F5C8VVJ81dVs3jNlp2/jDPSjP2KczmkX3eGjunHkNIjqC64gbx5/8OJsx7kxM+mQ68fQfn3oYt6z8XL7pLGof177NLxZc3mGuYFJZC5yzfywvuV/PkdX2uf08W3eY7q21SVleiG/iiFTRh/cs7dFb8hGJvRuw1iSgnV2+sY3rug0xU5ofmBgJM/0kDAKDnnWLWphk8qN+3SCL1wdTXbd/gGaDPo1yOHIaV5nDSijCHBeIb+hV3pkt7Mf6/ed8KYiX78xtRfwqyH4dib4KCzIab/vi0pys3kuANKOe4AP9GFc44la7fuUgp55I0lOzsGFOdlBm0hvirrwD4FFGS3z+q9sHfDlgboJX/61iRoaHBsrqljTP8O22M4lJYGAvbpHgwEPLQvuRoImHAbttbuLDF8Eldy2LS9qQG6ND+TIaV5nD+2nCFlvtvqoJLc1v/AKRoE5zwOS96Ayf8Bf/s3ePte+PqvYMBRCf6XdUxmxoCirgwo6sppB/vf0DV19Xyyspp5Qdfeucs38MrHTQuUDizu2lQK6dONA3rmN5/UU0zYv64DzCzbObetcYOZ5QOpMZQ0wTbX1uFov+MvEq25gYC3PvcRv3llAeeNLefwhlyKYpujDrPd2Vpbx8JVm+PaGHxiWF1ds/OY/Kx0hpbl8a1RvXwbQ/BIeIeE/uPgkql+tb8pt/j1xYec5Bd0Kh6S2HN1ApnpaTu76F54uN+2cdsO3lu+YWdJ5J8Lqvjru75rb5e0GMN65e9SldW/MCflqrLCJowHgdlm9hegEugHnIdfTKnDqQ5+ySlh7Cp+IOCcpet5YPpiJv1zEfe7K9gvtoqu974RdYjtwrYtF7KxIYfKn/9j52CyzPQYQ0rzGD+4mKFluQwty2doaR6l+UlsgI7F4KAz4YBvwozfw/T/gnsPg4qL4OjroWtRcuLooAqyMxg/uJjxg4sBX5W1YuP2nYML5y7bwBMzl/HIm0t2Hj+ybzdG9SlgVNCwHnZEfFsJOw5jqpl9A7gSGIMff3FasK53h1O9vY7sjDR1K92Dg/t1557zurNs3Vbu/u0dLK0v0jxVIRk1FKdt5LvHjN3ZztCvR07q9K7JyIIj/x0OvgBevd0vETvvCRj/YzjscsjIjjrCDsHM6N0tm97dsjnlIN+1t66+gYVB197G9pDfTavaOYK+T/fsXUohI3oVkN0leeNgWjOX1Gf4aUE6hfxs3fzC6Nsjh0uzpgAw/OIfRhxN+/DhbVcDMPy4ayKOZC+6FsEpv25qGJ9yi08ex/0MRpyhhvE2kJ4W44Ce+RzQM59zxvjRDFtq6vjgi407SyFzlm7guUtK7rIAABAgSURBVPd81960mDG0NI9R/boxqnc+h+auIb9+Pdlu+55Os+/xtcm3tnP7l+VpzWyRRsVD4Lt/hsX/hMk3wl8v9Q3jJ/zKt31Im+qamc7YgYWMHVi4c9vq6u18vGAh6xa8RdqK2ZTM+4BhcxeRb76ZeYvLZOPaSgoKEzvxpBJGC/ZUbzy8Z/ufW0qk1QYcBZe+Cu8/CVNuhUdOhv2/AV+7xfe2krZTuwVWzIUvZsMXsyhZPpuSTcv9vlg6rudwNvU4g1kZQ3lx9qfMahjEM90Tv76dEoaIhBeLwchzYNip8NY98Ppv4N6xfgXAf7kOuhbu/TtkzxrqoWo+fDELls+CL96F1R+BCxaW6tbPr4PS5wroPRp6jsQysikAKoDsj47kO8wmFkt8FbEShoi0XkY2HPUTOORCePU/Yeb9MO8vcNTVMOYy33Au4WxaESSG2f6xYg7UBt3Uswp8Uhh6tX/uPRpyiyMLVQlDRPZdbgl84zc+Sbz8M/+Y+QAc93MYcboffi5NaqqDqqW40kP1Cr8vlgFlB/op6PtUQO8K6DEwpToXKGGIyFdXsj+c9yR89ir840Z4+uKmhvHyw6OOLhr1dVD1sS81NJYgqj4B56cMofsA32mg92ifHMoOTPmSmRKGiCTOwKPhstfgvSdgyi/g4RP9QMCv3eLX5+ionINNXwSJISg5rJgDO7b6/dndfWI44Fu+9NDrkHbZ3qOEISKJFUuDUefCsNPgrd/B67+F+S/BmEvhqGv8ioDt3fZNsOLdoPTgey6xOZgrKq0LlB3k23ca2x16DOwQ1XNKGCLSNrrkwL9cC4d8D6b9Cmb8AeY+Dkdd65NHejtZwa5+h++lFN8wXTUfCMZqFQ7yJaveFdBnNJSOaD//tlZSwhCRtpVXCt/6bxj7b/DyTX5W3Jn3w9du9qWQVPrl7RxsWNpUrbR8FqycB3XBvKs5hT4xjDgdeh/iq5Y6QokpJCUMEUmO0mFw/tPw6RSYfBP87wToM8ZPpd53TIsfa9OBsts2+Kql5bN3DopjS5Xfl54FPUf6yRd7j/ZtD93KUyvBJVlSE4aZHQh85FzjCBQR6XQGHeercOb+yS/c9ODxMPzbvitujwFtd966Wlj1QVO10vJZsHZh0/6iITDoeF+t1DuoWkprnwsdtZWkJQwzGwtMBQqB+rjt5wA/BEqBC51zb5rZBUANfr2NR51zi83sWGAEYMDbzrkZyYpdRBIslgaHXOATxZv/A2/+N3zyvJ/o8Kif+F5FX4VzsH7Jrl1aV86D+mCtka4lvsQw8mxfxdT7ED9ITvYoaQnDOTfDzKrit5lZNlDvnBtnZucCN5nZ+cB3nXMnm1lP4B4zOxO4Ezg0+OgU4Nhkxf4lFz0f2alFOpTMXDjmehg9Aab90k83MvdxP81IxcWQHnKJga3rfJtDY7XSF7Nh61q/Lz0beo3yDe19KnzpoaBvp65a2ldRt2HsAJ4OXs8BTgYGAbUAzrmVZnYIfsGmNS6YQtbMdpjZwGDK9V2Y2URgIkC/fv3a/l8gIl9dfk849R4Ye7mfEfeln8I7k/z4Ded2vbnX1UDlB3GjpWfDukXBToPi/WHoSU0D4kqGQVrUt7qOIdKr6Jyri3t7FL4UsRI4KCh91AGZQBlQHXdsNb4K60sJwzk3CZgEUFFRoTnKRdqTshFwwTNBw/iN8OQFkJnvq5BeuNYnicr3ob7WH59b5ksNB5/vn3uOgqz8aP8NHVhKpF0zGwgsdc69F7y/GvglsBy/ut9aIDfuI7nAmmTHKSJJYAaDvxY0jP8Rnv8JrPsU5qyEXgf7Vf8aSw8FvaOOtlOJJGGYWQwocs6tNrMSYH/n3AtmlgXkO+eeAZ4xs5uASc65BWaWZ02LVOQ65xa29P0i0gGkpfu2jbl/8Y3Vl7ziG8slMsnsJVUBFAMn4EsNN5jZBODvQJ6Z3YkfOnlwcPw5+MTwYPAV1wNXx70Wkc4glgaxHCWLFJDMXlKzgK5xm84Knr80laWZnYgfr/GXuM9PB6a3aZAiItKilGjD2J1z7qWoYxARkV2lzsocIiKS0pQwREQklJSskpL25dbCuwB4IuI4RKRtqYQhIiKhKGGIiEgoqpISSbI2Xd9BpA2phCEiIqEoYYiISCiqkhIR6UDasspTCUMk2bQAl7RTShjylT1x2ZemAxORDkgJoxm6AYqIfJkavUVEJBQlDBERCUUJQ0REQlHCEBGRUJQwREQkFCUMEREJRQlDRERCUcIQEZFQlDBERCQUJQwREQlFCUNEREJRwhARkVCUMEREJBQlDBERCUUJQ0REQlHCEBGRUJQwREQkFCUMEREJRQlDRERCUcIQEZFQlDBERCQUJQwREQlFCUNEREJRwhARkVCSmjDM7EAzS0vA9+QnIh4REQkvPVknMrOxwFSgEKiP234O8EOgFLjQOfemmV0MbAAGAe87514ws0LgTSAN+DNwU7JiFxFpNy56vs2+OmkJwzk3w8yq4reZWTZQ75wbZ2bn4pPAScD5zrljgpLE48ALwEXAqc65T5IVs4iINIm6DWMH8HTweg6wNnhdZWbXAN8FfhtsKwaeM7NXg9KGiIgkUaQJwzlX55xrCN4eBdwZvP4hcCHwPeC94NjrgKHAXOCWlr7TzCaa2Swzm1VVVdXSYSIi0kpRlzAAMLOBwFLn3HvBpjuBscBjwB8aj3PO1QO3Av1a+i7n3CTnXIVzrqK4uLgNoxYR6VwiSRhmFjOzkuB1CbC/c+5FM8sK3vdxzm11zv0eKAqOyww+XgK8HUXcIiKdWTJ7SVXg2yFOAJYCN5jZBODvQJ6Z3Qk44GDgKTO7DKgBfmNmA4BnzWwSUAvcnay4RUTES2YvqVlA17hNZwXPhzdz+O+b2TYi4UGJiEhoSUsYIiL7pA3HFUjrpESjt4iIpD4lDBERCUUJQ0REQlHCEBGRUJQwREQkFCUMEREJRQlDRERCUcIQEZFQlDBERCQUc85FHUObCRZs+nwfP14ErElgOImiuFpHcbWO4mqdjhpXuXPuS9N9d+iE8VWY2SznXEXUcexOcbWO4modxdU6nS0uVUmJiEgoShgiIhKKEkbLJkUdQAsUV+sortZRXK3TqeJSG4aIiISiEoaIiISihNHOmVl+ROc90MzSojj3nuwtrqiuV3ul69U6Hf16dfqEYWbpZvYLM/u2md1gZrG4fcea2ZVmdpWZjU2huArNbL6ZfQpck8y4gvOPBd4GMnbbHtn12ktckV0vM8s3sz+b2Wdm9oiZWdy+KP++9hRXlNerm5n9HzN7xcyu3W1flNdrT3FF+v9jEMNoM7tvt22Jv17OuU79AC4H/i3u9dnB6zRgFmDBY2oqxBW8/wmwf8TXbQmQFfc+0uvVUlxRXy/gDCAbyATeB8amwvVqKa4UuF6H4H/IxoBXUuXvq6W4or5ewfm7BTE80tbXq9OXMIDDgLnB67nAKcHrfsAaFwB2mNnAFIgLoBh4zsxeNbPCJMa0J1Ffrz2J8nr9P+fcNudcDfARsDbYHvX1aikuiPB6Oefedc41AEcA98ftivR67SEuiP7/xzOAp3fb1ibXSwkDyoDq4HU1UNrM9t33RRkXzrnrgKH4RHJLEmPak6ivV4uivF7OuVoAM8sCljvnPg12RXq99hBX5H9fwY3tIuBnQXyQAn9fLcQV6fUyszOAZ4Ddu7u2yfVSwvC/rHKD17k0zb8Sv333fVHGBYBzrh64Ff9LIhVEfb32KAWu19nAz+Pep8r12j0uINrr5Zz7zDl3MTADODDYHPn1aiGuxn1RXa+LgAfx4y6ONbOrg+1tcr2UMGAyMDJ4fRAw2cxKnHMLgDwLALnOuYVRxwVgZpnB9hJ8I29kzCyWIter2biC15FeLzM7GXjBObfZzMpT5Xo1F1ewPVX+vjYAn6XK9WouLoj2ejnnTnHOnQZMBKYCv2nL69XpB+4FvY9uBd7D35ifAa5zzp1lZuOBxt4FM5xz06OOK3g8i/9FUQs8HNRDJ42ZVQCvAd8FlgI3RH29WoqLiK+XmZ0D3AVsxDdEPgaMivp6tRQX0V+vW4C++Dr5Gvyv4sj/vlqKixT4/zGIrz9wM/Bb2vB6dfqEISIi4ahKSkREQlHCEBGRUJQwREQkFCUMEREJRQlDRERCUcIQEZFQlDBERCQUJQyRdsbMepjZ82a2/27brzSz26KKSzo+JQzpkMxsnJltMbNbzOx6M3vazPok8fz9zWyGmR0bvB9hZrVmdmjcMcea2Q4zO8b8+hSvmdndwfoKL5rZb4MpTs40v2ZFGoBzbh2QDiwwsy5m9njwldvwMwPsKa6DgjguCN53N7PJwfW6zcxuboPLIR2EEoZ0SM65N4Aq/FQN/wnMBH6c5DA+ds5NDV5vA5YDvWHnLLGXA+8456Y55zYBrwILnHNrgU+AJcGU2vnA1cEEd42f3R7sOx6YEpxjLPDmXmLaBCx2zj0G4JxbD7wWXK/JCfg3SweWHnUAIknSA1hoZlfi1zT4AfAc8FNgIHA00AWYDhyHTzBnAOOBS5r5zDD8zfoT/Fol5zjnPtrD+Y8C/hdoLOVMBBYHn2+0FOhvZjn42VBrgontMp1za4O5gYbhp65+J/jMqcD1wet+QJWZPQbcEfybNgJjgDnOuYeCf9srjScM1m9YuccrJxJQCUM6usvN7F78zfMFgiob59wa/Op8BM+lzrlz8IsJEZRKluJnDG7uMx/7Te56/IRvuyzb2Yw8YCHQ28wOwpc2DsbPMNpoGb4EchpwHz4xnA08EVSn/dg5dx9+BbXpZpYOFATJpDuwHjgRv1LjB8AZQUmiEJgTnONY4hIGcAzw8l5iFwGUMKTj+71z7grgKeChFo5pwN9swS9EUxu8rsEvYdqc+ONmA0UtBWBN67F/gS8FfAdfUjmEXauQlgED8GuSLwyO7RpUUV0P/Do47nB8CeM4YFqw7Qj8AjlHO+e2BNummdkpwKPOuTlxn3017pwDnHPLWopdJJ4ShnQWi/C/8uvxa1kDZLV8+C729plS/KI6LakA5uFLFScDj+LbG+buNhX2MnwS+X/45FIBPBnsGwO8b2aj8Yvh5ADfxk97Dz5h3ACMMbMcM+uGL50U0NTGAb7arRrAzHrjq6xEQlHCkA7JzI7EL2hzuZn9GLgY+Hd89dJ+ZvYLfKliP/zNeKCZ9cRXQQ0IqoCG4Nciae4zAIPNbAIwDl8t1VwcXfGlg2J8Ergd2BzEUmNxa0A75zYDdwYN0WuA/wpKF+BLFPfh21tiwfcVOedWBftH40s6k4JYjsI3qo9n1zWorwX+YGY/Bf6VlktdIl+i9TBE9oGZHY1vKzinhf39gVucc99LYljx57/NOXdD8Poe59z3Q3zmaHyV1s1tHJ60UyphiOybsfiSSO8W9m8GNpjZCUmMKd46MzvFzE4C/rS3g81sGDCcvYzjkM5NJQwREQlFJQwREQlFCUNEREJRwhARkVCUMEREJBQlDBERCUUJQ0REQlHCEBGRUJQwREQklP8P4Ak8jLEpDPoAAAAASUVORK5CYII=\n",
       "text/plain": [
        "<Figure size 432x288 with 1 Axes>"
       ]
      },
-     "metadata": {},
+     "metadata": {
+      "needs_background": "light"
+     },
      "output_type": "display_data"
     }
    ],
@@ -461,28 +446,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "(<matplotlib.axes._subplots.AxesSubplot at 0x7ff3d07edd68>,\n",
-       " <matplotlib.axes._subplots.AxesSubplot at 0x7ff3d07ea2b0>)"
+       "(<matplotlib.axes._subplots.AxesSubplot at 0x7fa54cdec9d0>,\n",
+       " <matplotlib.axes._subplots.AxesSubplot at 0x7fa54cd87d90>)"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAboAAAERCAYAAAANLGKoAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvOIA7rQAAIABJREFUeJzs3Xd4VVX28PHvSiMhgSBNekc6hCKg0tURsCCISlGKCBZwbKM/HQvWd0Z0HAsg0kQEQYqVAStBRAEBpdcQWqSDBEhISFnvH+cSk3CT3JDc3JT1eZ77JPecffZZl3Huyt5nF1FVjDHGmOLKz9cBGGOMMd5kic4YY0yxZonOGGNMsWaJzhhjTLFmic4YY0yxZonOGGNMsVYkE52ITBeRoyKy2YOy/xWR9a7XThE5VRAxGmOMKRykKM6jE5EuwFlgpqo2z8V1DwGtVfUerwVnjDGmUCmSLTpVXQ6cTH9MROqLyNcisk5EfhKRxm4uHQjMKZAgjTHGFAoBvg4gH00G7lfVXSLSAZgI9LhwUkRqA3WBpT6KzxhjjA8Ui0QnImHA1cB8EblwuFSmYgOABaqaUpCxGWOM8a1ikehwumBPqWpENmUGAKMLKB5jjDGFRJF8RpeZqp4G9ojI7QDiaHXhvIg0Ai4DVvooRGOMMT5SJBOdiMzBSVqNRCRGREYAg4ERIrIB2AL0SXfJQGCuFsUhpsYYY/KkSE4vMMYYYzxVJFt0xhhjjKeK3GAUPz8/DQkJ8XUYxhhTpMTHx6uqlsjGTZFLdCEhIcTFxfk6DGOMKVJE5JyvY/CVEpndjTHGlByW6IwxxhRrluiMMcb4hIjUE5FpIrLAm/exRGeMMSWciJQTkQUisl1EtonIVZdYT5ZbqIlITxHZISJRIvIUgKpGq+qIvMafE0t0xhhj3ga+VtXGQCtgW/qTIlJZRMpkOtbATT0zgJ6ZD4qIPzAB6AU0BQaKSNP8CT1nluiMMaYEE5GyQBdgGoCqnlfVzBtUdwW+EJFg1zUjgXcy1+VuCzWX9kCUqwV3HphLxtWrvMoSnTHGlAz+IjJZRG7OdLwecAz4QER+F5GpIhKavoCqzge+BuaKyGDgHuCOXNy7OnAg3fsYoLqIVBCRSUBrEXk6tx/IU0VuHp0xxviCqpKqkJyaSkqqkpyqpKS4fqZqxuOpSlJKxvfJKe7LJacqySmpGd6nZHofcu4QDY58S3iD9rTqnDlPeSxFVUe5OR4AtAEeUtXVIvI28BTwXKbPP05E5gLvAfVV9Wwu7i1ujqmqngDuz0U9l8QSnTHmkqle+KJ2vsCTXV/86X9PSU0lKSXjl3/a+9RUV7JITVfPX1/8aT9T3V2fOTmku3eGJJSpXGq645kTVUrmMn8lpqSUgl0XuDyn6e2/mlv8f6G93w4AViYNgUtPdFmJAWJUdbXr/QKcRJeBiHQGmgOfAWOBMbm8R81072sABy8p2ktgic6YIkZVORWfxMHYcxw6lcCh2HOcTkj+K9lkSBR/JQ4nsbhPPMkXJZu/fs+YYNLX47wKmp9AgJ8fAf6Cv58Q4Cf4+/m5fkra8UA/vwzvL5wPCvTP8D7AX5z6Ml0fcOF6v0z38c90zN8vU5mM116o310sme8RlBxHSPQSQnZ8RsDeHxFNIbXiFaQ2fwZpcRtXVaif7/+eqnpYRA6ISCNV3QFcC2xNX0ZEWgNTgBuBPcAsEXlFVZ/18DZrgIYiUhf4A2d/0EH59iFyYInOmEJEVTmdkMwhVxI7GHuOw7EJHHQltEOxzs+EpFS31/sJBLi+eJ0v2Yt/909/3PWlHeDnR6nAgLQv88ALycLfz/Xzry/mAHfXp7uPv78fgX7urvfLcD93v6e/Ji0BpS/nJ/j5uesFK8KSEmDXt7BpvvMzOQHCa8HVD0GL/vhd3hzE65/5IWC2iAQB0cDwTOdLA7er6m4AERkKDMtciWsLtW5ARRGJAcaq6jRVTRaRMcA3gD8wXVW3eOvDXBSXt7bpcY3OWQ6UwkmoC1R1bKYyjwH3Ask4D0PvUdV92dUbGhqqttalKarOJiZz6NRfCStjAkvg0KlzxJ1PyXCNn8DlZYOpGh5M1XIhVAsPpmp4CNXKBVMl3HlfrnRQ8UwCxVVKMuxZBpsWwvZFkHgaQitBs77QvD/UbJ/vyU1E4lU1NOeSxY83E50Aoap6VkQCgRXAw6q6Kl2Z7sBqVY0XkQeAbqp6Z3b1WqIzhdW58ylpSetgumTmJDCndXYmITnDNSJQKaxUWgKrEh5MtfAQqpb7K5lVCitFgL8NkC7yUlMh5len5bblc4g/DqXKQpObofltULcr+Huvk60kJzqv/au6dvO+MCon0PXSTGUi071dBdzlrXiMyYvE5BS3XYhOAnN+PxWfdNF1FUKDqFoumFoVStOxXnmqlgtxWmbhzs/LywYTFGBJrNhShcObYPMC2PwpxB6AgGC4oie06A8NrofAYF9HWex59Rmdazb8OqABMCHdqB53RgBLvBmPMe4kpaRyODaBw6fTtcROnUtLYIdjEzh+9vxF15UrHei0usKDaVu7XFryutASu7xsMMGB/j74RMbnTuyGTQucBHd8J4g/1O8BPZ6FxjdCqTI512HyjVcTnaqmABEiUg74TESaq6q7NdDuAtrhzL6/iIiMAkYBBAUFeTFiU9wkp6Ry7GziXy2x9AM8XAnt2NlEMvfglwkOSEtaLaqHpyWxauVCqBLuPC8rHWRjuUw6pw86rbbNC+Dg786x2tdAh/uh6a0QWsG38ZVgXntGd9GNRMYCcar6Rqbj1wHvAl1V9WhO9dgzOpOdjTGnmLw8Oq1ldvRM4kVD4EsH+aclrarhfw3oSBvoUS6EsFKWxIwH4k/C1s+dQSX7fgYUqrZyBpQ07wfhNXwdYRp7RucFIlIJSFLVUyISAlwHvJapTGvgfaCnJ0nOmOykpiqPfrKeY2cSaVYtnKvqV0gb2FEtPCRtoEfZkADE+8O1TXGVeBZ2LHa6Jnf/AKnJUKEhdHvKSXAV3a11bHzJm3+2VgU+dD2n8wPmqeoiEXkJWKuqXwKvA2HAfNcXz35VvcWLMZli7Osth9l9LI53B7bm5lbVfB2OKU6SE2HXd0635I6vIfkclK0OHR+AFrdDlZYFMdfNXKIC67rML9Z1adxRVXq/s4LEpBS+e6wr/jafzORVagrsWe603LZ9BYmxULqC87ytRX+o2RH8is6IWeu6NKaIi9xxlG2HTvN6/5aW5MylU4WYNU5y2/IZxB2FoDBofJPTcqvXFfwDfR2lySVLdKbIU1XeXRpF9XIh3Nq6uq/DMUXRkS3ORO7NC+HUfvAvBVf8zXnmdsUNEBji6whNHliiM0Xeyt0n+H3/KV7u04xAW0HEeOrkHueZ26aFcGybM9etXlfo9rQz1y043NcRmnxiic4UeeMjo6hUphS3t6uZc2FTsp05/Ndctz/WOcdqdoTebzjP3sIq+TY+4xWW6EyRtm7fn/yy+wTP9G5iq5AY9879CVu/dJLbnp8AhctbwHUvOnPdytXydYTGyyzRmSJtQmQU5UoHMqiDfVmZdM7HwY4lzqCSqO8hNQnK14MuTzgjJis18nWEpgBZojNF1paDsSzdfpTHr7+CUFvJxCSfdyZwb1rgTOhOiocyVaHDfc7uANVa21y3Esq+HUyRNTFyN2VKBTDk6jq+DsX4SmoK7F3hdEtu/RISTkHIZdDyDmfEZO2rwc+6tF38RWQy8JWqfuXrYAqSJTpTJEUdPcPizYd4oGt9wkNsXlOJc3A9bPzEGVhy9jAEhjojJVv0h3rdIcAWf3cjRVVH+ToIX7BEZ4qkict2UyrAjxGd6vo6FFNQzsfDlk9hzVRndwD/IGc/txa3wRW9IKi0ryM0hZQlOlPkHDgZzxfrDzL0qjpUCCvl63CMtx3fBWunw/rZkBALFRtBr3FO92TIZb6OzhQBluhMkTPpx934izCqSz1fh2K8JSXJGVCyZqqz3qRfADS5Ba4c4ezxZoNKTC5YojNFyuHYBOavjeG2tjWoEh7s63BMfov9A377ENZ96Dx7C6/p7MrdegiUudzX0ZkiyhKdKVKm/BRNiioPdK3v61BMfklNhehIp3tyxxLQVGhwHVz5FjT8m42aNHlmic4UGSfOJvLx6v30aVWNWhVs4EGRF3/See62djqcjHa2wLl6DLQdDuVtkJHJP5boTJEx/ec9JCSn8GB3a80VWaoQsxbWTnOmBqQkOmtNdnsamvaBABtcZPKfJTpTJMSeS2LmL/vo1bwKDSqX8XU4JrfOxznb4KyZBoc3Onu8tR4M7UZAlea+js4Uc5boTJHw0cq9nElM5sFuDXwdismNo9ud1tuGuZB4Gio3gxv/Ay3vhFL2B4spGJboTKEXl5jMtBV76N6oEs2r2x5hhV7yedj+FayZDvtWOBO7m/aBK++Fmh1saoApcJboTKE359f9/BmfxJgeDX0disnOqf2wbgb89hHEHYVyteG6F6D13RBa0cfBmZLMEp0p1BKSUpi8PJqr6lWgbW1bBaPQSU11dgxYMw12feMMNrniBqf1Vv9a8LMd343veS3RiUgwsBwo5brPAlUdm6lMKWAm0BY4Adypqnu9FZMpeuavi+HomUT+e2eEr0Mx6cUdh98/grUfwKl9EFoJOj0KbYfZRqam0PFmiy4R6KGqZ0UkEFghIktUdVW6MiOAP1W1gYgMAF4D7vRiTKYISUpJZdKy3bSuVY6r61fwdThGFQ6sdlpvWz+HlPPOclzXjYXGN9uOAabQ8lqiU1UFzrreBrpemqlYH+AF1+8LgPEiIq5rTQn3xfqD/HHqHC/1aYbYAAbfSTzjbImzZjoc3QKlyjott3b3QOUmvo7OmBx59RmdiPgD64AGwARVXZ2pSHXgAICqJotILFABOJ6pnlHAKICgIPursSRISVUmRkbRpGpZejSu7OtwSqYjW5zW28ZP4PxZqNISbn7b2dC0VJivozPGY15NdKqaAkSISDngMxFprqqb0xVx92f6Ra05VZ0MTAYIDQ211l4JsGTzIaKPxzFhUBtrzRWk5ETY+oWT4A6sAv9S0LyfM7ikelubGmCKpAIZdamqp0RkGdATSJ/oYoCaQIyIBADhwMmCiMkUXqrKhMjd1KsUSs/mVXwdTslwcg+s+wB+nwXxJ6B8PfjbKxAxGEqX93V0xuSJN0ddVgKSXEkuBLgOZ7BJel8CQ4GVQH9gqT2fM0u3H2XbodO8cXsr/P2sBeE1qSmw61un9Rb1vdNaa9Tb2fOtbjebGmCKDW+26KoCH7qe0/kB81R1kYi8BKxV1S+BacBHIhKF05Ib4MV4TBGgqry7NIoal4XQJ6Kar8Mpns4e/WvPt9gDEFYFuj4JbYZCeHVfR2dMvvPmqMuNQGs3x59P93sCcLu3YjBFzy+7T7D+wCleubU5gf7Wosg3qrDvZ6f1tu0rSE2Cul3ghledVpx/oK8jNMZrbGUUU6iMXxpF5TKl6N+2hq9DKR4SYp0FlddOh2PbITgc2o90pgZUtCXVjG+JSD3gGSBcVft76z6W6EyhsW7fSVZGn+DZG5sQHGi7SufJoQ1O623TfEiKh2ptoM8EaNYPgmzTWnMx12OmtcAfqnrTJdYxHbgJOKqqzTOd6wm8DfgDU1X136oaDYwQkQV5iz57luhMoTF+aRTlQ4MY1MGWkLokSedgy2dOgvtjLQSEQIvbnD3fqrfxdXSm8HsY2AaUzXxCRCoD51T1TLpjDVQ1KlPRGcB4nKUd01/vD0wArscZbb9GRL5U1a35+gmykONDEBEZmum9n4g8472QTEm0+Y9YIncc455r6lA6yP7+ypU/98I3z8CbTeDzB5zuyp7/hse3Oa04S3LG4S8ik0Xk5swnRKQGcCMwNYtruwJfuNYwRkRGAu9kLqSqy3E/Raw9EKWq0ap6HpiLszJWgfDkG+VGEekP3AuUx8nYK70ZlCl5JkRGUaZUAHdfVcfXoRQdpw/B8tedEZQAjW90Wm91u9jEbuNOiqqOyuLcW8CTgNvdcFV1vojUBeaKyHzgHpzWmafSVsFyiQE6iEgF4FWgtYg8rar/ykWdHssx0anqHSIyCNgEnAOGqOqP3gjGlExRR8/w9ZbDjO7WgPAQG/2Xo/iTsOK/8OtkSE12pgV0ftymBphLIiIXnqmtE5FuWZVT1XEiMhd4D6ivqmezKuvuNu6r1BPA/bkK+BLkmOhco2IeAL4CGgO3i8ivqnrO28GZkmFi5G6CA/y5p1NdX4dSuCWegZUTYeV45/dWA6Dr/0F5+3czeXINcIuI9AaCgbIiMktV70pfSEQ6A82Bz4CxwJhc3OPCKlgX1AAO5inqXPBkotIS4GVVHQF0xml+rvFqVKbE2H8ini82HGRQh1qUD7UFu91KOge/jIe3W8Gy/wf1usKDK6HvJEtyJs9U9WlVraGqdXAW7VjqJsm1BqbgPFcbDpQXkVdycZs1QEMRqSsiQa77fJkvH8ADnjyja6+qsQCqmgq8JiJfeDcsU1K89+Nu/EUY1aWer0MpfFKSnLUnfxwHZw5C/R7Q41lncWVjClZp4HZV3Q1pgxSHZS4kInOAbkBFEYkBxqrqNNfuNGOAb3CmF0xX1S0FFbzktLSka7HlUUAX16EfgSmqmuzl2NwKDQ3VuLg4X9za5LPDsQl0GRfJ7e1q8GrfFr4Op/BITYXNCyHyVfhzD9TsAD2eg7qdfR2ZKcJEJF5VQ30dhy940qKbAIQC013v78JZ2iur0TvGeGTy8mhSVLm/a31fh1I4qMKOxbD0FTi6FS5vAYPmQcO/2ShKY/LAk0TXUVVbpXv/rYhs8FZApmQ4fjaRj3/dx60R1alZ3lbqIPpH+OElZ6J3+frQfzo07Ws7CBiTDzxJdKkiUkdV9wKISB0g1YsxmRJg+oo9JCan8mD3Et6aO7AGlr4Ee5ZD2Rpwy7vQahD426R5Y/KLJ/9vehJYLiI7ceZCNABGeDUqU6zFxicxc+U+ejevSv1KYb4OxzeObHG6KHcshtIVnZVM2g6HwGBfR2ZMsZNlohORjqq6SlW/E5FGQBOcRLfV5tCZvPhw5V7OJiYzunsDX4dS8E7shmX/gk0LoFRZZxRlhwegVAlN+MYUgOxadBOBNgCuxPZbgURkirW4xGSm/7yHaxtXpmm1i9aOLb5i/4Dl4+C3j8A/CDo9Alf/HUqX93VkxhR79iDAFKiPV+/nVHwSo3uUkNZc3HHXcl1TQFPhyhHQ+R9Q5nJfR2ZMiZFdoqsnIlnOXFfVW7wQjynGEpJSmPxTNNc0qECbWpf5OhzvSoiFlROcV1I8tBroLNd1WW1fR2ZMiZNdojsG/KegAjHF3/y1Bzh2JpG3B0T4OhTvOR8Pa6Y4rbhzf0LTW6H7P6FSI19HZkyJlV2iO2O7FJj8kpSSyqQfo2lTqxxX1avg63DyX/J5Z7uc5W/A2cPQ4HpnoEm1YpzUjSkiskt0ewsqCFP8ffb7H/xx6hyv3NocKU6rfKSmwMZ5zmLLp/ZDravg9g+g9tW+jswY45JlolPVfnmpWERq4mynXgVngvlkVX07U5lwYBZQyxXLG6r6QV7uawqflFTlvWW7aVatLN0aVfJ1OPlDFbZ95axHeWw7VGkJg/8LDa615bqMKWS8OeoyGXhcVX8TkTLAOhH5TlW3piszGmde3s0iUgnYISKzXVutm2Ji8aZD7Dkex8TBbYp+a04Vdi+FpS/Dwd+hQkO4/UNocost12VMIeW1RKeqh4BDrt/PiMg2nO3U0yc6BcqI8+0XBpzESZCmmEhNVSZERtGgchg9m1XxdTh5s38V/PAy7FsB4bWgz0Roeact12VMIefR/0NFpDpQO315VV3u6U1c62O2BlZnOjUeZ/O9g0AZ4E7XnneZrx+Fa7eEoCDbnLMo+WH7UbYfPsObd7TCz6+ItuYObXSW69r1DYRWhl6vQ9uhEFDK15EZYzyQY6ITkdeAO3FaYimuwwp4lOhEJAxYCDyiqqcznb4BWA/0AOoD34nIT5nLqepkYDI4+9F5cl/je6rK+MgoapYP4ZZW1XwdTu4dj3KewW35FILD4dqx0OE+CCqRW3oZU2R50qK7FWikqom5rVxEAnGS3GxV/dRNkeHAv9XZ/TVKRPYAjYFfc3svU/j8HHWCDQdO8Wrf5gT4F6HnV6cOwI+vwfqPISDYWcnk6ocgpJyvIzPGXAJPEl00EAjkKtG5nrtNA7ap6ptZFNsPXAv8JCKXA41c9zPFwLtLd3F52VL0b1vD16F45uxR+OlNWDvNed9+FHR+DMIq+zYuY0yeeJLo4oH1IvID6ZKdqv49h+uuAe4GNonIetexf+JMJUBVJwEvAzNEZBPOzgj/p6rHc/cRTGG0du9JVu85yXM3NaVUgL+vw8neuVPwy7uw6j1IToCIQc5yXeVq+joyY0w+8CTRfel65YqqrsBJXtmVOQj8Lbd1m8JvfGQU5UODGNi+ECeL83GwehL8/LazNmWzfs5yXRUb+joyY0w+yjHRqeqHIhIEXOE6tENVk7wblinKNsXEsmzHMZ64oRGlgwrh0PvkRFg3w1muK+4oNLzBWa6raktfR2aM8QJPRl12Az7EWRJMgJoiMjQ30wtMyTIhMooywQHcfVUhW6k/JRk2zoVl/4bYA1D7GrjzI6jV0deRGWO8yJM/t/8D/E1VdwCIyBXAHKCtNwMzRdPOI2f4esthHurRgLLBgb4Ox5GaCtu+gKWvwoldUK013Pw21O9hy3UZUwJ4kugCLyQ5AFXd6Zo2YMxFJkZGUTrIn+HX1PV1KM5yXVHfww8vweGNUKkx3DkLGt9kCc6YQkBE6gHPAOGq2t9b9/FkctNaEZkmIt1crynAOm8FZIqufSfi+HLDQQZ3qEX5UB+vYLPvF/igF8zu7ww06fs+PPALNLnZkpwx6YhIsIj8KiIbRGSLiLyYh7qmi8hREdns5lxPEdkhIlEi8hSAqkar6oi8xO8JTxLdA8AW4O/AwzgrpNzvzaBM0TTpx90E+PsxsnM93wVxdDvMus1Jcif3wI3/gTFrodUA8Cvk0xyM8Y1EoIeqtgIigJ4ikuHBtYhUdi3On/5YAzd1zQB6Zj4oIv7ABKAX0BQYKCJNcxuoiHQSkeGu3yuJiEddR56MukwE3nS9jHHr4KlzLFgXw4Ara1G5bHDBB6AKv8+CxU84a1Be/xJcORKCShd8LMYUIa6Vqc663ga6XpmXWuwKPCAivVU1QURGAn2B3pnqWu5a2ziz9kCUqkYDiMhcoA8ZF/nPloiMBdrhLCzygSvOWThztrOVZaITkXmqeodrMvdF60uqqo3FNmkmL49GFe7r6oPWXOJZ+N/jzojKul2g31Qoc3nBx2FM4eYvIpOBr1T1q/QnXC2udUADYIKqZliAX1Xnu1pPc0VkPnAPcH0u7l0dOJDufQzQQUQqAK8CrUXkaVX9VzZ19MXZHOA3V0wHM7cys5Jdi+5h18+bPKnIlFzHziQyd81+bm1dnRqXFXAL6shWmD8Uju+Cbk9Dlyesi9IY91JUdZS7E6qaAkSISDngMxFprqqbM5UZ52qJvQfUV9Wz7urKgrsH46qqJ/D8Udh5VVURUQAR8Xh19Syf0bn2kwN4UFX3pX8BD3p6A1P8TVuxh8TkVB7sVr/gbqoKv30EU3o4S3gN+QK6PWVJzpg8UNVTwDLcP2frDDQHPgPG5rLqGCD9Mkk1cLZny415IvI+UM7Vdfo9MMWTCz0ZjOKuedorF8GZYiw2PolZq/ZxY4uq1KsUVjA3TTwLn90PX46BmlfC/SugXteCubcxxYxrUEc51+8hwHXA9kxlWuMklT44u86UF5FXcnGbNUBDEanrWmlrALlcWlJV3wAW4OyI0wh4XlXf9eTa7J7RPYDTcqsvIhvTnSoD/JybAE3xNeOXvZxNTGZ0d3cDsLwgQ1flP6HLP6wVZ0zeVAU+dD2n8wPmqeqiTGVKA7er6m4AERkKDMtckYjMAboBFUUkBhirqtNUNVlExgDfAP7AdFXdkttAVfU7EVmNK3eJSHlVPZnTdeIMuHFzQiQcuAz4F/BUulNnPKnYW0JDQzUuLs5XtzfpnE1MptNrS2lXuzxTh7bz7s3Sj6osVQZum2qtOGNyQUTiVbXI7hosIvcBLwHngFSc536qqjmOgMuyRaeqsUCsiDwLHFbVRNe6ly1FZKarL9eUYLNX7eNUfBJjeni5NWejKo0x8A+g2aVs5ebJM7qFQIprcuA0oC7wcW5vZIqXhKQUpvy0h04NKhJR04s7bx/ZClO6w8ZPnK7Kuz+3JGdMybQbZ3/UXPNkrctUV/9qP+AtVX1XRH6/lJuZ4mPe2gMcP5vI6O6tvXMDVfj9I1j8pNNVOeQL66o0pmR7GvjF9YwuN5uAe5TokkRkIDAEuNl1zBZ1LsHOJ6cyadlu2tW+jI71yuf/DRLPwv8ec1pxdbtCvynWijPGvA8sBTbhPKPzmCeJbjjOhL5XVXWPa3b8rFyHaIqNz3//g4OxCbzarwWS3wskH9kC84fZqEpjTGbJqvrYpVyY5ajLDIWcuRW10m/X4ys26tK3UlKVa/+zjLDgAL4a0yn/El1aV+UTUKqsjao0Jp8Vg1GXrwL7gK/I2HWZ4ywAT3YYvxl4AwgC6opIBPCSqt5yyRGbImvRxoPsPRHPpLva5F+Ss65KY0zOBrl+Pp3umAKXPr0gnRdwVp5eBqCq6z3dGsEUL6mpysTI3TSsHMbfmlbJn0qPbIF5Q+FElHVVGmOypKqXnHc8SXTJqhqb6a/3HPs7RaQmMBOogvPgcLKqvu2mXDfgLZwBLsdV1fqrCqnvtx1hx5Ez/PfOVvj55bE1l7mr0kZVGmPcEJEeqrrUNfL/Iqr6aU51eJLoNovIIJwtHhribMD6iwfXJQOPq+pvrq0U1onId6qatv+Qa321iUBPVd0vIpU9qNf4gKoyPjKKWuVLc3PLanmrzLoqjTGe64Iz2vJmN+cUyJdE9xDwDM7Dvzk4a5W9nNNFrt0PDrl+PyMi23D2JEq/0d4g4FNV3e8qd9SDeIwP/LTrOBtjYvlXvxYE+HuyzkAWrKvSGJM7GwFUdfilVuDRqMu8cu04uxxorqqn0x2/0GVVJPRlAAAgAElEQVTZDGex6LdVdaab60cBowCCgoLaJiYmZi5ivOyO91ey/0Q8Pz7ZjVIBl5CY0ndVBoc7oyrrdsn/QI0xbhXVUZci8puqtslLHZ6MuvyKi5/JxQJrgfdVNSGH68NwlhF7JH2SS3f/tsC1QAiwUkRWqerO9IVUdTIwGZzpBTnFbPLXr3tO8uuek4y9uemlJbnMXZW3TYUw66U2xhQMT7ouo4FKON2WAHcCR4ArcPYnujurC0UkECfJzc7igWEMzgCUOCBORJYDrYCdbsoaHxkfGUWF0CAGXFkr9xdf6Ko8uRu6PwOdH7euSmNMbjTOtFXcBRd2L2iZUwWeJLrWqpq+j+krEVmuql1EJMv9hMQZpjkN2Kaqb2ZR7AtgvIgE4MzT6wD814OYTAHZGHOK5TuP8WTPRoQE5SJBqcJvM2HJk05X5ZAvrKvSGHMp9uB+IIrHPEl0lUSk1oUBIyJSC6joOnc+m+uuwWntbRKR9a5j/wRqAajqJFXdJiJf4zxsTAWmqurmS/gcxksmREZRNjiAuzvW9vyixLOw6FHYNA/qdXNGVVpXpTHm0pxX1X15qcCTRPc4sEJEduM0FesCD4pIKPBhVhep6gpX+Wyp6uvA656FawrSjsNn+GbLEf5+bUPKBHu4jvfhzc5aldZVaYzJHz/ntYIcE52qLnbNn2uMk7i2pxuA8lZeAzCF18RlUZQO8mf41XVyLmxdlcYYL1DVMXmtw5MWHTgjI+u4yrcUEdxNAzDFx97jcXy14SAjO9fjstCg7AtbV6UxphDzZHrBR0B9YD2Q4jqsOMt7mWLqvWW7CfD3Y0TnHJaXs65KY0wh50mLrh3QVAtiZrkpFA6eOsenv8cwsH0tKpcJdl/IuiqNMQXAzRqXChwH1qvqGU/q8GitS5yFmQ/lLjxTVE1eHo0q3Ne1vvsC1lVpjCk47qYWlMd5jDZCVZfmVIEnia4isFVEfiXjZne2H10xdOxMInN+3U+/NtWpXi7k4gLWVWmMKUBZrXEpIrWBeTjzr7Pl6X50poSYuiKapJRUHujWIOOJi7oqv4S6nX0TpDGmxFPVfa7Vt3LkyfSCH/MekikKTsWfZ9bKfdzYshp1K6Zb+zXxjKurcr51VRpjCgURaUS6XsbsZJnoROQM7jdYvbC+WNlLC88UVh/8vJe48ymM7p7u2dzhzTB/KJyMhu7PQufHrKvSGFNgsthYoDxQFbjLkzqyTHSqWubSQzNFzdnEZGb8spfrm15O4yplXV2VH8KS/7OuSmOML72R6b0CJ4BdqprdMpRpPJ0wboq5Wav2EXsuiTHdG1hXpTGm0FDVH0XkVqABsElVv8ltHZboDAlJKUz9KZrODSvSKjAGJltXpTGmcBCRiTibc/8CvCwi7VX15dzUYYnOMPfX/Rw/m8iL1dfC1Jesq9IYU5h0AVqpaoqIlAZ+AvI/0bnmKzRU1e9FJAQI8HRGuinczien8tGPW/io3BTqrVpmXZXGmMLmvKqmAKhqvGuv01zxZK3LkcAonFEu9YEawCTg2tzezBQ+S3/8gckJ/6Ce/xHrqjTGFEbpdxgXoL7rfb7uMD4aaA+sxql1l4jYn/tFnSopa2fQ/acnifMPtbUqjTGFVZO8VuBJoktU1fMXWosiEoD7+XWmqHCNqvTfNJ+fU1qQ3GcSPeo293VUxhjjTiBwuapm2IBVRDoDBz2pwM+DMj+KyD+BEBG5HpgPfJXbSE0hcXgzTO6Gbl7IB6Xu4tXLXqZbm2a+jsoYY7LyFuBuTMg5PNz825NE9xRwDNgE3AcsBp71MEBTWKjC2g9g6rWQeIY1nWfwYmxvHuxxBX5+uX62a4wxBaWOqm7MfFBV1+JsCJ4jT9a6TAWmuF6mKEo8A189ApsXQL3uaN/3eXnGLmpXSOLGFlV9HZ0xxmQni00xAXCzxcrFslvrchPZPIvzZKSLKQTSr1XZ41no9DjLo06w6Y9YXrutBQH+njTqjTHGZ9aIyEhVzdDYEpERwDpPKsiuRXeT6+do18+PXD8HA/E5VSwiNYGZOJu2pgKTVfXtLMpeCawC7lTVBR7EbTyxfTEsGA7B5WDoV1CnEwDjl+6iWngwfVvX8HGAxpiSTETqAc8A4araP4tijwCfichg/kps7YAgoK8n98nyz3lV3aeq+4BrVPVJVd3kej0F3OBB3cnA46raBOgIjBaRppkLiYg/8BqQ6/XLTDYOb4KFI6ByE7h/RVqSWx19gjV7/2RUl3oEBVhrzpiSTkRqikikiGwTkS0i8nAe6pouIkdFZLObcz1FZIeIRInIUwCqGq2qI7KrU1WPqOrVwIvAXtfrRVW9SlUPexKXJ990oSLSKV2wVwOh2ZS/ENwhVf3N9fsZYBtQ3U3Rh4CFwFFPAjYeOHsM5gxyWnID50JYpbRT4yOjqBgWxID2tXwYoDGmEMmxUSIilUWkTKZjmXZnBmAG0DPzQVeDZgLQC2gKDHTX8MmOqkaq6ruu19LcXOtJohsBTBCRvSKyF5gI3JObm4hIHaA1rknn6Y5Xx2l6Tsrh+lEislZE1iYnJ+fm1iVP8nmYNwTijsKA2VCmStqpDQdO8dOu49zbuR7Bgbb6iTEljL+ITBaRm9Mf9LBR0hX4QkSCIW3FrHcy30BVlwMn3dy7PRDlasGdB+YCffL6gTzlyajLdUArESkLiKrG5uYGIhKG02J7RFVPZzr9FvB/rsU6s4thMjAZIDQ01CarZ0UVFj8O+3+B26ZB9TYZTo+PjCI8JJC7Otb2UYDGGB9KUdVR2RXIqlGiqvNFpC4wV0Tm4zR2rs/FvasDB9K9jwE6iEgF4FWgtYg8rar/ykWdHstu1OVdqjpLRB7LdBwAVX0zp8pFJBAnyc1W1U/dFGmH8w8HUBHoLSLJqvq55x/BpPl1Mvw2Ezo/Di0yPtfdfvg03209wiPXNSSslG1aYYzJKIdGCao6TkTmAu8B9VX1bG6qd3NMVfUEcP8lBZwL2X3jXXgOd0k7jbtWmJ4GbMsqKapq3XTlZwCLLMldot2R8PXT0OhGZ3HmTCZG7iY0yJ9hV9cp+NiMMYWaB42SC0tuNQc+A8YCY3JxixigZrr3NfBw+a78kGWiU9X3XT9fvMS6rwHuBjaJyHrXsX8CtVz1ZvtczuTCid3OXLlKjaDf++CX8dHrnuNxLNp4kJFd6lGudJCPgjTGFEaeNEpEpDXOoiE3AnuAWSLyiqp6ukrWGqChq/vzD2AAMCjPwXvIk216KgEjcZZaSSuvqtkOSFHVFbhvrmZVfpinZU06CbEwZwCIPwycA6UuboC/tyyKQH8/7u1UzwcBGmMKObeNElVdnK5MaeB2Vd0NICJDgWGZKxKROUA3oKKIxABjVXWaqiaLyBicaWT+wHRV3eKtD5SZJw9rvsDZ0fV7IMW74ZhcSU2BBSOcVU/u/hwuq3NRkT9OnePT3/7gro61qVSmVMHHaIwp1DxplGTeOUBVk3CzLKSqDsymjsU4ayUXOE8SXWlV/T+vR2Jy7/uxEPUd3Pgm1O3stsj7P+5GBEZ1sdacMaZk8mQe3SIR6e31SEzurJ8Dv7wLV94LV7pfWODomQTmrjlAv9Y1qFbOo7VPjTGm2PEk0T2Mk+zOichpETkjIhcNPTUF6MAa+OrvUKcz9Py32yIJSSk8Pm8DKanKA93qF3CAxhhTeHgyYfySphcYL4n9A+YOgrLV4I6Z4B94UZHzyak8OPs3ftp1nHG3taROxRxXbDPGmGIruwnjjVV1u4i0cXf+wpIxpgCdj3eSXNI5GPollC5/UZGklFTGfPwbS7cf5dW+zbnjyppuKjLGmJIjuxbdY8Ao4D9uzinQwysRGfdU4csxcGiDs1Bz5SYXFUlOSeWRuev5dusRXri5KYM72FJfxhiT3YTxC2ui9VLVhPTnLizsaQrQT2/A5oVw3QvQ6KLFwUlJVR6fv4H/bTrEszc2Ydg1dS8qY4wxJZEng1F+8fCY8Zbt/4Olr0CLO+CaRy46nZqq/N/CjXyx/iBP3NCIezvbVAJjjLkgu2d0VXBWnA5xLf9yYUJhWZxZ8qYgHNkCC0dCtTZwyzuQaZeH1FTlmc83sWBdDI9c15DR3d1tEWWMMSVXds/obsBZ4qUGznO6C9+wp3HWrDTeFnfcWd6rVBkY8DEEZpwLp6q88NUW5vx6gNHd6/PwtQ19FKgxxhReopr99m4icpuqLiygeHIUGhqqcXFxvg7D+5LPw0e3QsxaGL4EarTNcFpVeeV/25i2Yg+jutTj6V6N07ZQMsaYzEQkXlVL5FwjT57RtRWRchfeiMhlIvKKF2MyqrDkSdj3M/SZ4DbJvfb1Dqat2MOwq+tYkjPGmGx4kuh6qeqpC29U9U/AlgTzpjVTYd0H0OlRaHn7Raf/+/0uJv24m8EdajH25qaW5IwxJhueJDp/EUlb9l5EQgBbBt9bopfBkv+DK3pCj+cuOj1+6S7e+WEXd7Srwct9mluSM8aYHHiye8Es4AcR+QBnovg9wEyvRlVSnYyGeUOh4hXQbwr4+Wc4/f6Pu3nj2530a12df/VriZ+fJTljjMlJjoNRAESkJ3AdzsjLb1X1G28HlpViOxgl4TRMvQ7ijsLISCifccL39BV7eGnRVm5qWZW37owgwN+TxrgxxjhK8mAUT1p0qOrXwNcAInKNiExQ1dFejawkSU2BhffCiSgY8vlFSe6jVft4adFWejarwn8tyRljTK54lOhEJAIYCNwJ7AE+9WZQJc4PL8Gub6D3G1C3S4ZTn6zZz3Ofb+a6JpV5Z2BrAi3JGWNMrmS3MsoVwACcBHcC+ASnq7N7AcVWMmz4BH5+C9rdA+1HZji1cF0MT326ia5XVGLC4DYEBViSM8aY3MquRbcd+Am4WVWjAETk0QKJqqSIWQtfPuRsoNprXIZTX6z/gycWbODq+hV4/+62lArwz6ISY4wx2cmuiXAbcBiIFJEpInItfy0DliMRqSkikSKyTUS2iMjDbsoMFpGNrtcvItIq9x+hiDp9EOYOhjJV4PYPM2ygumTTIR6bt4Er65Rn6pArCQ60JGeMMZfKkyXAQoFbcbowewAfAp+p6rc5XFcVqKqqv4lIGWAdcKuqbk1X5mpgm6r+KSK9gBdUtUN29RaLUZdJ5+CDXnB8F4z4Di5vmnbqu61HeGDWOlrVLMfMe9oTWsqjx6jGGJOtkjzqMseHPqoap6qzVfUmnAWe1wNPeXDdoQu7kKvqGWAbzm4I6cv84lppBWCVq/7iTRW+GAMH1ztz5dIlucjtR3lw9jqaVQ/ng+FXWpIzxph8kKvRDap6UlXfV9Vc7S4uInWA1sDqbIqNAJZkcf0oEVkrImuTk5Nzc+vCZ8V/YfMC6PEsNP5rJbWfdh3jvlnraFSlDDOHt6dscGA2lRhjjPGURxPG83QDkTDgR+BVVXU7LUFEugMTgU6qeiK7+op01+WOJTBnIDS/DW6bmra33MrdJxg+41fqVAhlzsiOXBYa5ONAjTHFTUnuuvRq35iIBAILgdnZJLmWwFScxaOzTXJF2pGtzqTwqq2gz/i0JLdm70lGfLiGmpeVZva9HSzJGWNMPvPaxCxxVhuehjPY5M0sytTCmXx+t6ru9FYsPhd/0tlANSgUBs5J20D19/1/MvyDNVQpG8zskR2oEGZrZRtjTH7zZovuGuBuYJOIrHcd+ydQC0BVJwHPAxWAia5V+JNVtZ0XYyp4KUkwbwicOQzDF0PZagBsiollyPRfqRAWxMcjO1K5TLCPAzXGmOLJ68/o8luRe0a36DFYOw36ToZWdwKw9eBpBk5ZRZngAD657yqqlwvxcZDGmOKuJD+jszWlvGnNVCfJXfNwWpLbcfgMd01bTWiQP3NGdrQkZ4wxXmaJzlv2/ORsoNrwBrh2LABRR88yeOoqAvyEj0d2pGb50j4O0hhjij9LdN5wcg/MuxvK13emEfj5s+d4HIOmrAKcJFenYonsQTDGmAJniS6/JZx25sqpOiMsg8ty4GQ8g6asIjlV+XhkBxpUDvN1lMYYU2LYGlP5KTUVPh0Fx3fC3Z9Chfr8ceocAyavIv58CnNGduSKy8v4OkpjjClRLNHlp6Uvw84l0Ot1qNeNw7EJDJqyitMJSXx8b0eaVivr6wiNMabEsa7L/LJxPqx4E9oOg/YjOXrGSXInzp5n5j3taVEj3NcRGmNMiWSJLj/8sQ6+HAO1r4Fer3Mi7jyDp6zm8OkEZgy/kta1LvN1hMYYU2JZ12VenT7kbKAaVhnumMmfiTB46moO/BnPB8Pa065OeV9HaIqIpKQkYmJiSEhI8HUopggLDg6mRo0aBAbaDigXWKLLi6Rz8MlgZ6TliG+JlXDumrqK6ONxTB96JVfVr+DrCE0REhMTQ5kyZahTpw6uJfGMyRVV5cSJE8TExFC3bl1fh1NoWNflpVKFrx52ui37TeZ0uUYMmb6aXUfOMvnutnRqWNHXEZoiJiEhgQoVKliSM5dMRKhQoYL1CmRiie5S/fw2bPwEuj/L2Xo9Gf7BGrYcPM3EwW3o1qiyr6MzRZQlOZNX9t/Qxazr8lLs+Bq+fwGa9SO+4yPcM2MN6w+cYvzA1lzX9HJfR2eMMSYda9Hl1tHtrg1UW5Jw4zuM/Ggda/ee5L93RtCrRVVfR2dMnn322WeICNu3b8+x7IwZMzh48GDa+3vvvZetW7dme82kSZOYOXPmRcf37t1L8+bNcxVrWFjBrDJ06tQpJk6cmPb+4MGD9O/fP8/19u3bl4iICBo0aEB4eDgRERFERETwyy+/5Lluk46qFqlX6dKl1WfiTqi+1Up1XANNOL5Xh0xbrXWeWqQL1x3wXUym2Ni6dauvQ1BV1dtvv107deqkY8eOzbFs165ddc2aNfly3z179mizZs1ydU1oaGi+3DsnlxJbbkRGRuqNN96Yb/W5+28JiNNC8B3ui5d1XXoqJQnmD4XTf5B09yJGLzrKjzuP8dptLejXpoavozPFzItfbWHrwdP5WmfTamUZe3OzbMucPXuWn3/+mcjISG655RZeeOGFtHPjxo3jo48+ws/Pj169etGuXTvWrl3L4MGDCQkJYeXKlfTq1Ys33niDdu3aERYWxsMPP8yiRYsICQnhiy++4PLLL+eFF14gLCyMf/zjH6xbt4577rmH0qVL06lTp7R7paSk8NRTT7Fs2TISExMZPXo09913X5ZxL1u2jBdeeIGKFSuyefNm2rZty6xZsxARFi9ezGOPPUbFihVp06YN0dHRLFq0iLi4OB566CE2bdpEcnIyL7zwAn369GHLli0MHz6c8+fPk5qaysKFC3nuuefYvXs3ERERXH/99YwePZqbbrqJzZs3k5CQwAMPPMDatWsJCAjgzTffpHv37syYMYMvv/yS+Ph4du/eTd++fRk3bpzH/3t99913PPHEE6SkpNCxY0cmTJhAfHw87du3Z/HixTRo0IDbb7+d3r17M3z4cI/rLYms69JT3/wT9iwn+ca3GPOTP99vO8ortzbnzitr+ToyY/LN559/Ts+ePbniiisoX748v/32GwBLlizh888/Z/Xq1WzYsIEnn3yS/v37065dO2bPns369esJCcm4t2JcXBwdO3Zkw4YNdOnShSlTplx0v+HDh/POO++wcuXKDMenTZtGeHg4a9asYc2aNUyZMoU9e/ZkG/vvv//OW2+9xdatW4mOjubnn38mISGB++67jyVLlrBixQqOHTuWVv7VV1+lR48erFmzhsjISJ544gni4uKYNGkSDz/8MOvXr2ft2rXUqFGDf//739SvX5/169fz+uuvZ7jvhAkTANi0aRNz5sxh6NChaaMe169fzyeffMKmTZv45JNPOHDggEf/O8THx3PPPfewcOFCNm3aRHx8PJMnT6ZcuXK88847DBs2jNmzZxMfH29JzgPWovPE2g/g18mkdhzDI9ub8M2WQ4y9uSl3dazt68hMMZVTy8tb5syZwyOPPALAgAEDmDNnDm3atOH7779n+PDhlC7t7KFYvnzOCyEEBQVx0003AdC2bVu+++67DOdjY2M5deoUXbt2BeDuu+9myZIlAHz77bds3LiRBQsWpJXdtWtXtnPD2rdvT40aTu9KREQEe/fuJSwsjHr16qVdN3DgQCZPnpx2jy+//JI33ngDcKZ37N+/n6uuuopXX32VmJgY+vXrR8OGDbP9nCtWrOChhx4CoHHjxtSuXZudO3cCcO211xIe7iz/17RpU/bt20fNmjVz/Lfbtm0bDRs2pH79+gAMGTKEadOmMWbMGHr27Mm8efN4+OGH2bhxY451GUt0Odu7Ahb/A21wPU+c6seijYf4Z+/GDL/GJmOa4uXEiRMsXbqUzZs3IyKkpKQgIowbNw5VzfWw9cDAwLRr/P39SU5OznA+uzpVlXfffZcbbrjB4/uVKlUq7fcL93MeTbmnqixcuJBGjRplON6kSRM6dOjA//73P2644QamTp1KvXr1sq0nNzF5Irs6U1JS2L59OyEhIfz5559Uq1bNozpLMuu6zM6fe+GTu9HL6jI28FEWrj/MEzc0YlSX+r6OzJh8t2DBAoYMGcK+ffvYu3cvBw4coG7duqxYsYK//e1vTJ8+nfj4eABOnjwJQJkyZThz5swl3a9cuXKEh4ezYsUKAGbPnp127oYbbuC9994jKSkJgJ07dxIXF5frezRu3Jjo6Gj27t0LwCeffJLhHu+++25aUvn9998BiI6Opl69evz973/nlltuYePGjdl+zi5duqTFvnPnTvbv339R8sytpk2bsmvXLqKjowGYNWtWWsv3jTfeICIigpkzZzJ8+HCPk2dJZokuK4lnYM4gVFN4s9JLzPz9FA9f25DR3Rv4OjJjvGLOnDn07ds3w7HbbruNjz/+mJ49e3LLLbfQrl07IiIi0rr7hg0bxv33309ERATnzp3L9T0/+OADRo8ezVVXXZXhGd+9995L06ZNadOmDc2bN+e+++67pC/0kJAQJk6cSM+ePenUqROXX355Wlfic889R1JSEi1btqR58+Y899xzgJMMmzdvTkREBNu3b2fIkCFUqFCBa665hubNm/PEE09kuMeDDz5ISkoKLVq04M4772TGjBkZWnKXonTp0kybNo1+/frRokULSpUqxciRI9m2bRsffvgh48aNo3v37nTs2JF//etfebpXSSDZNZHzVLFITWAmUAVIBSar6tuZygjwNtAbiAeGqepv2dUbGhqql/KXXa6kpsInd6E7v+aj+v/h+c2VeaBbfZ68oZGtOmC8Ztu2bTRp0sTXYRQ7Z8+eJSwsDFVl9OjRNGzYkEcffdTXYXmVu/+WRCReVUN9FJJPebNFlww8rqpNgI7AaBFpmqlML6Ch6zUKeM+L8Xhu2f+DHf/j25p/5/nNlbm3U11LcsYUUVOmTCEiIoJmzZoRGxub7TQFUzx5bTCKqh4CDrl+PyMi24DqQPplE/oAM12TGVeJSDkRqeq61jc2L4Tlr7Ohch/u29mOoVfV5pkbm1iSM6aIevTRR4t9C85kr0Ce0YlIHaA1sDrTqepA+oklMa5jma8fJSJrRWStVx+8HvwdPn+QP8pG0H//bQzqUJsXbmlmSc4YY4owryc6EQkDFgKPqGrmpR7cZZCLHhqq6mRVbaeq7QICvNQIPXMY5gzijH85bjl6H7e2rcMrfZpbkjPGmCLOq4lORAJxktxsVf3UTZEYIP3syRrAQTflvCspAeYOJinuJHecfpjOEU34920t8fOzJGeMMUWd1xKda0TlNGCbqr6ZRbEvgSHi6AjEFvjzOVVY9Aj8sZYxCfdTr0VH3ri9Ff6W5IwxpljwZovuGuBuoIeIrHe9eovI/SJyv6vMYiAaiAKmAA96MR73fnkXNszhzaT+0ORm3rozggB/m15oSqbDhw8zYMAA6tevT9OmTenduzc7d+5k7969hISEEBERQdOmTbn//vtJTU1l2bJlact8XTBs2LC0pbsuGD16dNq1F+qJiIhgwYIFPP/883z//ff5/ln8/f2JiIjIsI1Qep5sKeTus4CzpdDHH3+c9v6nn36iadOmud5myBQMb466XIH7Z3Dpyygw2lsx5Gjnt+h3z/O/lA5saXAf7w1sQ6AlOVNCqSp9+/Zl6NChzJ07F3AWJT5y5Ag1a9ZMW9Q4OTmZHj168Pnnn3u05iX8tfDx3r17uemmm1i/fn3aufzY182dkJCQDPdJLyUlhalTp15y3RcS3aBBgwDo3Lkzixcvvijpm8Kh5K51eWwHSfOGszO1Fp/XfoYJd7UlKMCSnCkkljwFhzflb51VWkCvf2d5OjIyksDAQO6///60YxEREQBpS2gBBAQEcPXVVxMVFUX79u3zHNawYcO46aab6N+/P3Xq1GHQoEFERkaSlJTE5MmTefrpp4mKiuKJJ55Ii+31119n3rx5JCYm0rdvX1588cUc7xMWFsZjjz3GN998w3/+8x+effbZtC2Fpk2bxmuvvUa1atVo2LAhpUqVYvz48QAsX76cN998k8OHDzNu3Dj69+/PU089xbZt24iIiGDo0KE2faGQK5nf7PEnOTujP7FJfkyq+grjh3YiONDf11EZ41MX9nHLSXx8PD/88AMtWrTwShw1a9Zk5cqVdO7cOa3rcNWqVTz//POAs+vArl27+PXXX1m/fj3r1q3j/7d3/7FV1Wccx9+ftsh10GoGuCiFwDaiKUWKISVOQcMmiFMoYYS5XyLGzUQW2ZYsrVvQjWzWmC38wZJlQWJct6kJIxrctMwfYFVKBVtFO8VsoFBitRRnQTDFZ3/cU7wtty299N7Te87zSm56f5xz7nP667nf8z3neXbs2DHodo8dO0Z5eTmNjY29et+1tbWxbt06du7cybZt287orH748GEaGhrYunUr1dXVANTW1jJ37lyam5s9yeWB+I3oTnXz4UPfpaTrELXjHuD+227wJOdGngFGXmHpaef/+g4AAAi9SURBVDwqiSVLlrBo0SK2b9+edtlzuSxn8eLFAMyYMYOuri6Ki4spLi4mkUhw9OhR6uvrqa+vZ9asWUCyxNe+ffuYN2/egNstLCxk2bJlZzy/a9currnmmtOHYZcvX366zQ5AVVUVBQUFlJWV8f7772e8Xy48sUt07z7yEya3v8SGkjVU/+gWvnBe7L4FzqU1ffr0tCde9OiZo0s1btw4Ojs7ez135MgRxo8fn3EcPQWRCwoKehVHLigoON16p6amZsilvBKJBIWFZ36oHazeb2oM2aoN7LIrVocu3/rHBibve5jHE1X84M5fMna0JznnesyfP5+TJ0/26gTe1NTU76gNYNq0abS1tdHa2grAgQMHaGlpOT23lw0LFy5k06ZNdHV1AXDo0CHa29sz3l5lZSXbt2+ns7OT7u5uNm/ePOg659KeyOVebP7Tv/7SP7m0cS27z7uCa1f/kZLEqLBDcm5EkcSWLVtYs2YNtbW1JBIJpkyZwvr16/tdZ/To0dTV1XHrrbdy4sQJRo0axcaNG0+3wsmGBQsW0NraypVXXgkkTzKpq6vjoosuymh7EydO5O6772bOnDlccskllJWVDRr/5ZdfTlFRETNnzmTlypU+TzfCZa1NT7Zk2qbn3Tcb+eiJGibd/igXjpuQhcicOzfepmd4jR079vSobzA9rXy6u7tZunQpq1atOqM332B6Lp3Yu3dvJuEOK2/T01tsDl1OLpvDjOpnPck5FxMlJSUDXjCe6t5776WiooLy8nKmTp1KVVXVkN7rhRde4KabbjqnuUmXPbEZ0Tk30vmIzg0XH9H1FpsRnXP5IN8+eLqRx3+HzuSJzrkRIpFI0NHR4f+oXMbMjI6ODhKJRNihjCixOevSuZGutLSUgwcP8sEHH4QdistjiUSC0tLSsMMYUXyOzjnnYmC45+gkfRn4BXCBmWWnMvcw8UOXzjnnAJC0SVK7pL19nr9e0luS3pFUDWBm/zGz28KJdGg80TnnnOvxEHB96hOSCoE/AIuAMuBmSWW5Dy1znuiccy4eiiS9knL7Yd8FzGwHcKTP05XAO8EI7lPgEWBJDuIdNnl3Msrx48dN0icZrl4EdA9nPHnA9zkefJ/j4Vz2+Xwzm53BehOB91IeHwTmSBoH/AaYJanGzO7LMK6sy7tEZ2YZj0IlvZLhDzpv+T7Hg+9zPIS0z+l6LpmZdQB3pHltxPFDl8455wZyEJiU8rgUGLyu2gjiic4559xAmoBpkqZKOg/4NvBEyDENSdwS3Z/CDiAEvs/x4PscD1ndZ0l/A14GLpV0UNJtZtYNrAaeBlqBx8zsjWzGMdzy7oJx55xzbijiNqJzzjkXM57onHPORVpsEl26EjZR1l8pnyiTNEnSc5JaJb0h6a6wY8o2SQlJuyS1BPv8q7BjygVJhZJelbQ17FhyQdJ+Sa9Lapb0Stjx5JtYzNEFJWzeBq4jeapsE3Czmb0ZamBZJGke0AU8bGblYceTC5IuBi42sz2SioHdQFXEf84CxphZl6RRQANwl5ntDDm0rJL0U2A2UGJmN4YdT7ZJ2g/MNrMPw44lH8VlRJf3JWyGqp9SPpFmZofNbE9w/2OSZ4hNDDeq7LKkruDhqOAW6U+vkkqBbwIbw47F5Ye4JLp0JWwi/Q8w7iRNAWYBjeFGkn3BYbxmoB3YZmZR3+f1wM+Bz8IOJIcMqJe0O12NSjewuCS6tCVsch6FywlJY4HNwBoz+1/Y8WSbmZ0yswqSFSsqJUX2ULWkG4F2M9sddiw5dpWZXUGyg8CdwdSEO0txSXR5X8LGnZ1gnmoz8Bcz+3vY8eSSmR0FnqdPm5WIuQpYHMxZPQLMl1QXbkjZZ2Ztwdd2YAvJ6Rh3luKS6PK+hI0bXHBixoNAq5n9Pux4ckHSBEkXBvfPB74B/DvcqLLHzGrMrNTMppD8O37WzL4XclhZJWlMcHIVksYAC4DYnE09HGKR6KJQwmao0pXyCTumHLgK+D7JT/nNwe2GsIPKsouB5yS9RvID3TYzi8Up9zHyJaBBUguwC3jSzJ4KOaa8EovLC5xzzsVXLEZ0zjnn4ssTnXPOuUjzROeccy7SPNE555yLNE90zjnnIs0TnYskSaeCywtaJO2R9LWwYxqIpIoYXArhXCg80bmo+sTMKsxsJlAD3DeUlYOOF7lUAXiicy4LPNG5OCgBOgEkXZvaw0zSBkkrg/v7Ja2V1AAsl/S8pPuDfm9vS5obLLdS0oaUbWyVdG1wv0vS74JR5DOSJvQNRtJySXuD0eaOoFrPr4EVwSh0RVANY5OkpqDv2pKU935c0lNBf8V7svVNcy4qisIOwLksOT+o6J8gWT1k/lmud8LMrgaQdAdQZGaVwWHFe0iW2BrIGGCPmf1M0tpgndV9llkLLDSzQ5IuNLNPg2Vnm9nq4L1/S7K81aqgxNcuSf8K1q8EyoHjQJOkJ83Mm3E61w8f0bmo6jl0eRnJIscPB7UwB/Non8c9haF3A1POYv3PUrZRB1ydZpkXgYck3Q70d4h0AVAdJOvnSSbsycFr28ysw8w+CeJL9x7OuYCP6FzkmdnLksYDE4Buen/AS/RZ/FifxyeDr6f4/O9lsG30evs08dwhaQ7J5qHNkirSrCdgmZm91evJ5Hp9t+l1/JwbgI/oXORJuozkyKkDOACUSRot6QLg6xlscj9QIalA0iR6t0wpAL4V3P8O0JAmnq+YWaOZrQU+JNlC6mOgOGWxp4Ef94xCJc1Kee06SV8MuhVUkRwhOuf64SM6F1U9c3SQHB3dYmangPckPQa8BuwDXs1g2y8C/wVeJ9kuZU/Ka8eA6ZJ2Ax8BK9Ks/4CkaUFczwAtwLt8fqjyPmAdyU7arwXJbj9wY7B+A/Bn4KvAX31+zrmBefcC54aRpC4zG5vF7a8k5aQV59zg/NClc865SPMRnXPOuUjzEZ1zzrlI80TnnHMu0jzROeecizRPdM455yLNE51zzrlI+z9PcFBwEOPFPAAAAABJRU5ErkJggg==\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAa4AAAEQCAYAAADoNZCfAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy8QZhcZAAAgAElEQVR4nOzdd3hUZfbA8e9JhwChSBOkRHrvYEGKggoqrIA0FQEFlbXvruuqP/uKBSs2UEREYMUVEQVk6SjSpUkNvfcEUkky5/fHnYQJpAyQyaScz/PwZObe+957EsIc3ve+97yiqhhjjDEFRYC/AzDGGGMuhiUuY4wxBYolLmOMMQWKJS5jjDEFiiUuY4wxBYolLmOMMQVKgUlcItJYRAL9HYcxxhj/CvJ3AN4QkbbAfKAckHrePgFWAy73pghVrZ23ERpjjMkrBSJxqepyETmWxe6qQFdVPS4iJYCX8zA0Y4wxeaxAJC5PIlIB6I3T+wpS1Rc8dncHZvslMGOMMXmiwNzj8vAPIA7YDtQVEc/voTOwwC9RGWOMyRMFrscFNAReVNVYYEraRhEJAVDVZH8FZowxxvcKYo9rHzAIQESuF5Er3NtvwpnAYYwxphArEIlLRFoB5YGuwBvAAyIyF6ihqsfdh3UHZvkpRGOMMXlEbFkTY4wxBUmB6HEZY4wxafL95IyAgAAtVqyYv8MwxpgCJT4+XlW1UHZO8n3iKlasGHFxcf4OwxhjChQRSfB3DL5SKLOxMcaYwssSlzHGmALFEpcxxphcJyJdRaS0L85ticsYY4ooEblGRPqLSJWLbJftMlMiEgx0AnySuPL95AxjjDG5T0RGAJVU9fmLbJdhmSkRCQJeANYA9YGRqposIkm5HXMa63EZY0zhFCgiY0Tk9vN3iEht4CGchOO5vYuINPN4HyQij3seo6rLAc9lph4ADqjqNOAU0CcXv4dMWeIyxpjCKVVVh6nqjEz23QUcBZ4RkTkicrV7+wrgDRGp5V6k9zNgaw7XaQesdb9eC3R3DxVWByIv+7vIhA0VGmMKHVUlxaWkutxfU5UUl+vc+/SvLlJcSkqqx/tUzfK41PRjM77P9Dj31+RU13lxZH6cE4eLgNQEmics47qEhWi5Olwz/ENf/IiqA5+q6rciEgX8E3hAVWNEZBDwNbALWKiqOdWArQSccb8+A1R0r9Ix2BeBgyUuY4oUzw/0tA/U5NTzP2AzfpinpHq+d53b7vJs78rkPBk/5DOex3mf6lKSXVm0T80Yi3Osy6tkkerybw3WAIGggAACA4SgACEwUAgKCHBeBwhBgXJuX0AAYZJCy5Q/6HB2Ea2TlhGmiZwKLMvW0Ja+CvEUkPZD2oJ7xQ0AVT0sIuuBW4GnvTjXCaCE+3UJ4Hg2x+YKS1zG5FMpqS6OnEniUHQCh2ISORSTwMFo5+up+ORzH/yZfKhnSDBpCcNPH+giEJz2IR7ofFgHBQa4v2b8QA8ODHB/dd6HBwe5P+ADCAzgXLu0NoFyLhm4k0CG94GS4dpZHpe+P4Dg895fcFxAQPp1g857HxggBIoQECA5/2BcqbBnKWz8DjZNh4RTEFYamveFxr0pU/062gVkOXHvcs3FmfU3FSgDrD/39yUPAolAP2CiiPRR1fhszjUHaAosB5q43/tUvq8OHx4erlbyyRQ2qS7leGwSB91J6aBHcjoUk8ih6ESOnknk/DxTIjSIyhFhlA0PISQoIP2D9FwSyCIpeHyAB6d9QKd9kKcng4xtPM+TIakEZEwuadvT2mbYFxDg3Yd4UaEKB9fAhv/Cn9/DmUMQXBzqdYdGveHqzhAUkiuXEpF4VQ3PZv/bOAmrKs6w4UkRuRm4Q1VHuI+5DnhQVe/xaNcKWAT0V9Uf3avQv+w+VxPgBVVNzZVvIqvYLXEZk7tcLuVE3NkMPaTDMYkcjElM7z0dOZ1IynlZqVhwIJVLh3FlRDEqRYRxZUQYlUsXo3JEGFe6v5YMC/bTd2Uuy7GtsOE7p3d1cicEBEPtLtCoF9S9FUKyzC+XLKfElUWbUkCsqro8tpVW1ehcD/Ay+CRxuZ+WfgloCMxR1Tc99vUDHgEqAveq6tLszmWJy+Qnqsqp+GQORjvJ6FBMQnpCOuh+fyQmibOprgztQoICqBwR5iShiGJULh1G5Yhi7m3FuLJ0GBHFgnEmcplCIXovbPyv07s6sgEQqHkDNO4N9W+HYmV8evlLSVwFha8SVwvOTY+co6o3ubcXA25T1akiMgC4R1Vvze5clrhMXlFVTiekcOh0AoeiEzkYc+6rk6ScxJSYnDEpBQcKFUud6yml9Zo8e0plw0MsKRUFscdg0w+wYSrsW+5sq9LKSVYN/wIlK+VZKJa4LvXkItcDVVT1P+73QYBLVV0iUh94VlXvzqTdMGAYQEhISMukJJ89gG2KkNiklHM9o/PuKaXdY4o/m3FoPkCgYimnp1S5dDFn+M7dQ6oU4by/okSo3ccpyhJjYPNPzjDgzkWgqVChgTMM2KgXlK3pl7AscV3KiUUigWdxHk5rqaqJ5+0fDvyuqusza5/GelzGGwlnU9N7SOkTHDzuMR2KSeRMYkqGNiJQvkRoekKqdN4w3pWlwyhfIpSgQHtO35wnOQG2zXbuW23/H6QmQelqzgSLxr2hYkN/R2iJ67IuIDIO+ERVV3psiwTqevFgmyUuk62FW4/yt6nrOB579oJ95cJDziUhj4kOafeWKpYKIyTIkpLxUmoy7FzoJKstP8PZMxBeARrd6SSsqq2c/w3lE4U5ceXFc1zRwE4RqaCqR0WkAlBPVWeKSBhQSlWP5kEcppBxuZRXf95M8ZAg/n5zzQwTHSqWCiMs2GfPwJiiwuWCvb+fe9Yq/gSERkDDHtC4D9RoD7571spkwSeJS0ReAq4C/gvMdL/+l4jcB0wHSorImzhPbjf3RQym8Pvlz8NEHY3lg/7NuaPplf4OxxQWqnBonZOsNn4Ppw9AUDFn2nrj3lDrJggK9XeURZo9x2UKJFXltg9/Jf5sKnOf7ECgTY4wl+v49nPPWp2IgoAguPpGp2dV91YILZHzOfIRGyo0Jp9ZuPUYfx48zZu9mljSMpcuZr/Tq9r4ndPLQqDG9XDNX6FBDyhe1t8RmkxY4jIFjqoyekEUVUoXo2fzi1q41RiIOwGbpjkPBu911z+4sjnc/G/nWatSNuyc31niMgXOsp0nWb3nFC/3aGizAo13ks44MwE3fAc75jvPWl1RFzo96zxrVe7qnM9h8g1LXKbAGb1gO1eUCOWuVlf5OxSTnyUnwvY5zjDgtl8gJREiroJrH3E/a9UoX01fN96zxGUKlD/2nuK3qBP8q1s9m+5uLpSaArsWOsOAW36CpNNQ/Apofo+TrKq2gQDrpRd0lrhMgfLRgihKFw9mYNvq/g7F5BcuF+xf4QwDbvoB4o5BaCmnkG2jXlCzAwTaR11hYn+bpsDYdPA0czcf5Ymb6hAear+6RZoqHN5w7lmrmH0QFAZ1bnaqWNTuCsFh/o7S+Ij96zcFxkcLoygRGsR919bwdyjGX07scC8V8h0c3woS6Cy+2Pk5qNsNwkr5O8L8JFBExgAzVHWGv4PJTZa4TIGw41gsMzcc4sEOVxNR3BZTLFISY2Ddf2DdJDj4h7Ot2rXQfRQ06AnhV/g3vvwrVVWH+TsIX7DEZQqEjxfsIDQogKHX+2eJCOMHB9fCqi+c3lVyPFRqDF1ecYraRlT1d3TGjyxxmXxv38l4flh7gHuvqc4VJaxGXKGWnAB/ToOVX8CBVU6NwMa9oNVQqNLC39GZfMISl8n3Plu8gwCBYTdE+jsU4ysndsCqcbD2G0g4BeVqwy0joWk/ny9xbwoeS1wmXztyOpFvV+2nd8uqVI4o5u9wTG5KTYFts5ze1c4FTlHbet2d3lXNG+zhYJMlS1wmXxu7eCcpqS4e7GAleQqN04dgzVew+is4cxBKVXFKL7W4F0pW8nd0pgCwxGXyrZNxZ/lm+V56NKtC9XKFcnWGokMVdi1yeldbfnZqBV7dGbq9BXVusQeEzUWx3xaTb3352y4SklN5uKP1tgqshFOwdpJz/+pElHO/6pqHoeVgK2xrLpklLpMvnU5MZvzS3dzSsBK1K5b0dzjmYh1YDSvHOQ8LpyRA1dbQ81No2BOC7V6luTyWuEy+9PXveziTmMJfO9fydyjGW2fjnRJMK7+AQ2shOBya9nUmW1Ru4u/oTCFiicvkO/FnU/ji1110rFueRlUi/B2Oycmxbe6p7JMgKQbK14dub0OTuyDM/v5M7rPEZfKdScv3cjLuLH/tZL2tfCs12Vk2ZOUXsHsJBARDgzuc3lX1a20qu/EpS1wmX0lKSWXskp20iyxLqxpl/R2OOV/Mfmca+5qvIPYIRFSDG//PWe+qRAV/R2eKCEtcJl/5bvV+jpxOYlSfZv4OxaRxuWDnfGeyxbZZztT22l2c3lXtLhBgC3qavOWTxCUipYGXgIbAHFV902NfZ6ARIMAyVV3uixhMwZOc6uKThTtoelVprqtVzt/hmPiT8MdE5/7VqV3OSsLXPQYt74MyNfwdnSnCfNXjigSecL+eA7wJICKB7tet3fvmAZ19FIMpYH5ce5D9pxJ48faGiN0j8Q9V2L/SuXf15zRITYJq1zjrXdW/HYKsyLHxP58kLlVdAyAi1wNjPXZVA46rqrr3J4tIpKru9GwvIsOAYQAhISG+CNHkM6ku5eOFUdSrVJIb69u9kjyXFAsbpjoJ68gGCCkJLe6BVkOgYkN/R2dMBj67xyUikcBgoJ2ITFfVRKAScMbjsDNARSBD4lLVMcAYgPDwcPVVjCb/mL3xMDuOxfFh/+bW28pLRzc7yWrdFDh7Bio2gtvehcZ9INQe/Db5k88Sl7sXNVRExgGNgZXACaCEx2ElgOO+isEUDKrK6AVRRF4RTrfGlf0dTuGXchY2/+gkrL1LITAEGv7FmWxxVRubym7yvbyYVRgN7BSRCqq6TURKyrn/UpdQ1e15EIPJxxZsPcrmQ6d5q3cTAgPsQ9NnTu2B1ePhj68h7pgzwaLLy9Dsbgi3yTCm4PDVrMKXgKuA/wIz3a//BdwFPAM85T70GV9c3xQcqsqH86OoUroYPZtX8Xc4hY8rFaLmwcrPYfscpzdV5xand3V1ZwgI8HeExlw0X03OeCGTzXe59y0Blvjiuqbg+X3HCf7YG80rPRsRHGgforkm9pjTs1r9JUTvhfAKcMPfoMUgKH2Vv6MzRYCIdAVWqGp0bp/bHkA2fjV6QRQVSobSp2VVf4dS8KnC3mVO72rTdHAlQ432cNNLUO82CLIZuiZ3iEhjYJOqpmaxPxjoBGzDuV2UqyxxGb9ZvecUS3ec4Nlu9QkLtuoLlyzxNKz/j/Og8NFNEFoKWg91prKXr+vv6Ew+JiItgWGqOvwi2rQF5gPlgFQRCQJeANYA9YGRqposIkm+iBkscRk/+mhBFGWKBzOgbTV/h1IwHd7gzAzcMBXOxkLlpnD7B9C4N4TYitEme+4KR52AUI9tXYBjqrrW/T4I+Kuqvpd2jKouF5FjHqd6ADigqtNEpBLQB/iPL2O3xGX84s+DMczfcpSnutQhPNR+Db2m6lRlX/oh7FsOQWHQqJcz2aJKC5vKbjwFisgYYIaqzshkf2+cCXSNPLatAL4VkRHADuAz4LscrtMO+MT9ei3wkIh8D1THqaK0+5K/gyzYJ4bxi48X7KBkaBD3XlvD36EUDKqwcwHMexkO/gFlakLX16DZAChuVfRNplJVdVhmO0SkNzANyPCUuarGiMgg4GtgF7BQVWflcB3PwhJngIqqmoxTgMInLHGZPBd19AwzNx7ioQ5XE1Es2N/h5H97l8P8V5x1ryKqQY+PoUlfCLR/vuaSDQbuBooD9UTkKVUdBaCqh0VkPXAr8LQX5/IsLJEnRSXsN9/kuY8X7iA0KICh19f0dyj52+ENMP9V2Dbbmc5+61vQcpAVujWXTVW7A4hIDeDFtKTl3vYgkAj0AyaKSB9Vjc/mdHOApsByoIn7vU/ZgzMmT+07Gc/0tQcZ0KY65UrYB3CmjkfBd0Pg0+th7+9w4wvw2FpoO8ySlvEpEbkZaKyqz6rqeuDfOPe5PI9pBZQHuro3TQCqichdOIXUJ/o8Tneh9nwrPDxc4+Li/B2GySX/mraB71btZ/E/OlEpIszf4eQvMfth0RvwxzfOpIt2D8G1j0Cx0v6OzBRAIhKvqhc1vVRESgGxqury2FbaFw8RXw4bKjR55nBMIt+t2k/vVlUtaXmKPQa/vuM8OAzQZhi0fxJK2PIuJm+p6ulMtuWrpAWWuEweGrtkJ6mqPNThan+Hkj8kRDvT2pd9AimJzgzBDk9bSSZjcmCJy+SJE7FJTFq+lx5Nr+SqssX9HY5/nY2D5Z/Bb+9BYgw0vBM6/QuuqO3vyIwpELxKXOevUiwir6uqVXY3Xhv32y4SU1J5uFMR7m2lJMHqr2DxWxB3FGrfDJ2fg8pN/B2ZMQWKtz2u50Tkc0CAd3Dm7RvjlZiEZCYs3cOtjSpRq0IRXFU3NcWpJbhwJMTsherXQd+voVo7f0dmTIHkbeKaCnyAU9PqEVVd6LOITKHz9e+7OZOUwsMda/k7lLzlcjkrDS94DY5vg8rN4Pb3nHWwrDSTMZfM2+e4RgF/V9XGQBkReceHMZlCJC4phS9+3UXnehVoVCXC3+HkDVXYPhfGdoSpg0AC4K6vYdhCqHWjJS1jLpO3Pa6uqrofwF0BeIsPYzKFyOQVezkVn8yITkWkt7VnKcx7BfYuhdLV4S+fQeM+EGDLthiTW7xNXMVE5GegDk7137/5LiRTWCQmpzJm8U6uiSxHy+pl/B2Obx1c65RnivoflKgE3UdB83tt8UZjfMDbxPUU8CKwHmfxsL7Auz6KyRQSU1fv5+iZJN7r28zfofjOsa3OPaxN06FYGejyMrR+AEKK+JR/Y3zI28T1s6qudL8+KCKnfBWQKRySU118unAHzauV5pqry/k7nNx3ao9TnmndZAgu7jw4fM0ICCsi9/GM8SNvE1ddEWkApAKtgL2+C8kUBtPXHuRAdAIv92iIFKbJCGeOwJK3YdWXzqSLdg/D9U9A+BX+jsyYIsOrxKWqb4vI7UA9YLyqzvZtWKYgS3UpHy+Ion7lUnSuV0jq7cWfhKUfwLJPIfUstLgHbvgHRFTxd2TGFDnZJi4R+RN4SFUXu5d+zmz558zalcIphd8WWAwMVncZehEZCkQDtYANqjrzMuI3+dCsjYfYeTyOjwa0KPi9raRYWP4J/PYhJJ2Gxr2h4zNQrghXADHGz3LqcX2jqovP3ygitVQ1Kpt2XYEhgAtYBbTBWWQM4G5V7eRObt8AlrgKEVVl9PwoIsuHc0ujSv4O59IlJ8LqL2Hx2xB/HOp2g07PQqVG/o7MmCIvp8TVU0QyewCnMdA6m3Y/qupZABHZRMYSUcdE5O/AaeC9zBqLyDBgGEBIiE0nLkjmbT7KlsNnGNWnKYEBBbC3lZoC6ybBwjfg9H6o0d5ZyPGq7H7djTF5KafEtQNYlMn21OwaeSStMGD/eb2zR4C5wBmgRxbtxwBjwFlIMocYTT6hqoxeEEXVMsW4o9mV/g7n4rhcsGkazH8NTu6AKi2h50cQ2dHfkRljzpNT4tqpql+dv1FEpnt5/r7AC+dtexPn3tcg4FOgl5fnMvnc0h0nWLsvmld7NiI40NtqYn6mCtvnONUujmyACg2g3yRnaLCg358zppDKKXFVF5H2qrrEc6M3K2KKSDdgpqrGikh1IEFVjwJVVTUe+ERE+l1y5CbfGT0/igolQ+ndsqq/Q/HOriUw72XYvwLK1IA7x0KjXlaeyZh8LtvEpap3X8pJ3QnpLSBGRAKBr4FmwF3AdyIyHEjCqm8UGqv3nOT3nSd4rnt9woLz+Qf/gdVOD2vnAihZGW57F5rfA4HB/o7MGOMFcc9Sz7fCw8M1Li7O32GYHAz+cgXr9sfw69OdKB6STxfWPrrZqSe45ScoVhbaPwmt74fgYv6OzJhcJyLxqhru7zh84ZI+YUSkalq1eGM2HohhwdZj/K1rnfyZtE7uchZxXP8fCCnhPIfV7mEIK+XvyIwxl8CrTxkReQXoA4TgrIIcAZT1YVymAPloQRQlw4K499oa/g4lo9OHYPFbsOYrCAiCax9xyjMVt19dYwoyb/97HInzEHGS+30r34RjCpqoo2eY/edhRnSsRamwfHKPKP4k/PourBgDrhRoMQhu+DuUquzvyIwxucDbxLUVuAE4637fDPjNJxGZAuXjBTsICwpkyPU1/R0KJJ2B3z+GpR/C2Vho0hc6/hPK5oPYjCliRKQrsMKbWegXy9vE1RDw/NcfifM8linC9p6IZ/q6gwy+tgZlw/1Y4SQ5AVZ+7vSy4k9Avduc8kwVG/gvJmMKMRFpDGxS1UyLUYhIMNAJ2IZTmzZXeZu4hgIlgKuBLUBCbgdiCp5PFu0gUIQHboj0XxBbfoaf/wZnDkJkJ7jxeafqhTEmSyJSGngJp1MyR1W97oiISFtgPs6iwqkiEoRTaGINUB8YqarJIpKUzWkui7flDQYAs4ERwBfA7b4KyBQMh2IS+O/q/fRpVZWKpcLyPoCUszD7GZgyAMLLwaAZcO8PlrSMOSdQRMa4l6Q6XyTwBE5B9K5pG0Wki4g083gfJCKPezZU1eXAMY9NDwAHVHUacApnIp9PeZu4yqpqM1UdoKo9gfz98JfxuTGLd5KqyoMd/LC8x6k9MO5mWPYxtBkO98+DmjfkfRzG5G+pqjrMvSRVBqq6RlVdwLXAWI9dK4A3RKSWOGsSfYYzxyE77YC17tdrge7uocLqOAkySyLSSkQecr/uKSI1cv62vB8q3ONxoQicyvDfetnWFDLHY5OYvGIvPZtV4aqyxfP24pt/gukPOzUG75oADTKt02yMyYGIRAKDgXYiMl1VE1U1RkQG4VQ72gUsVNVZOZyqEk7RdNxfK6pqsvvcOXkMWA+gqj+IyDfAwJwaedvjOikiS9wLS67BGTY0RdS4X3eRlOLi4U552NtKGxr8z0AoUxOGL7akZcxlUNWdqjoUZ63Exh7bD+Mkk+uBn7w41QmcORC4vx6/iDDm4e4YiUglnMeucuRV4lLVX3Cmw3dU1auB1RcRmClEYuKTmfD7Hro1rszV5Uvk3CA3nD80OHSOTXE3JvdEAzvT3ojIg0Ai0A+YKCI5DavMAZq6Xzdxv/fWPmCgiEzFyStveNMo26FCEXkYZ+mR3sAt7m3gzC7scBHBmULiq993E5uUwoiOma0v6gPpQ4PAXV9Dgzvy5rrGFGIi8hJwFfBfnFU8Tri33ww0VtUR7vf/xrnPdY9H21ZAeZxJHT8CE4CXReQuoBoXLmWVJVWdB8wTkfI4Ezu8Wloi2yK7ItJPVaeIyI1ASfeJAVqp6ihvg7scVmQ3/4hLSuG6N+bTsloZvrjPxysCp5yFuS84vawrm0PvL62XZcxFuJQiuyJSCoh1T9xI21baFw8Ru8/9Os4sxOI45QRLqmqOQzk5LWsyxf3yiDszpl3MlUUTU4hNWr6X6PhkRnT2cW/r1G6YOhgOroG2D0KXlyEo1LfXNMagqqcz2eaTpOVWDmigqmcBRKShN41yGiq8AngUaCwim92bA4EuQItLj9UUNInJqYxZspPrapWjRbUyvruQDQ0aU5RMB7qISLL7fRPgz5wa5dTjOi4ic3GqwqfN5XcB31xGoKYAmrpqH8fOJPF+v2Y5H3wpUs7C//4Pln9iQ4PGFB1PA/s5V8C9CvB2To1yfI5LVReLyC6c+fku4G4g0/pUpnBKTnXx6aKdtKhWmmsiy+X+BWxo0Jiiaraq/jvtjYhU8KaRtw8gPwX8E5gMbADuxIvunCkcpv1xgAPRCbzas1HarNLcs3kG/DDCeW1Dg8YUNa1E5Fsgxf3+KqB9To28TVx/AsOBUFX9PxEZemkxmoIm1aV8snAHDa8sRce65XPvxDY0aIyBucBmnNE8OPc8WLa8TVxrcepR9XEXYLQV+YqImRsOset4HB8PbJF7vS0bGjTGAKr6sed7EdnnTTtvE9dx4JCqxolIVWD0RcZnCiCXS/loQRS1KpTgloaVcuekNjRoTJHnrkl4H/Aw8DjOPGIBSgM5Tlv2tlbhSKCR+/Us4J2LDdSTiISLyGAR6XQ55zG+NW/LUbYcPsPDHa8mIOAye1spZ2HWP+E/d0O5SBi+yJKWMUXXP92FeOcAzVU1UlVr4rHESna8TVyzgU3u12HANdkdLCKlRGSyiOwUkfHiMcbkfjZsGjBfVRd4eX2Tx1SV0QuiuKpsMe5oeuXlnezUbqfW4PJPoO1DMOQXu59lTNH2vojcoKqbPR9wVtWV3jT2dqjwJHC3u0bVX4BJORzfFRiCc8NtFU7F3+XufaOAr1R1TxZtTT7wa9Rx1u2L5t9/aUxQoLf/v8mEDQ0aYy60SVUXn79RRMql1U3MjreJaxmwBKgFvAccFpEIVY3J4vgfPUp4bMIpe497cbE+wAYRmQDsUtULCjKKyDBgGEBISIiXIZrcNHp+FJVKhdGrZZVLO4HNGjTGZC1SRO7NZHt7nBWVs+Vt4hqH8/zWq6oaKyJTgM9EJFFVfz//YI+kFQbsV9Uo967ywG5Vfdu9/08RGauq+89rPwYYA06RXS9jNLlk5e6TLN91kudva0BoUODFnyDDrMGHoMtLNmvQGOOpFpDZHIfLr1XoIQanzFMnYAZQV1UXiMjzwAWJy0NfMpa4jyZj1Y1twJU4JT9MPjF6fhTlwkPo3+aqi29sQ4PGmJxNU9XXz98oIjW8aeztzYt1QCmgjYgEce4p5+ZZNRCRbjjrvMSKSHURqaCq8cAxESnpPqwYsN3LGEwe2LA/hkXbjjHk+poUD/H2/zVAShLMevrcrMEHF1vSMsZkpZeIXFAhQ1V3e9PY20+mrcAjOAURhwFTROQdnGR2ARHpB7wFxIhIIPA10Ay4y32Ol0RkFfC1qp7K7BzGPz5aEEXJsCDuuaa6941O7oLvBsPBP2xo0BiTI1VtdTnts11IMstGImWBOCBYVWMvJ4Cc2EKSeWfbkTN0fXcxj3auxZNd63rXaNOPMGYyzroAACAASURBVP2vzuueH0H9230XoDHGa5eykGRB4VWPS0TuB3oBoThPN1dW1XqcK0VvCoGPF0RRPCSQwdd5MfsvJck9a/BTuLIF9PkSytTweYzGmIJPRMJUNfFS23s7VNgTZ4gvLVFdVjfP5D97TsTx47qDDL2+JmXCc3gE4YKhwZchyB5bMMZ47Q0Rmca54ropwDZVPe5NY28T1xz3BdLGFZOzOdYUQJ8u2kFQYAAPtI/M/kDPocG+E21o0BhzKdJml6dVVQoF+orIEVX9LqfG3iauXjgVM9JUAb71OkSTrx2MTuC71fvp17oaFUqFZX6QDQ0aY3LPc+5Z5p4WiMgz3jTONnF5lN/o5dmF83aVSlMwjFm8E1UY3iGL3pYNDRpjclEmSSuNV9ORc+pxjRSRJcD5azHdANzvzQVM/nbsTBJTVu7lL82rULVM8QsPsKFBY0wuE5FHgR88NwF1gSbetM8pcTXN4phGmWwzBdAXv+7ibIqLhzpenXGHDQ0aY3znNeAJj/fxOIUunsj88IxySlwDPOoMphORWl6HZ/KtmPhkJi7bQ7fGlYksX+LcjpO7YOp9cGgttHsYbnrJhgaNMbmpk6quutTG2SauzJJWdttNwTJ+6W5ik1IY0cnj/yGbpruHBgX6fgP1b/NbfMaYQquSiJwAdgK3q+rhi2l8EcXoTGESm5TCuN92cVP9itSvXMoZGpzzPKz4zIYGjTG+NgDoAkQCTwL/uJjGXhXZFZEgEanvft3mYiM0+c83y/YQk5DMXzvXcoYGv+jqJK12DzsrFFvSMsb4zu+qusb9zFb66iDeVof3tsf1Nc4qyCOAPSLyiqo+f5GBmnwiMTmVsUt2cX2tK2h2ZhFMtKFBY0yeGiQiaauL1BGRZu7XjYHWOTX2NnEtwFlLC1U9IiJdAUtcBdS3q/ZxOjaWt0r8CN9+ZUODxpi8thZY4n69yGO7V1WZvE1cAjQXkVhgEHDE6/BMvnI2xcWPC35jVol3qbxlu80aNMb4wztALBCtqqcBRKQ8kGO5J/DyHpeqfgb8irOs8jRg4CWFavxu5czxjEt6impyxBkavOV1S1rGmLy2AejLufq3uF/f6U3jLHtcItIFuOb8zUA9nNkgQy8qTONfKUm45jzHdWvGsC2oNrUfmgplvVi+xBhjct8kVX3Lc4OqHheRKt40zm6oUIDVON257sBsnIq+AUCnS4vV+IX7geKAQ2v5IuVWqt75BnXKXsQKx8YYk7u2ZrE9k7pzF8oycanqnLTXInKFqs73eD/E6/CMf7kfKFYRXir+L34Lascvjar5OypjTNFWX0SKqWpC2gYRKQU08Kaxt5MzIkRkHHAKZxHJ3RcbpcljKUkw5zlYMQaubMGvzd5k/PdHea9vLQICJOf2xhjjO18Aq0VkCnAYqIYzd+IBbxqLquZ8FOkPhrXCmVG4TFXzZDHJ8PBwjYuLy4tLFR4nd8LUwem1BvWmF+nx6Uqi45OZ/1QHggK9mpNjjCnARCReVcP9HUdWRCQSeBSoBewFPlPVdd60zWk9rsaqusFdLaOee3NNnEUln7z0kI3PpNUalHMPFC/Zdoz1+2N4/c7GlrSMMXnC/bzvClWNzmy/qu4EHr+Uc+f0KfagiAQDV+MscVLT/efK7BqJSCkRmSwiO0VkvJy3mJf7mO+8Le9hvLTqS/j2XriiNgxfkl4FY/SCKCpHhHFnC68m7BhjTLZEpLGIBGazPxhnEl9pX1w/p+rwI9xBfA9MUfe4ohdTFrsCQwAXsApoAyxP2ykif8HLlS6Nl3YtgZl/g1pdoN+k9GezVuw6yYpdJ3nh9gaEBmX5e2aMKULcEyE+A9oCi4HB6uV9IxFpC8wHygGpIhIEvACsAeoDI1U1WUSSfBI8Xj6ADNwDzBSR+SIyH5iXw/E/qmqCqiYBm4ATaTvc9an2eW4zl+nUbqenVTYSen+R4YHi0QuiKBceQr/WNpPQGJMurXNRH2iJ07lARLp41A1MK7CeYThPVZcDxzw2PQAcUNVpOBP4+vg4dq8TV0/gaeAh959XsjtYVc8CiEgYsD9t/S4RKQPUymkBMREZJiKrRGRVSkqKlyEWUUlnYHJ/0FToPwXCItJ3rd8fzeJtx7i/fSTFQqy3ZUwREygiY0Tk9kz2ZdW5WAG8ISK13Ld4PiPrZ67StMOpPYj7a3f3UGF1nGVLcp230+Hn4Az7pXUlvZ1R2BenC5mmO9BHRAYCLYArRWSwqh7wbKSqY4Ax4Mwq9PJaRY/LBd8Ph2Nb4e7voNzVGXaPnh9FqbAg7m5nvS1jiqBUVR2W2Y6sOheqGiMig3BWBNkFLFTVWTlcpxJwxv36DFDRPet8cC58D5nyNnH1wplJmKYK8G12DUSkGzBTVWNFpDqQoKoTgYnu/eOBF89PWuYiLHgNtv4Mt7wBV3fOsGvr4TPM2XSER2+sTcmwYD8FaIzJ587vXKCqh0VkPXArzkhbTk4AJdyvSwDHczXCTHiduFQ1PRgRyfa/8CLSD3gLiHHPPPkaaAbcdamBmvNs+A6WvA0t7oW2wy/Y/fHCKMJDAhl8bY28j80Yk++d37lQ1T3u7Q8CiUA/YKKI9FHV+GxONQdn1vlyoIn7vU/l9BxXN1WdCbR0zyRJ0wDnm8qUqk4BpmR3blW97yLiNJ4OrIHpI6DaNdBtlPPMlofdx+OYse4gD7SPpEy4VX43xmSUSefiQ+BjEbkZaOwxo/zfOPe57vFo2woojzPB40dgAvCyiNyFUwEjQw/OF3LqcTUWkV9wpq5HAzHu7T6Zm2+8cOYwTBkI4eXhrq8zXZLkk4U7CAoMYGh7q/5ujLlQNp2L34H/eRz3m4j8eV7bVUC4x3sX8Jz7bba3kHJLTs9xvQEgIhtU9ce07SKS49LKxgeSE52klRgDQ3+BEuUvOORgdALf/7Gf/m2qUaFkmB+CNMYUVGmLOp63LdPKF/6U01DhFTgLe7USkbQp7AE4w4QdfRuayUAVZjwGB1Y5Pa1KjTM9bMzinajC8A5XZ7rfGGMKupx6XMdF5AzOTJHK7s0u4A1fB2bOs/QDWD8FOv4LGtyR6SFHTicyecVe7mxRhSqli+VxgMYYkzdynFWoqpNFZBYQqKonPGefmDyybQ787wVo0BM6/CPTQ07FnWXQuBUAPNyxVl5GZ4wxecrbyhlfAte4X8eLyHPZHWxy0bGt8N+hztBgz48vmEEIEJOQzD3jlrPzeBxj721FjSvy7UoGxhhz2bxNXF+r6k8AqnoM6O27kEy6+JMwqS8EhTqFc0MuTEhnEpO5d9wKth4+w2d3t+SGOhdO2DDGmMLkYlZAHoAzJf5uYIfvQjIApKbA1Pvg9AEY9BOUvuqCQ+KSUhj85Ur+PBDDxwNb0KlehbyP0xhj8phXPS5V/RI4gFNJeDpWAcP3fvkX7FoEt70H1dpesDvhbCpDxq/kj33RfNC/OV0bVvJDkMYYk/e87XGhqouARSJSDHgXZ8ll4wurx8OKz+Cav0LzgRfsTkxO5YEJq1i5+yTv9m1Gt8aVLzyHMcYUUl6v4y4iV4vIKGAPzjInxhd2/wY/PwVX3wg3vXTB7qSUVB6cuJrfdhznzd5N6dHMVjU2xhQtOfa43IUYH8FZW2Ub0Aiwkgy+cGoPfHsPlKkJvcdBYMa/nrMpLkZ8s4aFW4/x+p2N6d2yqp8CNcYY/8mpcsYY4EZgmKrOE5HHVPVo3oRWxCTFwpQBzqSM/lOgWMZykCmpLh6b8gdzNx/llR4N6d/G1tgyxhRNOVXOGCYitYCbRaQmUApARILdC4WZ3OBywbThcHQTDPwOrsj4AHGqS3ni23XM2niY529rwD3X1PBPnMYYkw94UzkjCogSkVCgp4j8A2d2oc9WtyxyFr4OW36Cm1+HWjdm2JXqUv4+dR0z1h3kn7fWY+j1VvHdGFO0XcyswiTgPwAiMtRnERU1G7+HxW9C87uh3UMZdrlcyr++38D3fxzgqS51eNAK5xpjDKKq/o4hW+Hh4RoXF+fvMHzj4FoYdwtUbgKDZjgVMtxUleenb2Tisr082rkWT3at68dAjTEFjYjEq2qhrP/m9XR4k8vOHHEmYxQvB30nXpC0Xv5pExOX7WV4h0ie6FLHj4EaY0z+4vVQoclFKUnwn7sh4RQM+QVKnCvVpKq8PmsLX/62myHX1eSft9RDMimsa4wxRZUlrrymCj89AftXQJ+vnGFCD6PmbGPM4p3c0646z99W35KWMcacx4YK89rvH8Hab6DDP6FhxgIkH8zbzugFUfRvcxUv3dHQkpYxxmTCElde2v4/+N/zUP8O6PB0hl0fL4zinf9to1eLqrzWszEBAZa0jDEmMz5JXCJSSkQmi8hOERkvHl0HEeknIr+JSJSIXOuL6+dLx7bBd0OgQkP4y6cQcO5H//mSnbw5eys9ml3Jm72bWNIyxphs+KrH1RUYgvOgckugDYC7snyqql4H/B/wvI+un78knILJ/SAwBPpnXBBywu+7efXnzXRrXIlRfZoSaEnLGGOy5avE9aOqJrgfWt4EnHBvTwb+6379h8f2wis1BaYOhui90O8bKH2uxuCk5Xv5v+l/0qVBRd7v15ygQBu5NcaYnPhkVqGqngUQkTBgv7tsFKqa4nHYDcCbmbUXkWHAMICQkBBfhJh35jwHOxfAHaOhWrv0zd+u2se/pm2gU93yjB7QnGBLWsYY4xWfVs4QkUHAf1U19rztkUBdVZ2V0zkKdOWMNRPgx0eg7UNw68j0zT/8cYAnvl3L9bWuYOy9rQgLDvRjkMaYwsgqZ1wC9zpeM1U1VkSqi0gF9/YKQD1VnSUiYWnbC509v8NPT0JkJ+j6avrmn9cf4slv19KuZjnG3GNJyxhjLpZPelwi0g94C4gBAoGvgWbAfcA8oKT7UAWanzeEmEGB7HFF74UxnSAsAh6YB8XKADB742FGTFpDi2ql+WpIG4qH2PPfxhjfKMw9Liuym9vOxsEXNzvJ6/65UN6pMzhv8xEenLiaRlUi+HpoW0qEWtIyxvhOYU5c9umZm1wumPYgHP0TBkxNT1qLth3joYlrqF+5FOMHt7GkZYwxl8E+QXPTojdg84/Q9TWofRMAS6OOM2zCKmpVKMGEIW2IKBbs5yCNMaZgsznYueXPH2DRSGg2EK4ZAcCKXScZ+tUqapQLZ+L9bSldvIBP7TfGmHzAElduOLQefngIqraB294FEVbvOcXgL1dwZekwJt7flrLhlrSMMSY3WOK6XLFHYXJ/Z+age0HIdfuiuW/cCiqUCmPyA+0oXzI05/MYY4zxit3juhxpC0LGn4Ahs6FkRTYeiOGeL5ZTOjyYSQ+0pUKpMH9HaYwxhYolrkulCj8/CfuWQ+8v4cpmbDl8mru/WE7JsGAm3d+OyhHF/B2lMcYUOjZUeKmWfQJ/TIQb/gGN7mT7kTMMHLucsKBAJj3QlqvKFvd3hMYYUyhZ4roUUfNgzrNQ7zbo+Aw7j8Uy4PPlBAQIkx5oS/VyhfKZP2OMyRdsqPBiHY+C7wZDhQbwl8/YcyqBAWOX43IpU4a1I7J8CX9HaIqY5ORk9u/fT2Jior9DMX4QFhZG1apVCQ4uOs+IWuK6GAnRMLkvBARBv0nsjw9gwNhlJKWkMnlYO2pXLJnzOYzJZfv376dkyZLUqFEDj8XGTRGgqpw4cYL9+/dTs2ZNf4eTZ2yo0FupKfDdEDi1G/pO5FBABfqPXcaZxGS+HtqWepVK+TtCU0QlJiZSrlw5S1pFkIhQrly5ItfbtsTlrbkvwI550H0UR8u0YMDY5UTHOUmrUZUIf0dnijhLWkVXUfy7t8TljT++gd9HQ5vhHKvTn/5jl3H0dCLjh7Sm6VWl/R2dMcYUKZa4crJ3Ofz0OER25GT7F7n78+UcjE5k3H2taVm9rL+jM6bI+eWXX5gzZ46/wzB+ZIkrO9H74D8DIaIqMd3HcPe41ew+EccXg1rRNrKcv6MzJt954IEHcLlcOR537NgxAEaOHMlPP/2U5XEPP/ww69aty7AtOTmZpUuXZnv+7du307p1a4YOHZp+rdySdr7JkyczevToSzrHwIEDeeaZZ+jXrx+tW7fmtddeo379+rkZZqFmswqzcjYOpgyAlCRi+0/nnsnbiToay9hBrbi21hX+js6YTL004082HTydq+dscGUpXri9YY7Hbd++nblz5zJz5kxuu+22LI+bNGkSZ86cYfjw4Tz11FMEBWX9MfTuu+8SGpqx1meJEjk/clK7dm0aNmxI+/btKV++fI7He2vRokXMnTuXV155hb59+3qVpDMzbNgwOnTowPjx41m4cCHPPvss1113Xa7FWdhZ4sqMKvzwMBzeQEKfydzzYzSbD53m07tb0qFO7v0jMKYw+eWXXxgzZgyjRo3KkLjGjRtHREQEEyZMYPz48cyYMYPw8HBuuukmNm7cSGhoKC1btqRXr1706tWLOXPm0KNHD+69916+//57IiMjadeuHV988QUREREsX76c8PBwVJXPPvsMEWHBggVMmDCBkJALV2E4duzYBeceNmwY06ZNY+vWraxbt47o6GjGjRvH8uXLOXnyJLNnz+b111/nxIkTrF27lo0bN/LUU08xc+ZMtmzZwvr16zl69CgnTpygb9++zJ49m5MnT7Jnzx7Kli3LgAEDGDp0KA0bNmTr1q1ERkby6quvpsfUoUOHC+Ls2LEjqsrbb79N3bp1+fnnn3nyyScpXrw4Xbt2ZdSoUUydOpVnn32WWrVq+eYvsYCwxJWZxW/Bph842/kl7l0SwYb90Xw0sAU31q/o78iMyZY3PSNfSExMJCQkhJtuuolHH32U7du3U7t2bRYuXEhISAi9evUiODiY1NRU6tatS6VKlYiMjOSnn37i1KlT3HLLLQQEBNCpUyc6duzIP/7xD4YOHcqqVas4e/YsFStWZMmSJYwfP54yZcqwZMkSfv75Z3bt2kXz5s0pU6YM27dvp2HDC7//8uXLX3DuYcOGMWXKFP7617/SrVs3Jk6cSEhICBMnTqR3797Uq1eP1atXc+jQIVSVkSNHkpSURP369RERmjRpwrRp05g1axZ9+vTh1Vdf5ddffwWgadOm3H777RQvXpzmzZvz+OOP06ZNmwyJKyszZswgJSWFO+64g0qVKvHEE08wc+ZMPvroI/7+97/z/vvvF/mkBZa4LrTpR1jwGimN+jJoc1tW7znJh/1bcHPDSv6OzJh864cffuDQoUO8//771K5dm48//ph3332XVatWUa9ePQDuuOOODG1EhIiICE6dOpW+La3HlJSURGBgIKVKOc9Hrlq1ijJlygAQGBgIwJ9//kn79u257bbb6NevX44xep4b4I033mDs2LG0adOG5557js2bN1OjRo0M54qNjaVPnz7pPTpPafEcP36ckydPpm+vX78+O3bsSL9maGho+jVzsmXLlvTvr0mTJmzduhWAzp07k5iYiKp6dZ7CziZneDq8AaYNx1WlFcOi72HZ7pO827cZ3ZtU9ndkxuRre/bs4YUXXuDxxx9n7NixTJw4kbi4OKpWrco333yDqnL06FF2795NQEDARd8bqlixIqtWrQLA5XKhqlx11VXpyeTw4cMsW7bsos75888/8+KLL9KjRw9KlSpF1apV+eGHH4iNjSUlJYUZM2awfft2Zs2aRZMmTfj6668zjb18+fIkJCSkJ+D4+Pj0ZH2xGjdunP59njx5kmbNmgHw/fff8+GHH/LUU09d8n21wsQSV5rYYzC5PxoWwZP8jflRp3mzVxN6NKvi78iMydc+//xzNm3alN6rSExMJDQ0lKeffppevXqRlJRE06ZN+fTTT6lRowatWrViypQpLF++nHXr1rFp0yb27NnD/v37Wbt2LatWreLgwYPs27ePzZs3s3btWtq2bUuNGjUYOHAg8+fPZ+/evXTv3p2EhARat27Nhx9+SNu2bdNj2r59Oxs2bGDx4sUcOXLkgnMfP36chIQErrnmGpo2bcpdd91FxYoVGTBgAK1ateL+++/nuuuu46effuLzzz8nKCiIDh060LRpU+bMmcOiRYtYtWoVO3bs4NSpU4wZM4ZXX32VKVOm0L9/f4oXL86OHTvSrxkdHc3evXsz/NxOnTrFr7/+yoYNG9i2bRsAt956K9WqVWPcuHFMnjyZt99+m02bNrF48WI6d+5M2bJleeaZZ4p8z0t88QMQkVLAZ0BbYDEwWN0XEpHOQCNAgGWqujy7c4WHh2tcXFyux5hBylmY0AM9uIbXKr7D5ztK8++/NGZA22q+va4xuWDz5s02lfoiJSYm8swzz/Duu+8CMG/ePFq0aJE+/FfQZPY7ICLxqlool6rw1T2ursAQwAWsAtoAy0UkEHgTaO0+bh7Q2UcxeEcVZj4Fe5cyrtLzfL6jNC/3aGhJy5hCLDk5mfXr19OzZ0+aN2/OTTfdVGCTVlHkq8T1o6qeBRCRTcAJ9/ZqwHGP3leyiESq6k4fxZGzFWNgzQR+KXc3r+yuz3Pd63PvNTX8Fo4xxvdKlizJvHnz/B2GuUQ+ucflkbTCgP2qGuXeVQk443HoGeCCOeYiMkxEVonIqpSUFF+E6NixAJ39DBtLXs+DB27h6VvqcX/7SN9dzxhjzGXz9eSMvsALHu9PAJ6PvZcAjp/fSFXHqGorVW2V3VP1l+XEDnTqII6EVqfvscE80aUeD3W82jfXMsYYk2t89hyXiHQDZqpqrIhUBxJUdZuIlJRzdfhLqOp2X8WQpcQYdHI/4lOE3nGPMrhTYx69sXaeh2GMMebi+aTHJSL9cGYVLhCRzcBAIK0a5TPAU+4/z/ji+tlypaLfDcV1fAdD4h6he/t2PNW1Tp6HYYwpmDZv3sz777/v7zCKNF/d45qiqlepaiNVra+q/1bVu9z7lqjq2+4/S3xx/Wxj+98LSNT/eD75Phpceyv/vLVekVyIzZjcNH/+fAYMGMDLL7/M3XffjYiwceNGhg4dSsuWLXn//ffp378/M2bMYOXKlZQoUYL33nsPl8tFXFwcTzzxBI888gjx8fHp52zZsiWvvfYarVu3pl+/fjz77LP07NmTvXv30r9//8uO+cUXX+T5559ny5YtF+zr0aMHJ06cyKQVVKlSJX0avae0qvF79uzhgw8+4L777rvsGE3milbJp7WTkN8/5KuULgS0Hsz/3dbAkpYxl2nHjh2MGDEiPSGBUwGiRIkStG/fntTUVB577DGuv/56unTpwsmTJ7niiivo2bMnAQEBhIeHc/vttwNQvHjx9PO+8847dOjQge3bt9OxY0fuu+8+Fi5cSLVq1Rg/fnyuxH7jjTdmWuXi22+/vaAqfZq0MlSeYmNjGTRoEDNnzqR69erccccdrFmzJldiNBcqOolr30pSpz/KstSGbG32L169o5ElLVP4zPqnU7osN1VqDLeOzHL3Bx98QN++fTMsN/Lggw9ecNyuXbuoUaNGpucICLhw8CerCuqbNm1izpw5PP7443z00UfMnTuXVq1aMXv2bJ5++mmmT59OuXLlGDlyJHPnzmXfvn3MmzePRx99lDZt2mR6/XHjxrFw4ULOnj1L//79OXr0KDfccAN169bl+eefp06dOowaNYqOHTvy3nvvkZyczDvvvMOUKVP49NNPKVasGEuXLmX69On06NEjy5+VyR1Fo+RTzAHiv+7LvtSyzKr/Oq/e2ZyAAEtaxuSGqKgoKlXKWIQ6IiKCiIgIALZt28Z7773HsmXLmDFjxmVfr3Llyrz33nuAU9A2MDCQZ599lqpVq6KqjB49mqlTp+Jyufjggw8oVqwYjRs3ZuXKlVmes0aNGhw5coQpU6bQrVs3Zs+ezaFDhwCYOHEid911F0OGDKFr166AU3njscceY+DAgcyZM4f69esTFhZmSSuPFP4e19l4jn/ei9CkeCZFfsJL/W6wpGUKr2x6Rr5SrVq1C+rweapTpw6PP/54hm3FixfPUG/P5XJlupZWZjwrXAQEBKQvRBkaGkpwcDChoaHExcVx7NgxQkJCvKocHxAQkH7e4OBgSpYsmb7vvffeY/z48dSsWZNu3bqlHxMYGEhoaGiG6vYmbxTuHpcqu8fdR9nTW5hw5XP8454eBFrSMiZXDR8+nG+++Ybo6Oj0bceOHePo0aNZtvFcsgNg06ZN1KmTu7N7y5Yty9KlS9N7TtOmTbuk8+zatYvhw4en34fLSlEvfJuXCnWPa/3k52ly+Be+K3s/Dwx9mKDAwp2njfGHZs2aMXbsWIYOHUr9+vUpXrw4VapUoVevXixdupQNGzawc+dOIiPPVaUZOXIkTzzxBEuXLiU0NJTatWtToUKFC869a9cuNm7cSGBgIN27d6d8+fKsWLGCU6dOERUVxbp169i3bx+HDx9m//79rF+/nqpVq3L69Gn27dvHiy++SPv27WndujWvvfZalt/DihUr2LlzJ4cOHSIkJISdO3eycuVKOnbsyO+//86kSZNISkqiT58+dOvWjZiYGHbv3s369es5fvw4KSkp1K5dm1GjRvHII4/45OdszvFJdfjcdKnV4Tf9PosGv/RjafiNtHz8W0KDC3WONkWYVYe/NC+++CIdOnSgU6dOWR6TtjTKiBEjcLlcTJs2jV69euV47t27d/Piiy/m2uzHnFh1+EKibuubWLbzKVrc+ZQlLWPMBZo0acL69eupWLEiDRo0yPSYlJQUJkyYwLJly2jWrJlXky927drFokWLuPbaa3M7ZPP/7d1/qN11Hcfx59O2usMlkpUTr8rWD1hss5g1yVEWsaRVLDAzKtBVYv6VFsFKHJFkfyToP4VFKiUVK1n0h39UJP5hTZ0xJFyUrv0xo6SLhm42l7774/udXW6ba917z/d8v+f1gHHOved8v9/35164r30+55z3pzXYGVfEpMiMKyZtxpUXfSIiolcSXBEDMO4rJ7F4JvF3n+CK6LmpqSlmZmYm8g/YVJFPHgAABWZJREFUpKsqZmZmmJqa6rqUkcq7FiJ6bnp6mgMHDrzU5DUmy9TUFNPT04t6DXUT8GBVPX3CJ49Agiui55YuXcrKlSu7LiN6Sl0LPFpVLxzn8aXAe4A/AmMRXFkqjIiYUOoGYBewVF2ifk39iPpl9RSAqjoCHO600DkSXBERE6qqHgCOrjF/FniiqnYCTwEf7aywE0hwRUQM0xJ196x/V53g+RcCe9r7e4DN8NJS4XnAquMcN3Jj/xrXoUOHSn1uHqdYAvxroerpgUkbL2TMkyJjPjnLquqCk3j+CuCZ9v4zwJnw0lLhlf9nDYti7IOrquY1K1R3n+Qvr9cmbbyQMU+KjHnRzQBHdwNdDvx9RNc9aVkqjIgIgF8A57f317Vfj6UEV0TEhFIvAF4HbAK+D5yrXgacC9zVZW0vZ+yXChfAd7ouYMQmbbyQMU+KjHmBVdVuYHYj3uvb2x2Led35Gvvu8BEREbNlqTAiInolwTUw6lr1FV3XERELR3111zWMk0EG1/Falwzd7PYtXdcyCupp6o/Ufeqdql3XtNjU09Vb1V+pX+q6nlFS16u3dV3HqKjb1cfUvUCCa5ah/kHvTeuShTSnfcsk2ARsBVYD64F3dFvOSKwCrqUZ+6aOaxkZ9XSaRq+v6rqWUVCXA8uANVW1uqr+0nVN42SowXXM1iUxOD+vqueq6jDwKM0HKAetqn5XVS8C7wS+23U9I3QpcHfXRYzQm4G3Ak+oW7suZtwMNbiO2bokhqWqngdQp4ADVfVYxyWNhLqKpgXPDe3YB029FNgJTMxboNv/oFwCbARuVM/quqZxMtTg6k3rklgQHwO2d13EqFTVvqr6NPAAsLbrekbgSuB7NJ9peq/6hY7rGZmq2gv8FEhwzTLU4OpN65KYH/UDwD1V9ax6Xtf1jNjTwL6ui1hsVbW5qrYAVwG/rqqbu65psc2ZSU/RLIVHa6jB1ZvWJQtpTvuWwVMvB24D7m3feTX41zLVr6q3q5tpAnvwr+tNqBvVn6ifAu6qqn92XdA4SeeMiIjolaHOuCIiYqASXBER0SsJroiI6JUEV0RE9EqCKyIieiXBFRERvZLgisFSL1IPtp992qberU53XJPqGV3WENF3Ca4YrKq6n6Zb/h1VdRPwEHBdt1WxDXh7xzVE9FqCKybJa4A/qcvV+9RL1I3qfnVKvVn9hvpb9RPqL9XPq3vUs9UPq7va43+mXtHO6h5Sr1UfVj8++4LqVvWD6h1tG59NwLvVFeqW9vEd6hvUa9Sd6k3qI+pbOvkpRYy5BFdMgs+p3wIupu1rCPy5fWw3QNtS5yDwD+Ai4H7gjKq6BbgXeBfwSPvcZ4E/tMf/hmaPrFuAy4Cvz7n2+4Engevba+wH7gOOAJ8EDrXnWg/sbU5f29rzTdRGkRH/qwRXTIJvV9U1NF22b3+Z570IPNXudwXwfHt7mONsYFhNz7Qj1Xic/959ejtwJ3D1nO+/EdhfVT+uqhuqagfNth1Hr/kw8NoTjixiAiW4YpI8zn+2QH+BZofZk9nP6ugxHOs49VTg93O+vQx4G3ChuoYmHE8BDgBb2mXHJeqH5hx3Js22JRExx5KuC4hYLOpG4PU0S4V/A95Hs+09wD3AV2j2a3tSXQ2sAVa0AXQ+cJZ6Ds3WOK8EfgAcVG9tz3FOe3uq+hmasJn75o8vAjtoAm0f8CDN7Os64Ic0S5W72q/XAW9SrwBWAt9cmJ9ExLCkO3zEPKl/raoVC3Cei4Grq+ry+VcVMVxZKoyYB3UDcJq6bgFOtwFYqZ69AOeKGKzMuCIiolcy44qIiF5JcEVERK8kuCIiolcSXBER0SsJroiI6JV/A783NPCncL4UAAAAAElFTkSuQmCC\n",
       "text/plain": [
        "<Figure size 432x288 with 2 Axes>"
       ]
      },
-     "metadata": {},
+     "metadata": {
+      "needs_background": "light"
+     },
      "output_type": "display_data"
     }
    ],
@@ -497,17 +484,42 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Universe Data (`universes`)"
+    "# Homogenized Universes"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Universe data is stored for each state point, i.e. `('univ',burnup, burnupIdx, time)`\n",
+    "Universe data is stored for each state point in the `universes` dictionary. Keys are `UnivTuple` representing `('univ',burnup, step, time)`\n",
     "\n",
-    "`'univ'`: universe ID (e.g., `'0'`), `burnup`: in MWd/kg, `burnupIdx`: step index, `time`: in days.  \n",
-    "Results, such as infinite cross-sections, b1-leakage corrected cross-sections, kinetic parameters, are included in `.universes`. All the results include values and uncertainties. "
+    "* `'univ'`: universe ID (e.g., `'0'`)\n",
+    "* `burnup`: in MWd/kg\n",
+    "* `step`: step index, \n",
+    "* `time`: in days.  \n",
+    "and can be indexes by attribute or by position."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "UnivTuple(universe='0', burnup=0.0, step=0, days=0.0)"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "for key in sorted(res.universes):\n",
+    "    break\n",
+    "key"
    ]
   },
   {
@@ -518,7 +530,7 @@
     {
      "data": {
       "text/plain": [
-       "dict_keys([('3101', 0.0, 0, 0.0), ('3102', 0.0, 0, 0.0), ('0', 0.0, 0, 0.0), ('3101', 0.1, 1, 1.20048), ('3102', 0.1, 1, 1.20048), ('0', 0.1, 1, 1.20048), ('3101', 1.0, 2, 12.0048), ('3102', 1.0, 2, 12.0048), ('0', 1.0, 3, 12.0048), ('3101', 2.0, 3, 24.0096), ('3102', 2.0, 3, 24.0096), ('0', 2.0, 3, 24.0096), ('3101', 3.0, 4, 36.0144), ('3102', 3.0, 4, 36.0144), ('0', 3.0, 4, 36.0144), ('3101', 4.0, 5, 48.0192), ('3102', 4.0, 5, 48.0192), ('0', 4.0, 5, 48.0192)])"
+       "'0'"
       ]
      },
      "execution_count": 18,
@@ -527,88 +539,50 @@
     }
    ],
    "source": [
-    "# The different states are obtained by:\n",
-    "res.universes.keys()\n",
-    "# The next cell presents the various unique states ('univ',burnup, burnupIdx, time)"
+    "key[0]"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 19,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "<HomogUniv 3102: burnup: 0.000 MWd/kgu, step: 0, 0.000 days>\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "# Let's use the following unique state\n",
-    "print(res.universes[('3102', 0.0, 0, 0.0)])"
+    "assert key.burnup == key[1]"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Each state contains the same data fields, which can be obatined by using the following attributes on the `HomogUniv` objects: \n",
-    "\n",
-    "`.infExp`: infinite values, e.g. `INF_ABS`, \n",
-    "\n",
-    "`.infUnc`: infinite uncertainties, \n",
-    "\n",
-    "`.b1Exp`:  b1 (leakage corrected) values, e.g. `B1_ABS`,  \n",
-    "\n",
-    "`.b1Exp`:  b1 (leakage corrected) uncertainties, \n",
-    "\n",
-    "`.gc`: variables that are not included in 'inf' or 'b1', e.g. `BETA`\n",
-    "\n",
-    "`.gcUnc`: group uncertainties\n",
-    "\n",
-    "`.groups`: macro energy group structure, MeV\n",
-    "\n",
-    "`.microGroups`: micro energy group structure, MeV"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Get Universe Data (`.getUniv`)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "A method to obtain the data for a specific universe and time of interest. \n",
-    "In order to obtain the data, the user needs to pass the `universe id` and the `time point`:\n",
-    "\n",
-    "`.getUniv(univ, burnup, index, time)`\n",
-    "\n",
-    "`univ` must be a string\n",
-    "`burnup` is a float or int with the units MWd/kgU\n",
-    "`time` is a float or int with the units Days\n",
-    "`index` is a non-negative integer (i.e. 0, 1, 2, ...)\n",
-    "\n",
-    "The method requires to insert the universe and burnup or time or index (only one of these is actually used to retrieve the data). \n",
-    "If more than one time parameter is given, the hierarchy of search is:\n",
-    "index (highest priority), burnup, time (lowest priority)"
+    "Results, such as infinite cross-sections, b1-leakage corrected cross-sections, kinetic parameters, are included in `.universes`. All the results include values and uncertainties. "
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 20,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "dict_keys([UnivTuple(universe='3101', burnup=0.0, step=0, days=0.0), UnivTuple(universe='3102', burnup=0.0, step=0, days=0.0), UnivTuple(universe='0', burnup=0.0, step=0, days=0.0), UnivTuple(universe='3101', burnup=0.1, step=1, days=1.20048), UnivTuple(universe='3102', burnup=0.1, step=1, days=1.20048), UnivTuple(universe='0', burnup=0.1, step=1, days=1.20048), UnivTuple(universe='3101', burnup=1.0, step=2, days=12.0048), UnivTuple(universe='3102', burnup=1.0, step=2, days=12.0048), UnivTuple(universe='0', burnup=1.0, step=2, days=12.0048), UnivTuple(universe='3101', burnup=2.0, step=3, days=24.0096), UnivTuple(universe='3102', burnup=2.0, step=3, days=24.0096), UnivTuple(universe='0', burnup=2.0, step=3, days=24.0096), UnivTuple(universe='3101', burnup=3.0, step=4, days=36.0144), UnivTuple(universe='3102', burnup=3.0, step=4, days=36.0144), UnivTuple(universe='0', burnup=3.0, step=4, days=36.0144), UnivTuple(universe='3101', burnup=4.0, step=5, days=48.0192), UnivTuple(universe='3102', burnup=4.0, step=5, days=48.0192), UnivTuple(universe='0', burnup=4.0, step=5, days=48.0192)])"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "# Examples to use various time entries\n",
-    "univ3101 = res.getUniv('3101', index=3) # obtain the results for universe=3101 and index=3 \n",
-    "univ3102 = res.getUniv('3102', burnup=0.1) # obtain the results for universe=3102 and index=0.1 MWd/kgU\n",
-    "univ0 = res.getUniv('0', timeDays=24.0096) # obtain the results for universe=0 and index=24.0096 days"
+    "res.universes.keys()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "One can directly index into the `universes` dictionary to obtain data for a specific universe."
    ]
   },
   {
@@ -620,17 +594,20 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "<HomogUniv 3101: burnup: 2.000 MWd/kgu, step: 3, 24.010 days>\n",
-      "<HomogUniv 3102: burnup: 0.100 MWd/kgu, step: 1, 1.200 days>\n",
-      "<HomogUniv 0: burnup: 2.000 MWd/kgu, step: 3, 24.010 days>\n"
+      "<HomogUniv 0: burnup: 0.00000E+00 MWd/kgU, 0.00000E+00 days>\n"
      ]
     }
    ],
    "source": [
-    "# The full states are printed below\n",
-    "print(univ3101)\n",
-    "print(univ3102)\n",
-    "print(univ0)"
+    "print(res.universes['0', 0, 0, 0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "However this requires knowledge of all four parameters which may be difficult. The `getUniv` method retrieves a specific universe that matches universe id and time of interest. \n",
+    "While all four identifers, (universe id, burnup, step, and time) can be provided, the latter three are usually redundant."
    ]
   },
   {
@@ -642,13 +619,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "<HomogUniv 0: burnup: 0.000 MWd/kgu, step: 0, 0.000 days>\n"
+      "<HomogUniv 0: burnup: 0.00000E+00 MWd/kgU, 0.00000E+00 days>\n"
      ]
     }
    ],
    "source": [
-    "# obtain the results for universe=0 and index=0 (burnup and timeDays are inserted but not used)\n",
-    "univ0 = res.getUniv('0', burnup=0.0, index=0, timeDays=0.0)  \n",
+    "univ0 = res.getUniv('0', index=0)  \n",
     "print(univ0)"
    ]
   },
@@ -658,25 +634,109 @@
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "dict_keys(['infMicroFlx', 'infKinf', 'infFlx', 'infFissFlx', 'infTot', 'infCapt', 'infAbs', 'infFiss', 'infNsf', 'infNubar', 'infKappa', 'infInvv', 'infScatt0', 'infScatt1', 'infScatt2', 'infScatt3', 'infScatt4', 'infScatt5', 'infScatt6', 'infScatt7', 'infScattp0', 'infScattp1', 'infScattp2', 'infScattp3', 'infScattp4', 'infScattp5', 'infScattp6', 'infScattp7', 'infTranspxs', 'infDiffcoef', 'infRabsxs', 'infRemxs', 'infI135Yield', 'infXe135Yield', 'infPm147Yield', 'infPm148Yield', 'infPm148mYield', 'infPm149Yield', 'infSm149Yield', 'infI135MicroAbs', 'infXe135MicroAbs', 'infPm147MicroAbs', 'infPm148MicroAbs', 'infPm148mMicroAbs', 'infPm149MicroAbs', 'infSm149MicroAbs', 'infXe135MacroAbs', 'infSm149MacroAbs', 'infChit', 'infChip', 'infChid', 'infS0', 'infS1', 'infS2', 'infS3', 'infS4', 'infS5', 'infS6', 'infS7', 'infSp0', 'infSp1', 'infSp2', 'infSp3', 'infSp4', 'infSp5', 'infSp6', 'infSp7'])"
-      ]
-     },
-     "execution_count": 23,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<HomogUniv 3101: burnup: 2.00000E+00 MWd/kgU, 2.40096E+01 days>\n"
+     ]
     }
    ],
    "source": [
-    "# The parser reads all the variables by default\n",
-    "# Each field is a dictionary, with variables as keys and corresponding values.\n",
-    "univ0.infExp.keys() # obtain all the variables stored in 'infExp' field"
+    "univ3101 = res.getUniv('3101', index=3)\n",
+    "print(univ3101)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 24,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<HomogUniv 3102: burnup: 1.00000E-01 MWd/kgU, 1.20048E+00 days>\n"
+     ]
+    }
+   ],
+   "source": [
+    "univ3102 = res.getUniv('3102', burnup=0.1)\n",
+    "print(univ3102)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<HomogUniv 0: burnup: 2.00000E+00 MWd/kgU, 2.40096E+01 days>\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(res.getUniv('0', timeDays=24.0096))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Working with homogenized universe data\n",
+    "Each state contains the same data fields, which can be obatined by using the following attributes on the `HomogUniv` objects: \n",
+    "\n",
+    "* `infExp`: infinite values, e.g. `INF_ABS`, \n",
+    "\n",
+    "* `infUnc`: infinite uncertainties, \n",
+    "\n",
+    "* `b1Exp`:  b1 (leakage corrected) values, e.g. `B1_ABS`,  \n",
+    "\n",
+    "* `b1Exp`:  b1 (leakage corrected) uncertainties, \n",
+    "\n",
+    "* `gc`: variables that are not included in 'inf' or 'b1', e.g. `BETA`\n",
+    "\n",
+    "* `gcUnc`: group uncertainties\n",
+    "\n",
+    "* `groups`: macro energy group structure, MeV\n",
+    "\n",
+    "* `microGroups`: micro energy group structure, MeV"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The parser reads all variables by default, and the `HomogUniv` objects stores data in various dictionaries. Data are energy dependent, exactly as they would appear in Serpent outputs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "dict_keys(['infMicroFlx', 'infKinf', 'infFlx', 'infFissFlx', 'infTot', 'infCapt', 'infAbs', 'infFiss', 'infNsf', 'infNubar', 'infKappa', 'infInvv', 'infScatt0', 'infScatt1', 'infScatt2', 'infScatt3', 'infScatt4', 'infScatt5', 'infScatt6', 'infScatt7', 'infScattp0', 'infScattp1', 'infScattp2', 'infScattp3', 'infScattp4', 'infScattp5', 'infScattp6', 'infScattp7', 'infTranspxs', 'infDiffcoef', 'infRabsxs', 'infRemxs', 'infI135Yield', 'infXe135Yield', 'infPm147Yield', 'infPm148Yield', 'infPm148mYield', 'infPm149Yield', 'infSm149Yield', 'infI135MicroAbs', 'infXe135MicroAbs', 'infPm147MicroAbs', 'infPm148MicroAbs', 'infPm148mMicroAbs', 'infPm149MicroAbs', 'infSm149MicroAbs', 'infXe135MacroAbs', 'infSm149MacroAbs', 'infChit', 'infChip', 'infChid', 'infS0', 'infS1', 'infS2', 'infS3', 'infS4', 'infS5', 'infS6', 'infS7', 'infSp0', 'infSp1', 'infSp2', 'infSp3', 'infSp4', 'infSp5', 'infSp6', 'infSp7'])"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "univ0.infExp.keys()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
    "metadata": {},
    "outputs": [
     {
@@ -689,19 +749,18 @@
        "       0.0292439 , 0.0315338 , 0.0463069 , 0.0807952 ])"
       ]
      },
-     "execution_count": 24,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "# The values are all energy dependent \n",
-    "univ0.infExp['infAbs'] # obtain the infinite macroscopic xs for ('0', 0.0, 1, 0.0)"
+    "univ0.infExp['infAbs']"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [
     {
@@ -714,19 +773,25 @@
        "       8.87468e+15, 1.70822e+15, 8.87055e+14, 6.22266e+13])"
       ]
      },
-     "execution_count": 25,
+     "execution_count": 28,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "# Obtain the infinite flux for ('0', 0.0, 1, 0.0)\n",
     "univ0.infExp['infFlx']"
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Uncertainties can be obtained by using the `infUnc`, `b1Unc`, and `gcUnc` dictionaries. Uncertainties are relative, as they appear in the output files."
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [
     {
@@ -738,106 +803,20 @@
        "       0.0491 , 0.19529, 0.16476])"
       ]
      },
-     "execution_count": 26,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# Uncertainties can be obtained in a similar was by using the 'infUnc' field. \n",
-    "# The variables will be identical to those defined in 'infExp'\n",
-    "univ0.infUnc['infFlx'] # obtain the relative uncertainty"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Serpent also outputs the `B1` cross-sections. However, the user must enable the `B1` option by setting the `fum` card:\n",
-    "http://serpent.vtt.fi/mediawiki/index.php/Input_syntax_manual#set_fum\n",
-    "\n",
-    "If this card is not enabled by the user, the `B1_` variables will all be zeros. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 27,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "dict_keys(['b1MicroFlx', 'b1Kinf', 'b1Keff', 'b1B2', 'b1Err', 'b1Flx', 'b1FissFlx', 'b1Tot', 'b1Capt', 'b1Abs', 'b1Fiss', 'b1Nsf', 'b1Nubar', 'b1Kappa', 'b1Invv', 'b1Scatt0', 'b1Scatt1', 'b1Scatt2', 'b1Scatt3', 'b1Scatt4', 'b1Scatt5', 'b1Scatt6', 'b1Scatt7', 'b1Scattp0', 'b1Scattp1', 'b1Scattp2', 'b1Scattp3', 'b1Scattp4', 'b1Scattp5', 'b1Scattp6', 'b1Scattp7', 'b1Transpxs', 'b1Diffcoef', 'b1Rabsxs', 'b1Remxs', 'b1I135Yield', 'b1Xe135Yield', 'b1Pm147Yield', 'b1Pm148Yield', 'b1Pm148mYield', 'b1Pm149Yield', 'b1Sm149Yield', 'b1I135MicroAbs', 'b1Xe135MicroAbs', 'b1Pm147MicroAbs', 'b1Pm148MicroAbs', 'b1Pm148mMicroAbs', 'b1Pm149MicroAbs', 'b1Sm149MicroAbs', 'b1Xe135MacroAbs', 'b1Sm149MacroAbs', 'b1Chit', 'b1Chip', 'b1Chid', 'b1S0', 'b1S1', 'b1S2', 'b1S3', 'b1S4', 'b1S5', 'b1S6', 'b1S7', 'b1Sp0', 'b1Sp1', 'b1Sp2', 'b1Sp3', 'b1Sp4', 'b1Sp5', 'b1Sp6', 'b1Sp7'])"
-      ]
-     },
-     "execution_count": 27,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# The parser reads all the variables by default\n",
-    "# Each field is a dictionary, with variables as keys and corresponding values.\n",
-    "univ0.b1Exp.keys() # obtain all the variables stored in 'b1Exp' field"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 28,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([1.20660e+15, 1.65202e+16, 7.47956e+16, 1.62709e+17, 2.74814e+17,\n",
-       "       4.22295e+17, 7.04931e+17, 9.70795e+17, 9.11899e+17, 9.33758e+17,\n",
-       "       7.23255e+17, 5.00291e+17, 3.16644e+17, 3.52049e+17, 1.62308e+17,\n",
-       "       6.68674e+16, 4.47932e+16, 1.23599e+16, 3.51299e+16, 1.46504e+16,\n",
-       "       4.38516e+15, 7.96971e+14, 3.54233e+14, 2.11013e+13])"
-      ]
-     },
-     "execution_count": 28,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# Obtain the b1 fluxes for ('3101', 0.0, 0, 0.0)\n",
-    "univ3101.b1Exp['b1Flx']"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 29,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([0.0162779 , 0.0122552 , 0.00779406, 0.00767857, 0.00694392,\n",
-       "       0.00412055, 0.00334267, 0.00296283, 0.00306196, 0.00335034,\n",
-       "       0.00403083, 0.00506224, 0.00652214, 0.00737463, 0.00906819,\n",
-       "       0.011397  , 0.0125957 , 0.0167696 , 0.0184019 , 0.0274004 ,\n",
-       "       0.0286808 , 0.0318976 , 0.0522545 , 0.0763042 ])"
-      ]
-     },
      "execution_count": 29,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "# Obtain the b1 absorption cross section for ('3101', 0.0, 0, 0.0)\n",
-    "univ3101.b1Exp['b1Abs']"
+    "univ0.infUnc['infFlx']"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Data that does not contain the prefix `INF_` or `B1_` is stored under the `gc` and `gcUnc` fields. \n",
-    "\n",
-    "Criticality, kinetic, and other variables are stored under this field.  "
+    "Serpent also outputs the `B1` cross-sections. However, the user must enable the `B1` option by setting the [`fum` card](http://serpent.vtt.fi/mediawiki/index.php/Input_syntax_manual#set_fum). If this card is not enabled by the user, the `B1_` variables will all be zeros. "
    ]
   },
   {
@@ -848,7 +827,7 @@
     {
      "data": {
       "text/plain": [
-       "dict_keys(['cmmTranspxs', 'cmmTranspxsX', 'cmmTranspxsY', 'cmmTranspxsZ', 'cmmDiffcoef', 'cmmDiffcoefX', 'cmmDiffcoefY', 'cmmDiffcoefZ', 'betaEff', 'lambda'])"
+       "dict_keys(['b1MicroFlx', 'b1Kinf', 'b1Keff', 'b1B2', 'b1Err', 'b1Flx', 'b1FissFlx', 'b1Tot', 'b1Capt', 'b1Abs', 'b1Fiss', 'b1Nsf', 'b1Nubar', 'b1Kappa', 'b1Invv', 'b1Scatt0', 'b1Scatt1', 'b1Scatt2', 'b1Scatt3', 'b1Scatt4', 'b1Scatt5', 'b1Scatt6', 'b1Scatt7', 'b1Scattp0', 'b1Scattp1', 'b1Scattp2', 'b1Scattp3', 'b1Scattp4', 'b1Scattp5', 'b1Scattp6', 'b1Scattp7', 'b1Transpxs', 'b1Diffcoef', 'b1Rabsxs', 'b1Remxs', 'b1I135Yield', 'b1Xe135Yield', 'b1Pm147Yield', 'b1Pm148Yield', 'b1Pm148mYield', 'b1Pm149Yield', 'b1Sm149Yield', 'b1I135MicroAbs', 'b1Xe135MicroAbs', 'b1Pm147MicroAbs', 'b1Pm148MicroAbs', 'b1Pm148mMicroAbs', 'b1Pm149MicroAbs', 'b1Sm149MicroAbs', 'b1Xe135MacroAbs', 'b1Sm149MacroAbs', 'b1Chit', 'b1Chip', 'b1Chid', 'b1S0', 'b1S1', 'b1S2', 'b1S3', 'b1S4', 'b1S5', 'b1S6', 'b1S7', 'b1Sp0', 'b1Sp1', 'b1Sp2', 'b1Sp3', 'b1Sp4', 'b1Sp5', 'b1Sp6', 'b1Sp7'])"
       ]
      },
      "execution_count": 30,
@@ -857,7 +836,7 @@
     }
    ],
    "source": [
-    "univ3101.gc.keys() # obtain all the variables stored in 'gc' field"
+    "univ0.b1Exp.keys()"
    ]
   },
   {
@@ -868,8 +847,11 @@
     {
      "data": {
       "text/plain": [
-       "array([3.04272e-03, 8.93131e-05, 6.59324e-04, 5.62858e-04, 1.04108e-03,\n",
-       "       5.67326e-04, 1.22822e-04])"
+       "array([1.39800e+15, 2.22121e+16, 1.00380e+17, 2.19050e+17, 3.61071e+17,\n",
+       "       5.61244e+17, 9.33086e+17, 1.28335e+18, 1.21094e+18, 1.24502e+18,\n",
+       "       9.62426e+17, 6.70263e+17, 4.23191e+17, 4.69164e+17, 2.14577e+17,\n",
+       "       8.77042e+16, 5.98583e+16, 1.67291e+16, 4.72542e+16, 1.96319e+16,\n",
+       "       6.00800e+15, 1.12777e+15, 5.79412e+14, 3.93280e+13])"
       ]
      },
      "execution_count": 31,
@@ -878,20 +860,91 @@
     }
    ],
    "source": [
-    "# The data included in the 'gc' field contains only the values (no uncertainties)\n",
-    "univ3101.gc['betaEff'] # obtain beta-effective"
+    "univ0.b1Exp['b1Flx']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([0.0170306 , 0.0124977 , 0.00777041, 0.00773244, 0.00700272,\n",
+       "       0.00410942, 0.00335046, 0.00296957, 0.00307219, 0.00335169,\n",
+       "       0.00402825, 0.00506175, 0.00651283, 0.00736592, 0.00907107,\n",
+       "       0.0113432 , 0.012588  , 0.0165002 , 0.018157  , 0.0266812 ,\n",
+       "       0.029204  , 0.0315299 , 0.0462994 , 0.0807952 ])"
+      ]
+     },
+     "execution_count": 32,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "univ0.b1Exp['b1Abs']"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`Macro` and `Micro` energy group structures are stored directly in the universe."
+    "Data that does not contain the prefix `INF_` or `B1_` is stored under the `gc` and `gcUnc` fields. Criticality, kinetic, and other variables are stored under this field.  "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 33,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "dict_keys(['cmmTranspxs', 'cmmTranspxsX', 'cmmTranspxsY', 'cmmTranspxsZ', 'cmmDiffcoef', 'cmmDiffcoefX', 'cmmDiffcoefY', 'cmmDiffcoefZ', 'betaEff', 'lambda'])"
+      ]
+     },
+     "execution_count": 33,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "univ3101.gc.keys()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([3.04272e-03, 8.93131e-05, 6.59324e-04, 5.62858e-04, 1.04108e-03,\n",
+       "       5.67326e-04, 1.22822e-04])"
+      ]
+     },
+     "execution_count": 34,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "univ3101.gc['betaEff']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Macro- and micro-group structures are stored directly in the universe in MeV as they appear in the Serpent output files. This means that the macro-group structure is in order of descending energy, while micro-group are in order of increasing energy."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
    "metadata": {},
    "outputs": [
     {
@@ -904,19 +957,18 @@
        "       7.4852e-04, 4.5400e-04, 3.1203e-04, 1.4894e-04, 0.0000e+00])"
       ]
      },
-     "execution_count": 32,
+     "execution_count": 35,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "# Obtain the macro energy structure in MeV\n",
     "univ3101.groups"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 36,
    "metadata": {},
    "outputs": [
     {
@@ -925,14 +977,13 @@
        "array([1.0000e-10, 1.4894e-04, 1.6525e-04, 1.8156e-04, 1.9787e-04])"
       ]
      },
-     "execution_count": 33,
+     "execution_count": 36,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "# Obtain the micro energy structure in MeV\n",
-    "univ3101.microGroups[:5:] # print only the five first values"
+    "univ3101.microGroups[:5:]"
    ]
   },
   {
@@ -946,22 +997,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 37,
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZMAAAEOCAYAAABM5Pr8AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvOIA7rQAAHl1JREFUeJzt3XucVXW9//HXe1QEpTiFYirIHbyBWCNkYKml4kPJMI6iWGpeql92eTzSh1odb8c0H+d0eXhK0USx8gyIhoVoXioN0kxBD4qXAB2EEBUQFBFJ+Pz+2HtkHGaGvWavNfv2fj4e+zGz1157zfvLHvjwXd+1vl9FBGZmZsWoK3UAMzOrfC4mZmZWNBcTMzMrmouJmZkVzcXEzMyK5mJiZmZFczExM7OiuZiYmVnRXEzMzKxoLiZmZla0HUsdoLPstttu0a9fv1LHMDOrKPPmzVsVEbtvb7+aKSb9+vXjiSeeKHUMM7OKImlpIfv5NJeZmRXNxcTMzIrmYmJmZkWrmTETM7PW/Otf/2L58uVs3Lix1FFKqmvXrvTu3ZuddtqpQ+93MTGzmrZ8+XI+9KEP0a9fPySVOk5JRASrV69m+fLl9O/fv0PH8GkuM6tpGzdupGfPnjVbSAAk0bNnz6J6Zy4mZlbzkhaSk294lJNveDSjNKVRbDF1MSnAwqvGsPCqMaWOYWZV6lOf+tR295kzZw4HHHAAI0aM4J133gHgpz/9KV27dmXdunXv7zd16lTOO++8zLK2xcXEzKzEHnnkke3uc9ttt3H++efz1FNP0a1bNwAaGho45JBDmDlzZtYRt8vFxMysxLp37w7AQw89xOGHH86ECRPYd999mTRpEhHBTTfdxO23384VV1zBpEmTAFiyZAnr16/nyiuvpKGh4QPHW7ZsGWPHjmXo0KFcfvnlALz99tscd9xxHHTQQRx44IFMnz491Tb4ai4zs7zLZy3k2RVvbne/Z1/J7VPIuMn+e32YS8cdUHCGJ598koULF7LXXnsxevRo/vrXv3L22Wczd+5cjj/+eCZMmADkeiWnnHIKhx12GC+88AKvvfYavXr1AuDvf/87zzzzDLvssguHHHIIxx13HEuXLmWvvfZi9uzZAB84NZYG90zMzMrIyJEj6d27N3V1dYwYMYLGxsZW95s2bRoTJ06krq6OE088kRkzZrz/2lFHHUXPnj3p1q0bJ554InPnzmXYsGE8+OCDXHjhhcyZM4cePXqkmts9EzOzvEJ7EE09kulfPTT1DDvvvPP73++www6899572+yzYMECFi1axFFHHQXApk2bGDBgAN/4xjeAba/MksSQIUOYN28e99xzDxdffDFHH300l1xySWq53TMxM6swDQ0NXHbZZTQ2NtLY2MiKFSv45z//ydKluQl+H3jgAdasWcM777zDXXfdxejRo1mxYgW77LILp512Gueffz7z589PNZN7JmZmFWbatGnce++9H9g2fvx4pk2bxh577MGYMWP40pe+xOLFizn11FOpr6/nvvvu44ILLqCuro6ddtqJ66+/PtVMiohUD1iu6uvro6PrmTTdY3LA9+amGcnMysBzzz3Hfvvtl+g9WZ7mKqXW/iwkzYuI+u291z0TM7OEqq2IpMFjJmZmVjQXEzMzK5qLiZmZFa1ii4mkAZKmSLqj1FnMzGpdSYqJpJslvSbpmRbbx0p6QdJiSRe1d4yIeDEizso2qZlZK245Lvew95WqZzIVGNt8g6QdgF8AxwL7A6dI2l/SMEl3t3j06vzIZmbZaGxs5MADD9xm+89//nMGDRqEJFatWrXN6yeccAKHHvrBK8vOOOMM7rij80/YlKSYRMRfgDUtNo8EFud7HJuAacAJEfF0RBzf4vFap4c2M+tko0eP5sEHH6Rv377bvLZ27Vrmz5/P2rVreemll0qQ7oPKacxkb2BZs+fL89taJamnpMnAwZIubmOfcyU9IemJ119/Pd20ZmYpeu+99zj99NMZPnw4EyZMYMOGDRx88MH069ev1f3vvPNOxo0bx8SJE5k2bdoHXnvwwQc57LDDGDJkCHfffTcACxcuZOTIkYwYMYLhw4ezaNGiVPOX002Lra0Z2ebt+RGxGvhaeweMiBuBGyF3B3xR6cys+t17Eax8evv7rVyQ+1rIuMnHhsGxP9rubi+88AJTpkxh9OjRfOUrX+G6667j/PPPb3P/hoYGLr30UvbYYw8mTJjAxRdv/T91Y2MjDz/8MEuWLOGII45g8eLFTJ48mW9/+9tMmjSJTZs2sXnz5u1nT6CceibLgT7NnvcGVpQoi5lZp+rTpw+jR48G4LTTTmPu3Lanb3r11VdZvHgxY8aMYciQIey4444888zW65lOOukk6urqGDx4MAMGDOD555/n0EMP5aqrruKaa65h6dKl76/WmJZy6pk8DgyW1B/4JzAROLW0kcysphTQgwC29kjOnJ3aj25t2vi2TJ8+nTfeeIP+/fsD8OabbzJt2jSuvPLKNo916qmnMmrUKGbPns0xxxzDTTfdxJFHHpla/lJdGtwAPAoMlbRc0lkR8R5wHnAf8Bxwe0QsLEU+M7PO9vLLL/Poo7kJJBsaGhgzZkyb+zY0NPCHP/zh/Sno582b94FxkxkzZrBlyxaWLFnCiy++yNChQ3nxxRcZMGAA3/rWt/j85z/PggULUs1fqqu5TomIPSNip4joHRFT8tvviYghETEwIn5YimxmZqWw3377ceuttzJ8+HDWrFnD17/+da699lp69+7N8uXLGT58OGeffTaNjY28/PLLfPKTn3z/vf379+fDH/4wjz32GABDhw7lM5/5DMceeyyTJ0+ma9euTJ8+nQMPPJARI0bw/PPP8+UvfznV/FU/Bb2kccC4QYMGndPRqxc8Bb1Z9erIFPRZnOYqB8VMQV9OA/CZiIhZEXFu2usdm1kNO3N21RWSYlV9MTEzs+y5mJiZWdFcTMys5lX72HEhiv0zcDExs5rWtWtXVq9eXdMFJSJYvXo1Xbt27fAxyummxUw0u5qr1FHMrAw1XXpb6/P3de3ald69e3f4/VV/aXCTA/buHrd/Y0SH3rtl43peqevF0Zfdn3IqM7PyVuilwVXfM0lDX62ELaVOYWZWvmqmmHTbc98O33T49CUd69GYmdUKD8CbmVnRCuqZSPpoAbttiYi1ReYxM7MKVOhprhX5R9tzIsMOwD5FJzIzs4pTaDF5LiIObm8HSU+mkCd1vjTYzCx7hY6ZHJrSPp3OEz2amWWvoGISERvT2MfMzKpT4qu5JF2YRRAzM6tc2x0zkXR786fACOCazBKZmVnFKWQA/s2IOLvpiaTrM8xjZmYVqJDTXC3XYv9+FkFqxi3HbV3y08ysSmy3mETESwCSdss/X5N1KDMzqyxJBuBvzixFhiSNk3TjunXrSh0FgIWvrGPhK+WRxcwsLUmKSXt3v5ct32diZpa9JMWkNhY+MTOzxKq+Z2JmZtlLUkwuziyFmZlVtIKLSUQ8k2UQMzOrXIlWWpRUT+4+k7759wqIiBieQbay0lcrWXjVmKKP07Se/AEpZDIzKxdJl+29DbgAeJoaWhX9lbpesCWdZSm9nryZVaOkxeT1iPh9JknK2N5dNgDdO7yGfHNeT97MqlHSYnKppJuAPwLvNm2MiN+mmipFXhzLzCx7SYvJmcC+wE5sPVkTQNkWk4iYBcyqr68/p9RZzMyqVdJiclBEDMskiZmZVaykY8p/k7R/JknMzKxiJe2ZjAFOl/QSuTGTmrk02MzM2pa0mIzNJIWZmVW0pKe5rgDWRcTSiFgKvAlcmn4sMzOrJEl7JsMjYm3Tk4h4Q9LBKWeqanV1ni/TzKpP0p5JnaSPND2R9FGSF6Ta1mXX3MPMrIokLQQ/Bh6RdAe5+0tOYts14s3MrMYkKiYR8StJTwBHkruS68SIeDaTZGZmVjESn6LKF4+KKSCeTsXMLHsFjZlImp/GPqXgNeDNzLJXaM9kP0kL2nldgP+1NjOrUYUWk30L2GdzMUHMzKxyFVRM8jcoWidpWtExjfVTzMw6QxqLB5qZWY1LVEwkeeoUMzPbRkdWWtwF+CgwH5gWEW+kH8vMzCpJ0tNcAWwE7gP6kLsb/qDUU5mZWUVJ2jN5PiKaTnXdIWkqMJncHfFmZlajkvZMVkn6RNOTiPgHsHu6kczMrNIk7Zl8C5gmaR7wNDAceCn1VFWuz6Yl71/+25otG9fzSl0vDujETGZmxUjUM4mI/wNGAA35TX8GTkk7VDVbP3g8y7oMbHefvlrJnlte66REZmbF68hEj+8Cs/MPS2jUv38X+G67+zx9yYjOCWNmlpKCi4mkkUBExOOS9ie3HvzzEXFPZumsYCff8CgA0796aImTmFktKqiY5G9WPBbYUdIDwCjgIeAiSQdHRNkukFUrU9BfsvqC/HeegsXMOl+hPZMJ5MZKdgZWAr0j4k1J/wU8RhmvthgRs4BZ9fX155Q6SxJ9tbLdQfqWPGhvZqVUaDF5LyI2AxskLYmINwEi4h1JW7KLV5teqesFW5JdHdFXK8GfhJmVSKHFZJOkXSJiA/D+fSaSeuB/wlK3d5cNQPdEswZ70N7MSqnQYvLp/FVcRETz4rETcHrqqaxDOnpq7OjL7s8wlZnVgoLOpDQVEgBJRzXbvgr4WAa5LKENw77Esp2TXWTg+1nMLC2J7zMBrgEeaOe5lUAh96+0tPCqMV7QxsxS0ZFi0pJSOIY14xUWzazSJLlp8RZyU9DvI+lmgIj4SlbBzMysciTpmUzNfz0MuDX9KGZmVqkKLiYR8TCApLeavm96KfVUZmZWUToy/rppO8/NzKzGJC4mEfHJ9p6bmVnt8ZWhZmZWNBcTMzMrmouJmZkVzcXEzMyK5mJiZmZFczExM7OiuZiYmVnREk30KGln4ItAv+bvjYgr0o1lZmaVJOmswb8D1gHzgHe3s29ZkDQOGDdoULK1PszMrHBJi0nviBibSZKMRMQsYFZ9ff05pc5iZtbZmlZfzXppi6RjJo9IGpZJEjMzq1hJeyZjgDMkvUTuNJeAiIjhqSezTtFn05JE68YDrB88Pr+yo5lZTtJicmwmKawk1g8ez7JFMxO9p8+mJfn3uJiY2VaJiklELJV0ELkFsgDmRMT/pR/LOkNH1403M2sp0ZiJpG8DtwG98o/fSPpmFsHMzKxyJD3NdRYwKiLeBpB0DfAo8D9pBzMzs8qRtJgI2Nzs+eb8NqshiQftN73N+m57M+rCu7MLZWYllbSY3AI8Jqlp1PYLwJR0I1k569CgPStZtnnXjBKZVafHZvyY7gn/rrVmy8b1rNa/pZCofUkH4H8i6WFgNLkeyZkR8WQmyawsedDerHN0XzQzd/Vkl4GljlKQpD0TImIeuelUzMwsQ8u6DCz6zvWFV41hd95LKVHbCiomkuZGxBhJbwHR/CVyNy1+OJN0ZmZWEQoqJhExJv/1Q9nGMTOzSpT0PpNrCtlmZma1JelEj0e1ss1TrJiZ1bhCx0y+Dvw/YKCkBc1e+hDwSBbBzMyschR6Ndf/AvcCVwMXNdv+VkSsST2VmZlVlIJOc0XEuohoBDYB6yJiaUQsBULSzVkGNDOz8pd0zGR4RKxtehIRbwAHpxvJzMwqTdJiUifpI01PJH2UDtz4aGZm1SVpIfgx8KikGeRuXjwJ+GHqqcpM1msnm5llpbP+/Uo6N9evJD0BHEnu7vcTI+LZTJKZmVnFSFRMJAn4OPDRiLhC0j6SRkbE37OJZ9Ui6bT1GzZt5i9dPsN3v/ejDFOZWVqSnua6DthCrmdyBfAWcCdwSMq5rIp0ZNr6oTSyCztklMisc3VkOvlKmjEYkheTURHxcUlPQu5qLkldMshlVcTT1lut68h08su6DGT94PEZpkpX0mLyL0k7kJ85WNLu5HoqZmbWjjSmky9nSS8NvhaYCfSS9ENgLnBV6qnMzKyiJL2a6zZJ84DPkrua6wsR8VwmyazmJV5rntz4TO60mpl1po6stPg88HwGWcze16G15jctyb/HxcSssxU6a/AhwLKIWJl//mXgi8BS4DJP9mhp86C9WWUpdMzkBnKTPCLp08CPgF8B64Abs4nWPklfkPRLSb+TdHQpMpiZWU6hxWSHZr2Pk4EbI+LOiPgPYFDSHyrpZkmvSXqmxfaxkl6QtFjSRW29HyAi7oqIc4Az8pnMzKxECi4mkppOiX0W+FOz1zoy0eNUYGzzDflLjn9BbuXG/YFTJO0vaZiku1s8ejV76w/y7zMzsxIptBA0AA9LWgW8A8wBkDSI3KmuRCLiL5L6tdg8ElgcES/mjz0NOCEirgaOb3mM/NQuPwLujYj5STOYmVl6CiomEfFDSX8E9gTuj4jIv1QHfDOlLHsDy5o9Xw6Mamf/bwKfA3pIGhQRk1vuIOlc4FyAffbZJ6WYZmbWUsGnqCLib61s+0eKWdTaj20nz7XkbqJsU0TcSP4Cgfr6+jaPZWZmxUl6B3yWlgN9mj3vDawoURYzM0ugnIrJ48BgSf3zk0dOBH5f4kxmZlaApOuZ/Dvwh4h4S9IPyK1tcmXSAXBJDcDhwG6SlgOXRsQUSecB9wE7ADdHxMIkxzVLOgWLp18xS0fSnsl/5AvJGOAY4Fbg+qQ/NCJOiYg9I2KniOgdEVPy2++JiCERMTAiqn45YEvX+sHjE03x3efdxezy9K8zTGRWO5LeI7I5//U44PqI+J2ky9KNlC5J44BxgwYlvrfSKkzSKVgWXjWmrM7zmlWypH+X/inpBuAk4B5JO3fgGJ0qImZFxLk9evQodRQzs6qVtBCcRG5MY2xErAU+AlyQeiozM6soSYvJccADEbEoPwB/HbAq/VhmZlZJSjIAb2Zm1SVpMdlmAB7okm4kMzOrNEmv5moagP8ccE0lDMD7ai4zS9NjM35M946sAprgsvVKlLSYnERu6vj/joi1kvakzAfgI2IWMKu+vv6cUmcxs/LSkcIwatPTACzsMqzg9yzrMpD1g8cn+jmVJlExiYgNkpYAx0g6BpgTEfdnE83MLFvdF81M3GtY2GWYZ05oRdLpVL4NnAP8Nr/pN5JujIj/ST2ZWSdIOv0KeAqWarOsy0AO+N7cUseoeEnHO84CRkXEJRFxCfBJcsXFrOIknX4FcsUn6WkRs1qQdMxEbL2ii/z3ra1DYlb2kk6/AiTuxZjViqTF5BbgMUlN/zX7AjAl3UhmZsn5KqvSSnSaKyJ+ApwJrAHeAM6MiJ9lESwtksZJunHdusRL1ZtZBWkaTE+iFq6y6iwF90wkCeidX7sk0folpeRLg81qhwfTSyfJGvAh6S7gExnmMSt7vgLMbFtJr+b6m6RDMkliVgE6dAXYu4vpvvA3GSUyKw9JB+CPAL4qaSnwdtPGiBieaiqzMuUrwMxaV1AxkTQI2AM4tsVLfYEVaYcyM7PKUuhprp8Bb0XE0uYPYAPw0+zimZlZJSi0mPSLiAUtN0bEE0C/VBOZmVnFKbSYdG3ntW5pBMmK7zMxM8teocXkcUnb3Kch6SxgXrqR0hURsyLi3B49epQ6iplZ1Sr0aq7vADMlTWJr8agnt8qibx81M6txBRWTiHgV+JSkI4AD85tnR8SfMktmZmYVI+niWH8G/pxRFjMzq1BlvX67mZlVBhcTMzMrWtLpVMysAzw5pFU790zMMublga0WVH3PRNI4YNygQYNKHcVqlCeHtFpQ9T0T37RoZpa9qi8mZmaWPRcTMzMrmouJmZkVzcXEzMyK5mJiZmZFczExM7OiuZiYmVnRqv6mRTOrTI/N+HGiWQD6bFqSeKYBS4+LiVmZqvX5vLovmpmoQCzrMpD1g71WX6lUfTHxdCpWidYPHs+yhHNz9dm0JP+e6igmkCsQB3xvbqljWAGqvphExCxgVn19/TZr2JuVK8/nZZXGA/BmZlY0FxMzMyuai4mZmRXNxcTMzIrmYmJmZkVzMTEzs6JV/aXBZrWk1m90tNJxMTGrEh260fHdxSx9+teQcTFJOjUK5LIt054ZJbK0uZiYVYmO3ujYGee6k06NArBs50GeHqWCuJiYWafw1CjVzQPwZmZWNPdMzGqcB+0tDe6ZmNWw9YPHJ14DpM+mJYkH0636VX3PxFPQm7Wto4P2SXszfd5dzNL4WMJ0VkmqvmcSEbMi4twePXqUOopZVehIb2bZzoPYMOxLGSWyclD1PRMzS1dHejNW/aq+Z2JmZtlzMTEzs6K5mJiZWdFcTMzMrGguJmZmVjQXEzMzK5qLiZmZFc3FxMzMiqaIKHWGTiHpdWBp/mkPYB2wG7AqhcM3Ha/Yfdt6reX2JM+bf59Gezu7ra1ta6t9abe1vZxJ9yukXa1tK6Tt/j3umDQ+21r4Pe4bEbtv950RUXMP4Mb81yfSPF6x+7b1WsvtSZ63+L7o9nZ2WxO2L9W2Jmnv9vYrpF0d/Wz9e1y6z7bWfo/be9Tqaa5ZJTxee/u29VrL7UmeV3pbW9vWVvvSbmuSY25vv0La1dq2av5sS9nWJMf073EBauY0V2skPRER9aXO0Vlqqb1ua/WqpfZWUltrtWfS5MZSB+hktdRet7V61VJ7K6atNd0zMTOzdNR6z8TMzFLgYmJmZkVzMTEzs6K5mLRD0q6S5kk6vtRZsiRpP0mTJd0h6eulzpM1SV+Q9EtJv5N0dKnzZEnSAElTJN1R6ixZyP8dvTX/eU4qdZ6slfPnWZXFRNLNkl6T9EyL7WMlvSBpsaSLCjjUhcDt2aRMRxptjYjnIuJrwElAWV+GmFJ774qIc4AzgJMzjFuUlNr6YkSclW3SdCVs94nAHfnP8/OdHjYFSdpbzp9nVRYTYCowtvkGSTsAvwCOBfYHTpG0v6Rhku5u8egl6XPAs8CrnR0+oakU2db8ez4PzAX+2LnxE5tKCu3N+0H+feVqKum1tZJMpcB2A72BZfndNndixjRNpfD2lq0dSx0gCxHxF0n9WmweCSyOiBcBJE0DToiIq4FtTmNJOgLYldwH+Y6keyJiS6bBOyCNtuaP83vg95JmA/+bXeLipPTZCvgRcG9EzM82ccel9dlWmiTtBpaTKyhPUaH/OU7Y3mc7N13hKvIPv4P2Zuv/YCD3S7h3WztHxPcj4jvk/mH9ZTkWknYkaqukwyVdK+kG4J6sw2UgUXuBbwKfAyZI+lqWwTKQ9LPtKWkycLCki7MOl6G22v1b4IuSriebaUhKpdX2lvPnWZU9kzaolW3bvWMzIqamHyVzidoaEQ8BD2UVphMkbe+1wLXZxclU0rauBiqtYLam1XZHxNvAmZ0dphO01d6y/TxrqWeyHOjT7HlvYEWJsmStltoKtdXeWmprc7XW7oprby0Vk8eBwZL6S+oCTAR+X+JMWamltkJttbeW2tpcrbW74tpblcVEUgPwKDBU0nJJZ0XEe8B5wH3Ac8DtEbGwlDnTUEtthdpqby21tblaa3e1tNcTPZqZWdGqsmdiZmady8XEzMyK5mJiZmZFczExM7OiuZiYmVnRXEzMzKxoLiZW8yRtlvRUs0chyxNkTlKjpKcl1eefPyTp5fxElU373CVp/XaO85CkY1ps+46k6yQNzLe53WOYbU8tzc1l1pZ3ImJEmgeUtGP+xrNiHRERq5o9XwuMBuZK+jdgzwKO0UDuDur7mm2bCFwQEUuAES4mViz3TMzakO8ZXC5pfr6HsG9++67KLWj0uKQnJZ2Q336GpBmSZgH3S6rL/+9/YX59kXskTZD0WUkzm/2coyT9tsBY08gVAsgtDPWB90m6IJ9rgaTL85vvAI6XtHN+n37AXuTWrzFLhYuJGXRrcZqr+eqLqyLi48D1wPn5bd8H/hQRhwBHAP8ladf8a4cCp0fEkeT+se8HDAPOzr8G8CdgP0m755+fCdxSYNY/Ap/OL540EZje9IJySxAPJrcWxgjgE5I+nZ9p9u9sXYBpIjA9PP2FpcjFxCx/mqvZY3qz15r+5z+PXGEAOBq4SNJT5Kbu7wrsk3/tgYhYk/9+DDAjIrZExErgz5CbRxz4NXBa/lTVocC9BWbdTK5HcTLQLSIam712dP7xJDAf2JdccYGtp7rIf20o8OeZFcRjJmbtezf/dTNb/74I+GJEvNB8R0mjgLebb2rnuLeQW8xpI7mCk2R8ZRowE7isxXYBV0fEDa285y7gJ5I+Tq4Ile0Kk1aZ3DMxS+4+4JtNV1VJOriN/eaSWwWwTtIewOFNL0TECnLrU/yA3BrgScwBrmbb3sV9wFckdc/n2lv5deAjYj25XtTNrbzPrGjumZjlx0yaPf9DRLR3efB/Aj8DFuQLSiOtr79+J/BZ4BngH8BjwLpmr98G7B4Ridb1zp8m++9Wtt8vaT/g0XydWw+cBryW36WB3Gm7iS3fa1YsT0FvliFJ3SNivaSe5AbBR+fHT5D0c+DJiJjSxnsbgfoWlwZnlXN9RHTP+udY9fJpLrNs3Z3v9cwB/rNZIZkHDAd+0857Xwf+2HTTYhaabloEXs3qZ1htcM/EzMyK5p6JmZkVzcXEzMyK5mJiZmZFczExM7OiuZiYmVnRXEzMzKxo/x/13KsImGfA4QAAAABJRU5ErkJggg==\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYgAAAEKCAYAAAAIO8L1AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy8QZhcZAAAgAElEQVR4nO3df5hWZb3v8fcH5IfsQVMcQJBBUFP8fTyjaFq7yGK3be/CvcHquHeliedy165L+iFpWHY0ctd1KC2DOmVaJkoRmVqjmGeDG0g0UkgTUcExTGb8NZwUsPmeP541OIxrmOdZ8zxrnpnn87quuWate/14vjczF9+5173u+1ZEYGZm1tWgvg7AzMyqkxOEmZmlcoIwM7NUThBmZpbKCcLMzFI5QZiZWap9+jqAcjrooIPi0EMP7eswzMz6jQceeKAlIurTjg2oBHHooYeydu3avg7DzKzfkLS5u2N+xGRmZqmcIMzMLJUThJmZpRpQfRBmZj3ZtWsXzc3NvPrqq30dSq6GDx/OIYccwpAhQ4q+xgnCzGpKc3MzI0eO5NBDD0VSX4eTi4igtbWV5uZmJk2aVPR1fsRkZjXl1VdfZdSoUTWTHAAkMWrUqJJbTU4QZlZzSk0O5yxcxTkLV1UomnxkSYhOEGZm/cxzzz3HggULaG1trejnOEEAG646gw1XndHXYZhZDdiyZQsf/OAHuz0+f/58rrnmGj73uc/tLrvyyivZtGnT7v1Ro0Zx00030dbWVtFY3UltZpajhoYGrr/++tRjzz//PMuWLWPVqlW88sorALS3t/PrX/+aF154ga997WsADB48mBEjRlQ8VicIM6tZX7ptA3/408s9nveHrYVziumHOHrcflz+D8d0f68//IGmpiba2tp44oknGDduHKtWrWL58uXceuuttLS0cPPNN/OBD3wAgDvvvJMFCxbw/ve/ny9/+cvsu+++u++1cOFCVq9ezVvf+lauuOIKvvGNb3D44Yfzq1/9imuuuabHWHviR0xmZjk6+OCDWbBgARMmTOCAAw7gyiuv5IUXXuDZZ59l+vTpjBo1andyAHj88cc56aST+Lu/+ztuuummPe41c+ZMmpqauP7662lubub222/nzW9+M5dccklZYnULwsxq1t7+0u+so+Ww+MLTev2ZBxxwwO7toUOHAjBs2DB27NjxhnM3b97M+vXrWbBgAXV1dXzrW9/i/PPP3318xIgRDBkyhJNOOomtW7cyb948pk+fzqc//WkuuuiiXsfqBGFmVqV++tOf8u1vf3v36OfjjjuO++67j9NPP32P89rb2znqqKN4/PHHefDBB/nbv/1bzj33XPbbb79efb4fMZmZ5ei3v/0tL7zwAsuWLeORRx5h8+bNNDc389BDD7Fy5Uqam5t57LHHuP/++/nFL37B888/D0BbWxsTJkxg7ty5PPfcc0ybNo3Fixfzox/9iIsuuoiRI0cyb9487rvvPs4880xGjhzZ61jdgjAzy9Epp5zCSy+9tEdZc3Pz7u1zzz139/a99967e3vkyJHccccdu/fnzZv3hnvfdtttAJx11llliTW3BCFpH+By4EFgCjA/ItqTY9OAYwEBqyNijaTzgReBw4GHI+KO9DubmVVWOfoe+qM8WxAXAM9ExFJJY4GZwGJJg4GrgZOT85YD04BzI+IdkvYDfgz0mCBe2fpopgFv7a9uZ+ug0RTXXWVmVhvy7IM4FViXbK8DOtpADUBLJIBdkiYD2yR9BvggsKCSgU3Usxzc/lwlP8LMrN/JswUxFugYF94GjEkp73zsE8Ddyf77uruppNnAbCiMUDzm8ytLDuzheSeWfI2Z2UCXZwuiFahLtuuAlpTyzseuBqYCNwLf6e6mEbEoIhojorG+vr7sQZuZ1ao8E0QTcEKyfTzQJGl0RDwGjFQCqIuIjcAhEfGXiLgOOCjHOM3M9vSDswpfZXD33Xdzyy23vKH8qaeeesPbTWmeeuoprrrqqrLE0pM8E8QNQIOkWRT6HdYD1ybH5gJzkq+5SdkSSRdK+gjwv3OM08ysYl555ZU9XleFwvxMb3vb29i6desbzv/Upz7Fyy+/Pl/UuHHjyjLPUjFy64NIXmm9LNntSJ+zkmMrgBVdzr8ur9jMzPKSNoDt6KOPZvLkyW8of+mll7jrrrs4/PDD+fjHPw4UpucYNmxYxeMEj6Q2M8vdli1b+NjHPkZjYyNPPPFEt+f97Gc/48Ybb+S669749/JXvvIVpk6dysKFC3fvL1u2jEsvvbRscXoktZnVrjsvgWcf7vm8Zx8qfC+mH2LscfCe+Xs9pa6uju9973tcd911zJ8/n0WLFqWe19bWxkknncT48eNZvnw573znO3cfu/DCC7nwwgs58sgjOe+881i2bBnnnXcejY2NPcdYJLcgzMxy1rHYz2mnncYzzzyTes5//ud/smXLFhYsWMC4ceO49tpr9zg+YsQIDjzwQMaPH8+LL77IZz/7WU499VTWrFlTtjjdggAGDa/r+SQzG3h6+Et/t46Ww0dvL+vHP//885x2Wvo0HqtWrdq9gtyOHTuYOHEiW7ZsoaGhYY/zDjzwQOrr65k0aRIrV65k+vTpnH322WWJzy0IM7McTZo0iV27dnHTTTexbt06Lr74Yh599FGefPJJ7rnnHl577TXuvPNOVqxYsfu115dffpnx48dz8cUXs337dqZPn86iRYv43ve+x1e/+lUA5syZw+9+9ztmzJhRtlhVmN1iYGhsbIy1a9eWfF3H/E1ZRmGbWf/yyCOPMGXKlNIuqlALIm9pdZf0QESkdly4BWFmZqncB2Fm1pN+3nLIyi0IMzNL5QRhZjVnIPW9FitLnZ0gzKymDB8+nNbW1ppKEhFBa2srw4cPL+k690GYWU055JBDaG5uZtu2bX0dSq6GDx/OIYccUtI1ThBmVlOGDBnCpEmT+jqMfsGPmMzMLJUThJmZpXKCMDOzVE4QZmaWKrdOakn7AJcDDwJTgPnJKnNImgYcCwhYDfwWeABoTy7fPyKOyCtWMzPL9y2mC4BnImKppLHATGCxpMHA1cDJyXnLgQ8D746IFkl1wBU5xmlmZuT7iOlUYF2yvQ7oWJqpAWiJBLALGBIRLcnxs4Bf5RinmZmRb4IYC7Ql223AmJTyrscApgG/6e6mkmZLWitpba0NfDEzq6Q8E0Qr0LF0Wx3QklK+xzFJQwEiYld3N42IRRHRGBGN9fX1ZQ/azKxW5ZkgmoATku3jgSZJoyPiMWCkEkBdRGxMzjsTuCfHGM3MLJFngrgBaJA0i0K/w3qgYxXuucCc5Gtup2vOAu7MMUYzM0vk9hZT8krrZcnuLcn3WcmxFcCKlGv+LZ/ozMysKw+UMzOzVE4QZmaWygnCzMxSOUGU2TkLV3HOwlV9HYaZWa95waAym9f6mWRrZZ/GYWbWW0UnCEnzejjloYj4eS/jMTOzKlFKC2IYhcFu3Tm6l7GYmVkVKSVB3BARf+zuoKTnyhCPmZlViaI7qfeWHJLjj/Q+HDMzqxY9tiAk7Qe8qVPR5Ii4t2IRmZlZVSjmEdNU4B3AjmS/Abi3UgGZmVl16DFBRMRdkn4TEa/B7qVDzcxsgCuqD6JTcji9Y9vMzAa2UkdSX1iRKMzMrOqUmiBUkSjMzKzqVPVcTJL+RtJHJb2jr2MxM6s1pXY435b1g5LO7cuBB4EpwPxkESEkTQOOpdBCWR0RayQdBNwEXBARm7N+rpmZZVNSgoiIjpXgkDQ02TwxIn5bxOUXAM9ExFJJY4GZwGJJg4GrgZOT85YD04CvAz90cjAz6xslP2KS9GNJW4BHgT8Cvyry0lOBdcn2OgrrTUNhXEVLJIBdko6kkEAOlnSDpC+VGqeZmfVOljENzRHR0LEjaUKR140F2pLtNmBMSnnHsYOApyLia8lnbJD03Yho7npTSbOB2QANDQ1dD5uZWUZZEsQKSf8G7Er2jwE+WcR1rUBdsl0HtKSUdxzbDvy1U9ljwDjgDQkiIhYBiwAaGxujuCqYmVlPsrzFNBcYDxycfO1f5HVNwAnJ9vFAk6TREfEYMFIJoC4ifg9skzQyOX9fYGOGWM3MLKMsLYilHY9+AJIO52LcAFwhaRaFfoelwLXALApJZ05y3tzk++eAL0laC9wYES9kiNXMzDLKkiCmJ//Jv0bhtdR64PCeLkpeab0s2e14G2pWcmwFsKLL+fcD92eIz8zMyiBLgvgW8HugPdk/YS/nmplZP1Vygui87rSkfTxOwcxsYMoyDuL7kj6a7B4j6f1ljsnMzKpAlreYVkTEDwCSt40uLm9IZmZWDbL0QYyQNA54EfgX4G/KG5KZmVWDLAni+8BngUYKA9fOLmtEZmZWFYpOEJLeHhH3RsQrwBvmRpJ0ZkTcXdbozMysz5TSgpgv6Q/dHBOFR05OEGZmA0QpCeKcHo5v700gZmZWXYpOEB7vYGZWW7KMgzi2EoGYmVl1yTIO4hZJoySdLWl02SMyM7OqkCVBHEBh5tVjge9IOr28IZmZWTXIMg7iSeCbEfEsgKSeOq/NzKwfytKCuAy4R9K5kt7M60uHmpnZAFJygoiIe4B/AqYC/wE8W+6gupK0X6U/w8zM9pTlERPAJuB64IliV3qTtA9wOfAgMAWYnywihKRpFPo0BKyOiDWSRgH/BQwGfgJ8IWOsZmaWQSlTbXwGeBfwXWAesAZ4UdIdSauiJxcAz0TE0mSZ0pnAYkmDgauBk5PzlgPTgI8C74uIR4uujZmZlU0pj5jeBUwH/gSsiYiPRcSngWFFXn8qsC7ZXgeclWw3AC2RAHZJmkxhKdNfSro3aU2YmVmOSkkQf0j+D78PuLJT+T8Vef1YoC3ZbuP1zu3O5buPRcTngCMpJJM3TA7YQdJsSWslrd22bVuRoZiZWU9KSRCXSzoRICKe7FTeXOT1rUBdsl0HtKSU73EsIv4KXEGhlZEqIhZFRGNENNbX1xcZipmZ9aToBBERL0XEOgBJ7+xU/sXO+3vRBJyQbB8PNEkaHRGPASOVAOoiYqOkjkdXo4HVxcZpZmblkWUcBBRGUu9tP80NQIOkWRRaBOuBa5Njc5N7zAHmSpoEPCDp34G3A1/PGKeZmWWU9TXXrtTTCckrrZclu7ck32clx1YAK7pc4kkBzcz6UEkJQtIFwFuA4yR9PyleAkS5AzMzs75VUoKIiO8C35V0Z0Sc11Eu6eNlj8zMzPpU1j6Irnp8xGRmZv1L1j6IH/aw3+9M2LmJDVed0ev7tL+6na2DRnNMGWIyM+tLmVoQEXHz3vb7m+1HzODpoYeV5V4T9SwHtz9XlnuZmfWlcr3F1K9Nndnxhm3vPTzvxLLcx8ysr5WrD8LMzAYYJwgzM0vlBGFmZqlK7oOQNJzCnEodcyUdHxHX7uUSMzPrh7J0Uq8EtgA7kv0jeH1OJTMzGyCyJIglETG/Y0fS+DLGY2ZmVSJLgjhZ0hJgZ7I/CTitfCGZmVk1yJIgbgc2ddo/obsTzcys/8ryFtNPgFOAcylMyX1dWSMyM7OqkCVBfCP5vgR4Hri4fOGYmVm1yPKIqSkilnTsSJpRzEWS9gEuBx4EpgDzk0WEkDSNQmtEwOqIWNPpuiXApyPiqQyxmplZRlkSxERJU4G/Ao3AScDSIq67AHgmIpZKGgvMBBZLGgxcDZycnLccmAa7k8+wtJuZmVllZXnEdD2FpUK/BBwKfLbI604F1iXb64Czku0GoCUSwC5JkyX9N+BpoDVDjGZm1ksltyAiopVOU59Kmgy8WMSlY4G2ZLsNGJNS3vnYIRFxq7T3tYgkzQZmAzQ0NBQRhpmZFaPoFoSkH0saIumTkp6U9ISkJ4EHirxFK1CXbNcBLSnlHcfOBM6V9HMKj5sWdTcgLyIWRURjRDTW19cXWx0zM+tBKS2ISyJil6Qm4IcR8SKApJN7uK5DE4UxE2uA44EmSaMj4jFJI/V6U6EuIr7ccZGk64EvRsQzJcRqZma9VHQLIiKeTjb360gOiTFp56e4AWiQNItCv8N6Xp/DaS6Fx1Zzkm0zM+tjRbcgJB0E/C/gWElbkuLBFF5P/WVP1yevtF6W7N6SfJ+VHFsBrOjmuo8UG6OZmZVP0QkiIlokLQDeDjySFLcDf6xAXGZm1sdKes01Ih6lMM3G5Ij4v8DLwFsqEZiZmfWtLOMgVkTEDwAi4vd4qg0zswEpy0jqEZLGURj78C/A35Q3JDMzqwZZEsT3KYyebqQw0vnsskZkZmZVIctI6lcoTLOBpFHJyGozMxtgSu6DkPRFSTclu0dJ+lCZYzIzsyqQpZP6NeDnABFxH/CRcgZkZmbVIUsfRCswTNIICsnBEyCZmQ1AWVoQSyjMpXRr8t2d1GZmA1Aps7kulHQpEMBCCvMpvZ/CBHxmZjbAlNKCOAr4CoV1qG+hMP/SYcAZFYjLzMz6WCl9EHdFRLukOcCuiJgLIKm5MqGZmVlfKqUFMU7SncClFNaXRtJo4MJKBGZmZn2rlNlcL5J0ItCczOw6lMK60sWuSW1mZv1ISa+5RsS6Tts7gR+UPaIBYKKeZcNVPXfNbD9iBlNnzunxPDOzvpBlHEQmkvYBLgceBKYA85NFhJA0jcLCQwJWR8QaSTOB91LoCJ8ZEVvzirU3tg4aDe09P7ubsHMTT29cSmERPTOz6pNbgqDQb/FMRCyVNBaYCSyWNBi4GuhY23q5pHcBGyPiw5I+lRz7RY6xZjZ+6F+AOo75/Mq9nldMCyPt/J7ua2ZWLlnmYpogaX9JIyVdJOmYIi89Feh4RLWOQv8FFMZTtEQC2AVMjIh1SaujHrir1DjNzKx3soykngPsAG4AxlL8SOqxQFuy3QaMSSnffUySgH8F/hn4QHc3lTRb0lpJa7dt21Z0JczMbO+yPGLaAMwGhkXEPEnnF3ldK1CXbNcBLSnlu48lrYnvS7obuI5uOsQjYhGwCKCxsTFKqUhfm7BzU9GPmtpf3c7WQaMptrlmZtZbWVoQHY+JZiavvY4t8romXp+W43igSdLoiHgMGKkEUBcRGztdtxNYnyHOqrb9iBk8PfSwos+fqGc5uP25CkZkZranLC2IZyk8XhoEvIVk6u8i3ABcIWkWhX6HpcC1wCxgLq+/zjNX0ijgHuDryed8OUOcVa3wemvxbzA9PO/EygVjZpYiS4KYA1wC/AR4mEIfxIaeLkpeab0s2b0l+T4rObYCWNHlEk8CaGbWh7I8YtpAYXqNYRExD/hTeUMyM7NqkLUPoh3456QP4uDyhmRpBg2vY9Dwup5P7GTDVWeUPN7CzKxDlkdMDwNvB75BIVl8tZwBWfdKeesJ/OaTmfVOlhbEN5PvSyisDXFx+cKx7pT61hP4zScz650sLYimiFjSsSNpRhnj6fcqNRVGqW89gd98MrPeyZIgJkqaCvwVaAROovDKqlWZUvsszMw6y5IgngPOAY4EHsLrQZiZDUhZEsR7IuJDHTuSxuztZDMz65+yJIhdydKjLyT7kynM1GpmZgNI0QlCUkOy+QCFV13bgdHAoeUPy8zM+lopLYgnKUyxsTAiXgaQdBDwnkoEZmZmfauUBHFTRPxH54KIaJE0vswxmZlZFShloNwfuykfUY5AzMysupSSIKZI2rdzgaT9gKPLG5KZmVWDUh4x/R/gAUk3U1gTogH4H8AFlQjMzMz6VtEtiIi4B3gvcCDwj8n390fE3RWKzczM+lBJ4yAi4gngU1k+SNI+wOXAg8AUYH6yiBCSpgHHAgJWR8QaSR8APgGMAf41Iv4ry+eamVk2WQbKZXUB8ExELJU0FpgJLJY0GLgaODk5b7mks4C/RsTpkj4EfAG/Tmtmlqss031ndSqF9SNIvp+VbDcALZEAdgETgJ8mx38HtOYYp5mZkW+CGAu0JdttFB4ddS3vODaq4/ET8DYKLYxUkmZLWitp7bZt28ocsplZ7cozQbQCHfNP1wEtKeV7HJM0GdgSEQ91d9OIWBQRjRHRWF9fX/6ozcxqVJ4Jogk4Idk+HmiSNDoiHgNGKgHURcRGSaOBoyLiTknDk30zM8tJngniBqBB0iwK/Q7rgWuTY3MpLJc2B5graQSwDLha0nrgfgrLm5qZWU5ye4sp6VO4LNm9Jfk+Kzm2AljR5ZLTcgptQJuwcxMbrjqj6PPbX93O1kGjefcXmyoYlZn1B3m2ICxn24+YwdNDDyvpmomD/sz4oX+pUERmVm4brjqjpD8CS5HnOAjL2dSZHU/tilepXzQz63+cIMzM+sCaW79O3calvb5P+6vbadWbyhDRGzlB2BuU2m8BhcdZhRaLmRWjbuNSJuzcVPJj4Dw5Qdgeth8xg6dL/Ktmws5NyTVOEGaleHroYRzz+ZW9useGq86gntfKFNGenCBsD+63MOtfeptg9sZvMZmZWSonCDMzS+UEYWZmqZwgzMwslROEmZmlcoIwM7NUfs3VysKD68wGHicI67VMg+t2PM7mh28EJwgbALJMmzFhx+NsjrEViqg8nCCs17IOrvPzTRsoskyb8fSww/nLETMqGFXvOUFYn/FjKRtIyjFtRrWp6j/iJA2VNKWv47Dyy7JWxYQdjzPi4RsrFJGZdZVbC0LSPsDlwIPAFGB+ssockqYBxwICVkfEGklvAr4GtACX5BWn5cOPpcyqX56PmC4AnomIpZLGAjOBxZIGA1cDJyfnLQemRcSLklYCR+UYo5mZJfL8g+xUYF2yvQ44K9luAFoiAeySNDnHuMzMLEWeCWIs0JZstwFjUsq7HuuRpNmS1kpau23btrIEamZm+T5iagXqku06Cn0LXcu7HutRRCwCFgE0NjZG78O0auY3n8zyk2cLogk4Idk+HmiSNDoiHgNGKgHURcTGHOOyfiLTm087N5Vl3V+zWpRnC+IG4ApJsyj0OywFrgVmAXN5/ZWWuQCS9gfeAkyQNCYi/pxjrFaFvNqdWb5ySxDJK62XJbu3JN9nJcdWACu6nP8SMDuv+MxsYMoyDUapSh1F3V94JLUNeO63qG1ZpsFof3U7AIOG1/VwZsHm9jFs3TmCYzJFWL2cIGxAyzSR4M5NyTVOENUm06R4SXKo9DQYx1X07n3DCcIGtKz9Fm51VKdMk+INPYztVT4pXrVygjDrwq2O6jYQJ8WrVk4QZl34bSmzAs99ZmZmqdyCMCuTUvst3Gdh1c4tCLMyKHWUt0d4W3/gFoRZGZTab+E3pXr3yqrlwy0Isz7geaVef2W1FH5lNV8qLMEwMDQ2NsbatWv7OgyziuhodeTxF3SpLZVqHsBmeyfpgYhoTDvmR0xm/USW8RlZHLPzYdjwMBtK+KypOx8GYMPQ4scTuzVQ/dyCMLM9ZJ3cbiD1j9QStyDMrGhZBgrawOROajMzS+UEYWZmqXJ7xCRpH+By4EFgCjA/WUQISdOAYwEBqyNiTVpZXrGamVm+fRAXAM9ExFJJY4GZwGJJg4GrgZOT85ZLelfXMmBajrGamdW8PB8xnQqsS7bXAWcl2w1ASySAXcChXcskTc4xVjOzmpdnghgLtCXbbcCYlPKOY6NTysaQQtJsSWslrd22bVt5IzYzq2F5JohWoGOB1zqgJaW849jzKWUtpIiIRRHRGBGN9fX15Y3YzKyG5ZkgmoATku3jgSZJoyPiMWCkEkBdRPwxpWxjjrGamdW83EZSSxoEXAE8RCFBLAU+FxGzJL0VmJqcuiYiVqSVFfEZ24DNwP7AS0nxQXTT+ihB5/v15tzujqWVdy3rvN/ddjnqurc4Sz2vmHqllXVXv877ede1p3OL/dmWsu/f496ppt/jrvvV9Hs8MSLSH79ExID7AhZ12l5bzvv15tzujqWVdy3rUqfutntd11Lq29N5xdSrlLp23s+7ruX62Zay79/jgfN73F19q+33uOvXQB0od1sf3m9v53Z3LK28a9ltRWyXS7H37Om8YuqVVra3+vX3n20p+/29rmlltfp73HW/Wn+2exhQk/WlkbQ2upmIaqBxXQeuWqqv61o9BmoLorNFfR1AjlzXgauW6uu6VokB34IwM7NsaqEFYWZmGThBmJlZKicIs35M0rslvamv47Dyqaafab9PEJKOS2aELeWaYyXNrVRMlVRqfSUdk8xX1e/qm6GuJ0v6sqQfVzKuSslQ3yHAO4Cq+M8ki57qLOl9kt4q6ZN5xlUpRdS3qn6m/TpBSJoKrAaGSNon+c9hhqTPJyO30645EtgODMsz1nLIUt+I2AA8QvGjLKtClroC6yPiC8CW/CItj4w/213AjlwDLaMi6/yeKMyi8FdJx/VdtL1XTH2r7Wfar9ekjsLCQh1TuHa33sQ5wD90umwj8GegMZkL6rl8o84uY30XAr8Fzge+nWvAvZC1rpKepcpfHUzTi59tv1VMnSksGAYQyVe/VWR9q0q/bkF0kbreREQsjohzO319KSK+Q2GIe79JDimKqi9wIHA68NO+CbMsiq3rGOCTwPmSJvZNqGVRbH1XAxOBgbBWSnfrxdwt6TRgaESs75PIKiO1vskjpqr5mfbrFkQX3a03kSoivljpgCqsqPpGxLLcIqqcYuu6BFiSV1AVVGx9dwEfzSuoCkutc0TcmpSt6ougKqi7+lbVz3QgtSC6W29ioKql+tZSXaH26gu1V+d+Ud+BlCDesN5EH8aSh1qqby3VFWqvvlB7de4X9e3XCUJSI1APvBu4AWiQNIvCOtc/6svYKqGW6ltLdYXaqy/UXp37Y309F5OZmaXq1y0IMzOrHCcIMzNL5QRhZmapnCDMzCyVE4SZmaVygjAzs1ROEGZmlsoJwmqOpPdKCkn/Lul/SvqKpE/k+PnXS/q4pInJdM8h6e+7nLNE0gNpkw4m65lslnRNMrkbkqZJulvSaEnTJT2VU3VsABtIk/WZFSUifimJiPhmR5mkSTmH8cuI2AxslrSJwiy0dySxjKMw4vbh5Jw9RMR6SVcB70smdwPYF5ibzFD8aycIKwe3IKzmSZoVEU9Keo+kuyR9StI6SeMljZD0b5I+Kem7kvaXdKOkSyWtkTRc0nWSPizpRUlnS5qX/DU/TNI/SPpwDyHcCpwg6ahkfyZwS6f4TpH00eTz35sU3wicIumwZP+UiLi/rP8wVvOcIKxmJYngM8R9wLMAAAHtSURBVMBFSdEjwKiIWAD8BngbcB6Fv87/DAxNvgJ4AjgNmAS8OSJ+SGHCtbuB+cB4YAgwAehpCdQdwHeBT6iwHOVQ4P91Oj4HeAV4CDgZICL+AnwfuEhSPbANszLzIyarWUkiQNIdnYp3Jt93UFiW9hjgW8liNTcn57cDL0REO/CIpOWS/hH4ZkS8nJxzI/CvwKCIeK2IcK4DNlBY/e+XwNROx8ZHxM0p13wLWAs8B/ygiM8wK4lbEFbzImKDpBndHH4a+DCApKNVWNN8N0n7Ai0R8YuIWNnp0HeAz/D6qmGpJIlCEvkT8GtgZkQ80uW0UR3rMXeOM+mfWAE09vPVEa1KuQVhNSf5ax9JlwIvAocB+wPtwMGSJlCYo38ocBXwc0krgJ8B1wNHUHj+v5zCY6QLJc2m8AfXFyLi9oh4XtLtwH09hHM+8FZJhwDXJJ//JuDtwIlJ5/lngaWSfk/h8VVn3wAOyPyPYbYXnu7brBckfQR4NCJWJ6+c/j2wnMLjqQ9FxDUp11wPfCkinqxgXPdGxNsrdX+rDW5BmPWOgAWSfgf8jsLbR/8B/HfgzG6u+S/gnZKWlztJSBoKvJNCh7tZr7gFYWZmqdxJbWZmqZwgzMwslROEmZmlcoIwM7NUThBmZpbKCcLMzFL9fywbY1VYF37aAAAAAElFTkSuQmCC\n",
       "text/plain": [
        "<Figure size 432x288 with 1 Axes>"
       ]
      },
-     "metadata": {},
+     "metadata": {
+      "needs_background": "light"
+     },
      "output_type": "display_data"
     }
    ],
    "source": [
-    "univ3101.plot(['infAbs', 'b1Abs']);"
+    "univ0.plot(['infAbs', 'b1Abs']);"
    ]
   },
   {
@@ -974,22 +1027,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 38,
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAe4AAAEOCAYAAABPU/TUAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvOIA7rQAAIABJREFUeJzt3Xt8VeWV//HPIgE0gCgXQbkYkEsMoqVEELHWS2sRKVqVUZnRirexM3ScH72MnZ+jFm2d6vx4dSqOFuQiWrVirWWAQR0vVStagqAgJBQRa+QuXrgJJFm/P8458ZCck5xNzm0n3/frlVeyn7PP3msn4jrr2c9+HnN3REREJBza5DoAERERSZ0St4iISIgocYuIiISIEreIiEiIKHGLiIiEiBK3iIhIiChxi4iIhIgSt4iISIgocYuIiISIEreIiEiIFOY6gEzq1q2bFxcX5zoMEZFQWb58+Q53757ktWMLCwsfAk5GxV8m1AKrq6urrx8+fPi2RDu06MRdXFxMeXl5rsMQEQkVM/sg2WuFhYUP9ezZ86Tu3bt/0qZNGy12kWa1tbW2ffv20i1btjwEjE+0jz4tiYhIECd37979cyXtzGjTpo137979MyI9Gon3yWI8IiISfm2CJu2Lpr82+KLprw3OVEAtTfT3mzQ/K3GLiEioDBs2rKSpfZYsWdJxwIABQwoKCoYXFxefXFJSUtq5c+ev9OrVa2hJSUnpGWecMSjZe9esWdNuxowZx6Q36vTJ28RtZv3NbJaZPRXX1tfMFpjZbDO7JZfxiYhIbqxYsaKiqX3mzZvX5fvf//6Wmpqa5Rs3blxdUVGx5hvf+Mand911V1VFRcWa119/fV2y965bt679k08+2SW9UadPVhN3NOFuM7PV9drHmFmlma2PJWR33+Du19U7xCBgkbtfC5RmKWwREckjRUVFwwAWLlzYacSIEYPHjBnTv1+/fkPGjx/fr7a2lmnTpnVbtGhRl3vuuef48ePH90t2nJqaGq6//vreAwcOHDJo0KDSOXPmHANw66239n7zzTc7lZSUlN51113HZuu6UpXtUeVzgenAvFiDmRUA9wPfBKqAZWa2wN3XJHj/CuD/mtnlwCOZD1dERJL50VNv91m3ZVdRU/ut37b7SIjc625q30E9O+2997JTP0w1hrVr1x65cuXKDcXFxQeHDx9e8vzzz3ecMmXKjj/96U8dx40b99mkSZM+Sfbe2bNnH1NZWXnk2rVr3920aVPhiBEjSs8///xdd911V9X06dOP/d///d/3Uo0jm7Jacbv7K8DOes0jgPXRCvsA8ARwUZJDTAJud/dzgQszF6mIiITB0KFD95x44okHCwoKGDJkyN733nuvXarvfe211zpefvnlOwsLC+nbt2/1aaedtuu1117rkMl40yEfnuPuBcR/uqoCRppZV+BnwDAz+4m73w0sAe4ws4nAxkQHM7MbgRsB+vbtm8m4RSSflM+BVU81vV/Mlnci33uekvp7hl4GZZOCxdWCpVoZxyrtP0w+szLdMbRv375uhHtBQQHV1dWW6nvdPeV980k+JO5Evzh394+Bm+o1rgYua+xg7j4DmAFQVlam5wxFWotVT8GWVdBzaGr7B0nYAB+8FvlK9OFACT2UzjrrrF2PPPJI15tuuunjzZs3F5aXl3d88MEHP6ysrGy/Z8+eglzHl0w+JO4qoE/cdm9gU45iEZEwSFRdx5L2pEXZO2fsvKDEHUKTJk365I033uhw0kknDTEz//nPf17Vq1ev6q5du9bU1NTY4MGDS6+66qodt956a8KpR3PF3LNblJpZMbDQ3U+ObhcC64DzgI+AZcBEd3+3uecqKytzTXkqEgKNdXMnqmbnXJi4us5F5TsnOtwmUx8YcsDMlrt7WaLX3n777Y2nnnrqjiDHy2RXeUv19ttvdzv11FOLE72W1YrbzB4Hzga6mVkVkYFms8xsMvAsUADMTkfSFpEQSdbNnax7OtPVdVBbVn2ZwOOpCx1Qwk63rCZud78ySftiYHE2YxGRPJMoESerxHsOjSTFfJAsDnWhS4bkwz1uEWktGrtPnGhQWdmk/E98yWKMdefXr8RVhUsz5e2UpyLSAsW6xOvLpwo6XYZe1vDDyJZVwR5ZE0lAFbeIZFc+3ZvOpESVeLIqHFSJS8qUuEVEsiVZr8Jfl0YmhGmpiXvGOZGpTm98SYPU0kCJW0TSL+i97NaisfvhkrJhw4aVNLVC2JIlSzpOnjz5hMLCQn/sscc2nHHGGaXFxcVfxF5fuXLl2hkzZnQpLy/vMG/evL9mPur0UeIWkfRL9nhXS7yXLVkXZFnPm2+++ePKysp2ffr02V9RUZFo8arQUeIWkcPXVGXdGu5lp4vufaesqKho2N69e1csXLiw09SpU4/v0qXLwcrKyiOHDh2695lnnnn/l7/8ZbdFixZ1+eMf/9j5hRdeOOree+/9qKljnnfeeSd+5zvf+XTy5Mkf33vvvd1effXVTgsWLHg/G9cTlBK3iBwqyCxmqqzTI6zPgj/zj33YtqbJZT3Zse5I4Mt73Y05tnQvF9+f1mU9Kysr23344YftS0pKSgFOO+203Y888sgh3eNz5879YPTo0SUDBgzYf//99/d8880316YaQ7YpcYvIoZIl42RJRJV18+ne92GLLesJNLqsZ1Nd5X369Kn+13/9103jxo0bPG/evPU9evSoyVTMzaXELSINJUrGSiJSX6qVcQZHlTdnWc/6Vq1adWTnzp2rP/roo7bpiS4zNAGLiIi0ei+99FLRCy+80Hn58uVrpk+f3rOioiJh5Z4PVHGLtFZ6ZEsEgH379tlNN91UPGvWrI3FxcUHf/7zn3/43e9+t3jp0qXr2rTJv/o268t6ZpOW9RRpRLKlMSH1pTQ1ejyzcrRkaLqX9dQELMHlzbKeIpJngiTdRCOfNXo881rCY2JK2GmlxC0iqQnDSl0tTVgfE5OMUuIWEclXekxMElDiFmnpNAhNpEXJv+FyIpJerWkNbJFWQBW3SGugkd+SQ1cuvHIwwOPjHtcgtTRQxS0iIqEybNiwkqb2WbJkSccBAwYMKSkpKX3rrbeOMLPhN9988/Gx1zdv3lxYWFj41auvvrovwD333NN9+vTpXdMRX0FBwfCSkpLS2FdlZWW7hQsXdjrnnHMGpOP4qrhFRCRUDmdZz969e+9/7rnnjgY2RV8/ZsCAAXXrc//4xz/enur5q6urKSxMnj7bt29fW39e9L/85S/tUz1+U/K24jaz/mY2y8yeims728xeNbMHzezsHIYnIiI5UlRUNAxg4cKFnUaMGDF4zJgx/fv16zdk/Pjx/Wpra5k2bVq3RYsWdbnnnnuOHz9+fD+AI444wgcMGLDvlVdeKQL43e9+1+Xiiy/eGTvmlClTjr/tttt6AKxevbr9GWecMWjw4MGlpaWlJ7377rvtFy5c2GnkyJGDvv3tb/cbPHjwEIA77rijx8CBA4cMHDhwyNSpU49NNf5rrrmmzw9/+MPjonEcVVZWNrimJvU1TbJacZvZbGAcsM3dT45rHwP8J1AAPOTu/+7uG4Dr4hM34MBu4AigKnuRi4hIff/2p3/rs/6T9U0u67nhsw1Hwpf3uhsz4JgBe+8cfWfal/UEuOKKK3Y++uijXXr16nWwoKDAjz/++IObNm1qMCf5xIkT+/3whz/ccvXVV3+6d+9eq6mpsffff7/dO++802HFihXvlpSUHHj11VeLHnvssa7Lly9f6+4MHz78pPPOO2/X6NGj9+3fv79NbAnRPn367H/++effiz/+fffd99GwYcNO+vrXv777Bz/4Qd9Fixb9paCgINVLznpX+VxgOjAv1mBmBcD9wDeJJONlZrbA3RMtv/aqu//RzHoA04C/zXzIIiKSr1Jd1hPg0ksv/Xzq1Km9evTocfDSSy/dmWifTz75pM3WrVvbXX311Z8CFBUVOZGikVNOOWVPSUnJAYCXX36549ixYz896qijagEuvPDCT1566aVOo0eP3peoqzxep06dah944IGNF1xwQclPf/rTD4cMGbI/yDVnNXG7+ytmVlyveQSwPlphY2ZPABcBDS7a3WujP34CpO1+gUiLUv+57b8uhXYdchePtFipVsaZHFUeZFnPI444wk855ZS9DzzwQM/Vq1evfvLJJ4+uv09j63cUFRXVprJfKlauXHlk586dqzdt2hR4CdF8GJzWC4j/41cBI82sK/AzYJiZ/cTd7zazS4BvAUcTqdwbMLMbgRsB+vbtm9HARfJS7Lnt2OQqfUfpee2WKNkc5gBb3oF2HeEHa7MbUwj8y7/8y5azzjprV8+ePRPeVO7SpUttz549DzzyyCNHX3XVVZ/u27fPEn0YOPfcc3dfe+21xXfeeecWd2fx4sXHzJ07d0MqMaxbt67d/fff33P58uVrxowZM/DFF1/89Nxzz92T6jXkQ+JO9OnI3f1j4KZ6jU8DTzd2MHefAcyAyOpg6QpSJFT03HbLpg9ih62srOyLsrKyLxrb59FHH33/hhtuOOHOO+88vm3btj5//vz36u9z5pln7p04ceLHX/3qV08CuOqqq7aPHj16X1Pnr62t5Zprrin+2c9+9mFxcfHBmTNnbrzuuuuKV65cuTbaLd+krC/rGe0qXxgbnGZmo4A73P1b0e2fALj73c09l5b1lBYn2fSl8WJd4z9JeXyPyCHSvaynJmAJLt+X9VwGDDSzfsBHwBXAxNyGJJKn6neDJ9KuA3RI+ckUkYxTwk6vbD8O9jhwNtDNzKqA2919lplNBp4l8jjYbHd/N5txiYSKusFFWrVsjyq/Mkn7YmBxNmMREREJo7ydOU1ERPJSbW1tbdJHrqT5or/f2mSvK3GLiEgQq7dv395ZyTszamtrbfv27Z2B1cn2yYfBaSIiEhLV1dXXb9my5aEtW7acjIq/TKgFVldXV1+fbAclbhERSdnw4cO3AeNzHUdrpk9LIiIiIaKKWyRMtryT6whEJMdUcYuIiISIEreIiEiIKHGLiIiESMu+x73jL8mXvRMJowN7tLa2SCunilskTLSAiEirl3LFbWa3u/tPMxlM2nUbqMUYpGVRD5JIqxekq/x2MysCugBvAU+4+yeZCUtEREQSCdJV7sAXRJbf7AO8bmanZiQqERERSShIxV3h7rdHf37KzOYCDwLnpj0qERERSShIxb3DzIbHNtx9HdA9/SGJiIhIMkEq7n8CnjCz5cAq4FTg/YxEJSIiIgmlXHG7+9vAV4DHo00vAldmIigRERFJLKXEbWYjzOw0d99PpMquBja5+56MRiciIiKHaLKr3MxuBy4ACs3seWAE8EfgFjMb5u4/y3CMIiIiEpXKPe7LiHSRtwe2AL3d/XMzuxd4E1DiFhERyZJUusqr3b3G3fcC77n75wDuvg+ozWRwZtbfzGaZ2VNxbReb2Uwz+4OZnZ/J84uIiOSbVBL3geiMaQB1j4OZWWcOI3Gb2Wwz22Zmq+u1jzGzSjNbb2a3ALj7Bne/Ln4/d3/G3W8ArgEuD3p+ERGRMEslcZ8VrbZx9/hE3Rb47mGccy4wJr7BzAqA+4ncSy8FrjSz0iaOc2v0PSIiIq1Gk4k7OpIcADP7Zlz7DqBn0BO6+yvAznrNI4D10Qr7APAEcFGi91vEL4D/cfe3gp5fREQkzIIu6/mLJrYPVy/gw7jtKqCXmXU1sweBYWb2k+hr3we+AVxmZjfVP5CZ3Whm5WZWvn379jSFJyIikh+CzJyWiKUlisTHcXf/GLipXuOvgF8lO5C7zwBmAJSVlXma4hMREckLKSVuM5tDZHWwvmY2G8Ddr01jHFVEVhyL6Q1sSuPxRUREWoRUK+650e9fAx7OQBzLgIFm1g/4CLgCmJiB84iIiIRaSonb3f8IYGa7Yj/HXgp6QjN7HDgb6GZmVcDt7j7LzCYTWeu7AJjt7u8GPbaIiEhLF/Qe94Emtpvk7gkXJnH3xcDioMcTERFpTQKNKnf30xvbFhERkcwK+jiYiIiI5JASt4iISIgocYuIiISIEreIiEiIKHGLiIiEiBK3iIhIiChxi4iIhEjKiTu6lGaTbSIiIpI5QSrubyZouyBdgYiIiEjTmpzy1My+B/wD0N/M3ol7qRPweqYCExERkYZSmav8MeB/gLuBW+Lad7n7zoxEJSIiIgk1mbjd/TPgMzObBFwCFMfeZ2a4+9SMRigiIiJ1gqwO9gzwGbAc2J+ZcERERKQxQRJ3b3cfk7FIREREpElBRpW/bmZDMxaJiIiINClIxX0mcI2ZvU+kq9wAd/dTMhKZiIiINBAkceuZbRERkRxLOXG7+wdmdgwwEDgi7qUP0h6ViIiIJJRy4jaz64Gbgd7ASuB0YClwbmZCExERkfqCDE67GTgN+MDdzwGGAdszEpWIiIgkFCRxf+HuXwCYWXt3rwAGZyasxMys1MyeNLMHzOyybJ5bREQkHwRJ3FVmdjSRiVieN7M/AJuaG4CZzTazbWa2ul77GDOrNLP1ZhabavUC4D53/x5wdXPPLSIiEjZBBqd9J/rjHWb2EtCZyBzmzTUXmA7MizWYWQFwP5EVyaqAZWa2AHgEuN3MxgNd03BuERGRUDms9bjd/Y/uvgC4q7kBuPsrQP3FSkYA6919g7sfAJ4ALnL3be7+j0QWO9nR3HOLiIiETb6ux90L+DBuuwroZWbFZjaDSHV+b6I3mtmNZlZuZuXbt2vsnIiItCxB1uM+MW49biOyHvefMhSXJWhzd98I3NjYG919BjADoKyszNMfmoiISO7k63rcVUCfuO3epGEgnIiISNg12VXu7p9FK92ngZ3u/gFwFfCQmQ3LUFzLgIFm1s/M2gFXAAsydC4REZHQCHKP+9/cfZeZnQl8C3gYeLC5AZjZ40RmYBtsZlVmdp27VwOTgWeBtcCT7v5uc88lIiISdkEWGamJfr8QeMDd/2BmdzQ3AHe/Mkn7YmBxc48vIiLSkgSpuD8ys18DfwMsNrP2Ad8vIiIizRQk8f4Nka7rMe7+KdAF+FFGohIREZGEgsyctpfIALXY9mZgcyaCEhERkcSCLOvZHrgUKI5/n7tPTX9YIiIikkiQwWl/AD4DlgP7MxOOiIiINCZI4u7t7mMyFomIiIg0KcjgtNfNbGjGIhEREZEmBam4zwSuMbP3iXSVG5H5w0/JSGQiIiLSQJDEnamVwERERCRFKXeVR+coPxr4dvTr6GibiIiIZEnKidvMbgZ+Axwb/XrUzL6fqcBERESkoSBd5dcBI919D4CZ/YLI4iD3ZSIwERERaSjIqHLjy4VGiP5s6Q1HREREGhOk4p4DvGlmv49uXwzMSn9IIiIikkyQucqnmdnLRB4LM2CSu6/IVGAiIiLSUJOJ28wGAD3c/U/u/hbwVrT9a2Z2oru/l+kgRUREJCKVe9y/BHYlaN8XfU1ERESyJJXEXezu79RvdPdyIiuFiYiISJakkriPaOS1I9MViIiIiDQtlcS9zMxuqN9oZtcRWeJTREREsiSVUeX/DPzezP6WLxN1GdAO+E6mAhMREZGGmkzc7r4VOMPMzgFOjjYvcvcXMxpZAmbWBrgTOAood/eHsx2DiIhILgV5jvsl4KV0B2Bms4FxwDZ3PzmufQzwn0AB8JC7/ztwEdAL2AlUpTsWERGRfBdkytNMmQuMiW8wswLgfiJLiZYCV5pZKTAYWOruU4DvZTlOERGRnMt54nb3V4hU0PFGAOvdfYO7HwCeIFJtVwGfRPepQUREpJVJuavczI4A/oHIlKcOvAY84O5fZCCuXsCHcdtVwEgiXef3mdnXgFeSxHkjcCNA3759MxCaiIhI7gRZZGQekRnUYst4Xgk8AkxId1AkXnXM3X0vkeVFk3L3GcAMgLKyMs9AbCIiIjkTJHEPdvdT47ZfMrO30x1QVBXQJ267N7ApQ+cSEREJjSD3uFeY2emxDTMbCfwp/SEBsAwYaGb9zKwdcAWwIEPnEhERCY0giXsk8LqZbTSzjcBS4OtmtsrMGsxlniozezx6rMFmVmVm17l7NTAZeBZYCzzp7u8e7jlERERaiiBd5WOa3iU4d78ySftiYHEmzikiuTV/3XwWb1jM2P5jmTCoecNkbnjuBt7Y/AZlPcrScjyRfBdkApYPMhmIiLR8sSQbU761PKUEHkv0MfH7x45XvrUcQIlbWrwgj4Pdlqjd3aemLxwRaQnmr5vPtPJpAEwpm9IgycaLJVyAxRsW122Xdi2lqLCIsf3HMq18Gvuq9zHs2GFU7qys23/q0uD/+xn39Dg+/uLjQ+ISCRNzT+2JKTP7QdzmEUSmKV3r7tdmIrB0KCsr8/Ly8qZ3FAmLORdGvk9alNs4GjF/3fzACbXACqjxxudUKutRxpwxc5i0ZBKVOyvZdXBXg306te3E4C6DGdt/LA+vfjhhgp60ZBLlW8vrjicNmdlydy/LdRySWJCu8v8Xv21m/4FGeou0ajc8F1nxd+b5M4FDk/ZtoyKddPFVdKx9wqAJdd3fe6v3UlRYBES6wJ/b+FzdPeu91XtZ8/GaQ845tv9YKnZW0LFtR3Yf3M3px53OzPNn1h2vfGt5gyo+UWVdvrWc+evmq+qW0Em54m7wRrNjgD+7+8D0hpQ+qrilxcmjijs+Sa/67qoGSTs+IcbubceSbBBBK+T6FX+sCodI0q//QSKmfsytmSru/BbkHvcqIlOdQmTFru6A7m+LtHCJRoDXT46NJW0gcLKON7b/2EO+N2XCoAl1scTukwOHVOKxEejxSXxa+TQlbgmFIPe4T4jbrAa2Rp+3zluquKXFyUHFPeqxUew+uBuIJDw4dEBZp7ad6u4350vVWr8LHw79cBFfvdcf6X44vQItjSru/BbocTAzOxX4WrTpFeCwJ14RkfwWq7QtbumAWJd1rGIF6h7TyqdnqBMl3gmDJiTsJp95/kzGPT2OD3ZFnnh9Y/MbTFoyCcivaxKJCdJVfjNwA/B0tOk3ZjbD3e9r5G0iEgLx3eEQ6TaOr7JjyS5RRd0SEtvCSxY26P5fsW0FFTsrWsT1ScsSZOa064CR7r4HwMx+QWSqUiVukZCKH4kNh3aBx89EFut6bslJbMKgCQ0eGxPJR0EStwHxD1rWkHj5TREJgfr3fOsP3IpPYi3lnm/QgW4x8TO3qftcci1I4p4DvGlmv49uXwzMSn9IIpJu8Ylnb/Ve/vr5X+u6wmPd34kGdLU09avqxlTsrGD3wd11v7vYjG3lW8t5buNzLfr3JPktpVHlZmZE1sTuDpxJpNJ+xd1XZDa85tGocmlxDmNUebKZzLQoR+Pq/97qj6hvyb8/jSrPbylV3O7uZvaMuw8H3spwTCKSRrFK+7ZRtyWdBlQaiv1+Ysk71r0ePx4g0cImiWaEi2mpiV6yK0hX+Rtmdpq7L8tYNCKSVrHHnDq27Riom1giJgyawHMbn6v7Of57rCKvP3FL/Ih8gDbWhqLCorrH6vQ3kOZqE2Dfc4ClZvaemb1jZqvMTM9xi+Sp+evm1z2bPKVsSo6jCa+Z589M+lx4WY+yuvvgMSVdSup+vm3Ubbx99dssnbi0btpVkeYKUnFfkLEoRCRt6j/ilS+zmbVEY/uPrVtTvP7v+PTjTj+krWJnRbbDkxaqycRtZhcBvd39/uj2m0QGqQH8GPggc+GJSFDxXbWxLnLJjNhsbDHz182vm10uUZW+r3qfZmWTZkulq/zHHLp8Z3vgNOBs4HsZiElEDtO4p8fVJe021oauR3TNcUStS/yz3vVNKZuC47y17S3Kt5YzdenUQ7rYRVKVSld5O3f/MG77NXf/GPjYzDpkKC4RCSh+vu0TOp3AwksW5jii1qmsR1nCSjp+cGBsYFtsxLoqbwkilYr7mPgNd58ct9kdEckLH+6OfL6+bdRtStpZVr61nPnr5lOxsyKle9kTBk3gtlG3ARzS1S6SilQq7jfN7AZ3P+SGjZn9PfDnzISVmJmdBNwMdANecPcHMnWu8+afx96Dew8ZISqSc7aVsd6B+vXZ/HXzqfVa3dPOgfgBakH+fxG/Wtn8dfP1d5OUpZK4/w/wjJlN5MvJV4YTudd9cXMDMLPZwDhgm7ufHNc+BvhPoAB4yN3/3d3XAjeZWRtA8w1Kq1PJATAOSdzxXeS6p5199QeoBbF973YAdZlLIE0mbnffBpxhZucCQ6LNi9z9xTTFMBeYDsyLNZhZAXA/8E2gClhmZgvcfY2ZjQduib4nY16Y8EImDy9yWCbNLaOCA0xaMok5Y+Yc8qy2HvvKncN91GvhJQsZ+vBQQMlbUpfyc9zRRJ2uZB1/3FfMrLhe8whgvbtvADCzJ4CLgDXuvgBYYGaLgMfSHY9ImEwrnwYoaedac26pnX7c6byx+Q2ABrOwiSQSZOa0bOoFxI9krwJ6mdnZZvYrM/s1kLBvysxuNLNyMyvfvn17NmIVybrte7cz6rFR7Kvel3QUs2RPxc4KVmxbUbeCWBAzz59JWY8y2lgbdh/czajHRukxMWlUvibuROt8u7u/7O7/5O5/H5sQJsFOM9y9zN3LunfXoHdpeXab88GuD9h9cDfDjh0WeG1pSb8pZVM4svBIHD+sv8ecMXPo07EPHdt2xDCNNJdGBZnyNJuqgD5x272BTTmKRSRvVHCg7md1j+ePdCzgEnuELzazmkgy+VpxLwMGmlk/M2sHXMGhs7eJtGp67Ktliz0iJpJIzhO3mT0OLAUGm1mVmV3n7tXAZOBZYC3wpLu/m8s4RfJBVwpo43rsqyWLf0RMyVsSyXnidvcr3f04d2/r7r3dfVa0fbG7D3L3E939Z7mOUyQfdKeAIozuRRq/0VLFz3oXe2pAJF7OE7eIpG6O96CEdrkOQ7Ko7NEyhj48lKEPD1UFLoASt4hI3jn9uNMB2H1wN/tr9te1xyrwSUsmNTqIranXJdyUuEVE8szM82fSsW3HBu27D+5W1S1K3CIi+Sh+AGJZj7K6n6cunXrYU6xKy6DELSKSh7oXdad9QXs6tu3I2P5j6dSuU91rB2sP5jAyybV8nYBFRKRVmzNmTt196tgKZKt2rGJ/zX721+ynfGt50vvYFTsrKGpblM1wJYtUcYuIhETbNm1zHYLkAVXcIiIhUdKu8FUsAAAJ+UlEQVSlhBXbVlDjNUCkKk9EI8pbNiVuEZEQiCXpUY+NYvfB3RRYQY4jklxRV7mISMi0sTYMO3ZYrsOQHFHiFhEJkZIuJRQVauBZa6bELSIiEiK6xy0ikqeSDT6T1k0Vt4iISIgocYuIiISIEreIiEiIKHGLiIiEiBK3iIhIiChxi4iIhIgSt4iISIgocYuIiIRIqCZgMbMOwH8BB4CX3f03OQ5JREQkq3JecZvZbDPbZmar67WPMbNKM1tvZrdEmy8BnnL3G4DxWQ9WREQkx3KeuIG5wJj4BjMrAO4HLgBKgSvNrBToDXwY3a0mizGKiIjkhZwnbnd/BdhZr3kEsN7dN7j7AeAJ4CKgikjyhjyIXUREJNvy9R53L76srCGSsEcCvwKmm9mFwH8neqOZ3QjcCNC3b98MhymSXe9u/ow93arpkINzP/bmX/nDyo8atF/0lV5MHKl/ayLZkq+J2xK0ubvvASY19kZ3nwHMACgrK/MMxCbSKv1h5Ues2fw5pccdVde2ZvPnAErcIlmUr4m7CugTt90b2BT0IBu27+HyXy9NW1AiubZ3z0R2tVtBP6pzcv7S447it38/qm472b+vZNU5qEIXaa58TdzLgIFm1g/4CLgCmJjbkERyb1XNCbDjBD5dsZ3LP0icNGNVcHxlnMlkuWbz5w0S+JvvR4atjOzXJWFsStwihy/nidvMHgfOBrqZWRVwu7vPMrPJwLNAATDb3d8Neuz+3TscUh2IhN1/3DGZhxkMdEq6T3zChkgSffP9nUkr4FTV7yaHyAeCREb265Lww0LQHjBV7iIN5Txxu/uVSdoXA4uzHI5IXrug3Ur+3O01OvQdxpwx16T0nsaSXxClxx3VIFFPHNk3cPJMVKFD4kSc6L46JP8womQurUHOE7eIZNbhJNdMSVahJ0vEsaRdv+cs0YeRdPUsxOLMl9+ZSH1K3CKSNck+RCTrFUhU5Sc7Trp6FtL5ASAd9CFC6lPiFpGcS0evQLp6FtL1ASAdEn2IqNz5dfZWn8aKD4qSDlCs3Pl1Onb8tN6clNJSKHGLiMTJp1sLh/shYs+Bag7sPZCBiCQfKHGLiOSpRB8iJi2ZQcXOCkq6lCQdoDhpyYwsRCe5ovm+RUREQkQVt0iIDDmuMx3si1yHISI5pIpbREQkRJS4RUREQkSJW0REJESUuEVEREJEiVtERCRElLhFRERCRIlbREQkRJS4RUREQkSJW0REJETM3XMdQ8aY2Xbgg1zHkaJuwI5cB5FmLfGaQNcVNrqu4E5w9+4ZOrY0U4tO3GFiZuXuXpbrONKpJV4T6LrCRtclLY26ykVEREJEiVtERCRElLjzR0tcQLclXhPousJG1yUtiu5xi4iIhIgqbhERkRBR4hYREQkRJW4REZEQUeLOc2ZWamZPmtkDZnZZruNJFzP7mpk9aGYPmdnruY4nXczsbDN7NXptZ+c6nnQxs5Oi1/SUmX0v1/Gki5n1N7NZZvZUrmNprpZ0LdI4Je4MMrPZZrbNzFbXax9jZpVmtt7MbmniMBcA97n794CrMxZsAOm4Lnd/1d1vAhYCD2cy3lSl6e/lwG7gCKAqU7EGkaa/19ro3+tvgLyY9CNN17XB3a/LbKSHL8g15vu1SPpoVHkGmdlZRP4nPs/dT462FQDrgG8S+R/7MuBKoAC4u94hro1+vx3YC5zh7qOzEHqj0nFd7r4t+r4ngevd/fMshZ9Umv5eO9y91sx6ANPc/W+zFX8y6fp7mdl44BZgurs/lq34k0nzf4dPuXve9WgFuUZ3XxN9PS+vRdKnMNcBtGTu/oqZFddrHgGsd/cNAGb2BHCRu98NjEtyqH+M/mN9OlOxBpGu6zKzvsBn+ZC0Ia1/L4BPgPaZiDOodF2Xuy8AFpjZIiDniTvNf6+8FOQagTXZjU5yRV3l2dcL+DBuuyralpCZFZvZDGAecG+GY2uOQNcVdR0wJ2MRpUfQv9clZvZr4BFgeoZja46g13W2mf0qem2LMx1cMwS9rq5m9iAwzMx+kung0iThNYb0WuQwqOLOPkvQlvR+hbtvBG7MWDTpE+i6ANz99gzFkk5B/15Pkyc9I00Iel0vAy9nKpg0CnpdHwM3ZS6cjEh4jSG9FjkMqrizrwroE7fdG9iUo1jSSdcVLrqu8GoN1yiNUOLOvmXAQDPrZ2btgCuABTmOKR10XeGi6wqv1nCN0ggl7gwys8eBpcBgM6sys+vcvRqYDDwLrAWedPd3cxlnULouXVc+aKnXFa81XKMEp8fBREREQkQVt4iISIgocYuIiISIEreIiEiIKHGLiIiEiBK3iIhIiChxi4iIhIgSt7RKZlZjZivjvpparjMrzGyjma0ys7Lo9stm9lczs7h9njGz3U0c52Uz+1a9tn82s/8ysxOj19zoMUQkP2mucmmt9rn7V9J5QDMrjE6O0VznuPuOuO1PgdHAa2Z2NHBcCsd4nMiMWs/GtV0B/Mjd3wO+osQtEk6quEXiRCven5rZW9HKtyTa3sHMZpvZMjNbYWYXRduvMbP5ZvbfwHNm1iZa1b5rZgvNbLGZXWZm55nZ7+PO800zS3UxkieIJF2AS6i3iImZ/Sga1ztm9tNo81PAODNrH92nGDgeeO2wfjEikjeUuKW1OrJeV/nlca/tcPevAg8AP4y2/V/gRXc/DTgHuNfMOkRfGwV8193PJZJYi4GhwPXR1wBeBE4ys+7R7UmkvqTpC8BZ0TXZrwB+G3vBzM4HBhJZo/krwHAzOyu6UtSfgTHRXa8AfuuaKlEk9JS4pbXa5+5fifv6bdxrsYp2OZEkDHA+cIuZrSSyvOURQN/oa8+7+87oz2cC89291t23AC9BZM1FImt0/120u3sU8D8pxlpDpFK+HDgyutRrzPnRrxXAW0AJkUQOX3aXE/3+eIrnE5E8pnvcIg3tj36v4ct/IwZc6u6V8Tua2UhgT3xTI8edA/w38AWR5B7kfvgTwO+BO+q1G3C3u/86wXueAaaZ2VeJJPy3ApxPRPKUKm6R1DwLfD82utvMhiXZ7zXg0ui97h7A2bEX3H0TkXWTbwXmBjz/q8DdNKyanwWuNbOO0bh6mdmx0fPtJtI7MDvB+0QkpFRxS2t1ZLTbO2aJuzf2SNidwC+Bd6LJeyMwLsF+vwPOA1YD64A3gc/iXv8N0N3d1wQJNtrV/h8J2p8zs5OApdHPFLuBvwO2RXd5nEjX/xX13ysi4aRlPUXSzMw6uvtuM+tKZIDY6Oj9bsxsOrDC3Wclee9GoKze42CZinO3u3fM9HlEJL3UVS6Sfguj1fyrwJ1xSXs5cArwaCPv3Q68EJuAJRNiE7AAWzN1DhHJHFXcIiIiIaKKW0REJESUuEVEREJEiVtERCRElLhFRERCRIlbREQkRJS4RUREQuT/A+OaC7NAMOcgAAAAAElFTkSuQmCC\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAeQAAAEPCAYAAACTLbe4AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy8QZhcZAAAgAElEQVR4nO3de3xU9bnv8c8TAkIIyi0SjpugWC5eAhWmQlrZu3b3UC/YbtgGWkur9BRabT1t9VQsdWsLp1aOr5dtt3Z3C57NpR4sly2tAlW2l+7WrWKDBKWUSytaqgbCRUhEMJDn/DEzcQgzyUySmVkz832/Xr6ybrPWs5KWZ57f+q3fz9wdERERya6ibAcgIiIiSsgiIiKBoIQsIiISAErIIiIiAaCELCIiEgBKyCIiIgGghCwiIhIASsgiIiIBELiEbGaTzKxvtuMQERHJpIwmZDOrNLNubezvDlwO9DWzajO7zMy+aWbFmYtSREQk8zKWkM1sPPAi0N3Mis1svplNMbO5ZlYE4O5NwPHIR6ZGjn8XGJOpOEVERLIhY5Wnu280s/rI6izgTXdfY2blQDWwotVH7gOmA1XAL9s7/8CBA/3cc8/twohFRPLfpk2b9rt7WYJ9ZxcXFz8EXEwAH3HmmGZg64kTJ748bty4ffEOyFZT8ATgZ5HlWuBGYEWkyXooMMzdnzEzB4rdvT7eScxsNjAboKKigpqamvRHLiKSR8zsjUT7iouLHyovL7+grKzsUFFRkWYi6oTm5marr6+/sK6u7iHg0/GOydY3nnKgIbLcAAyCcJO1u8+MJOMyoM7dlyY6ibsvdPeQu4fKyuJ+wRMRkY67uKys7IiScecVFRV5WVnZYcKtDXFlq0I+AJRGlkuB/a0PSFQVi4hIxhSlmow/88BzIwF+9fXLdqQnpNwV+V0mLISzVSFv4IOOWqMj6yIiIgUrYxWymYWAMmASsAyYZ2bTgArgrkzFISIiuWHXrl09brnllnMef/zx3fH2z507t7x3797Nr7/+eo/m5mY7duyY/fa3vz3zC1/4wv5169b1Xbly5WsjR458v/Xn9u7d223gwIEnu3VL+BZuVmSyl3UN0Dtm0x2RnyszFYOIiOSO4cOHv79y5crX4+3bu3dvt/Xr1/etra3dvm7dutKrr766ce3atX127drV6+6776777Gc/e6hnz56nNbc3NTUxbdq0837961//uaSkJFDPxjXghoiItOvbq7cM2VnXUNLecX/a19gLPniW3JYR5X2O3nvtmD2J9m/atKnnunXrzmxoaOi2e/fuMwYPHtz0+9//vvfzzz+/c9myZf0OHTpUvHDhwn6zZ88+1Pqzo0ePPg6wYMGCsnPOOafpqaee6jNjxoyDQ4cObXrllVd6L168uN9Xv/rVg0GqkvVemYiIBFJFRUXTgw8+OGjIkCHv9+3b98T999//5uHDh4v37NnT/dOf/vSRvn37noiXjKM2btzYa8uWLb1mzJjxzrx5896+8cYbzx0+fPj7JSUlzTNnzjwUpGQMqpBFJJ/ULIZXV3fNuSqvhdDMrjlXHmirko3Vlb2sy8rKTkaXe/To4ZGfzceOHbNkPv/qq6/2LCoK150VFRUnDh8+3K25ubmzYaWNErKI5J5EifeN58I/h17WufPXvRr+qYSc0y655JL37r///kEAx48ftyFDhhwvKirCzDh58qQBeoYsIpKUVBPv0Mu6prJdfHU4KS+++tTtqpoz6tlnny05cuRIt8cff7xvc3MzO3fu7FFXV9ejpqam1+HDh7vV1dX1eOWVV84YPXr08cbGRtuwYUOfPXv29Hj++ed7ffSjH31v3Lhxx6655ppD8+bNO7tHjx7+k5/8ZA/A2LFjG+fMmTN4/vz5dQMGDDjZXhyZYu6B+oLQYaFQyDV0pkieiSbG8srT96UzOcb7IhCNY+a69FwzS8xsk7uH4u3bsmXL62PGjDlt4Ka2aGCQtm3ZsmXgmDFjzo23TxWyiGRW3GT3Svhn+ehW27OUBEMzT0/2ratliUuJuOOUkEUks15dfXrV2zoRt2yvDFfCQRGvGRvUlC1dQglZRDIvF5t+E30xUAcw6SJKyCKSHok6ZCV6Jhx08ZqxIXEHMFDlLCnRwCAikh7RpunWgtYM3VmV18b/glH3ate9Ey0FQRWyiKRPLjZNp0qV86kWXh4eMnP2s+rclSJVyCIi6aDKOesee+yxPgsWLCjLdhzJUoUsIp2Tb8+Ku0pblbMkJdnpF59//vnSl19+ufcnP/nJw5WVle81NDQU7d69+4wbb7yxfvny5QPmzJlTn+nYO0IJWUSSk+qoWfn2rFgyLtnpFxsbG+s/8YlPjJg+ffqhyZMnNwDs3LmzR64NfKWELFKo2pqIId4zznjvDwOccSb0Pjv/nxV3pVx8tvzLrw1h37Z2p19k/85ewAfPktty9oVH+Yefdvn0i7/85S/7XHbZZUcPHDjQMp3TnXfeOeixxx7rN3fu3Lc2b95cMn/+/Lri4mClwGBFIyKZkyjBtvVebSF00ko3vc+ctOj0i3PmzHnr0KFD3e6///43L7jggguj0y8+/PDDA2OT8cqVK/vV1NSUrFmzpt/TTz+9K/Zc8+bN2/vkk0+e9dRTT525cOHCv2b+btqnhCxSyOIlWD3jTK9cfbbcRiV7ii7sZZ3q9IvTpk07NHny5IbPfvazh0pKSppjK2SAL3/5y/WLFy8e2Nm40kW9rEVEJK+MGjXq/ZKSklMeIB87dszeeeedbuXl5U1Llizpm63Y2qIKWSTfqRe05Khkp188efKk7dmzp8dTTz3V5+Mf/3hjaWmpAzz99NOl+/fv77579+7u3//+98tvvfXWfWPHjn3vuuuuO3/s2LHvjR49+ni27zGWErJIvkv0rLitXtDxOh0pgUuGXX755UcbGhpqY7ft3bv3lejyTTfddDC6/Pbbb582LNxNN910MHrMkiVLok3ux2PPESSBS8hmNgl4yd3fMbOLgBLgZXcPzCTSIjknlc5YiZK0XmNKv1zsfd2aRujqsIwmZDOrBLYlSq5m1h24HNgZScYXufvCTMYoUvASdTqS9Er0ZecvL4Tni9bfJO9lLCGb2XjgGWCAmRlwF/AycAFwj7s3u3uTmUXb9G8CVpvZvwC3uXtjpmIVEcm4XO19LV0mYwnZ3TeaWXT4slnAm+6+xszKgWpgRauPNMTsvxB4KVOxiuSseB249OxXJCdk67WnCUD0QX0tcDW0NFkPBYYBy83sGqAXsCXeScxstpnVmFlNfX1ODFUqkl5xpzx0aKjLSjgikrxsdeoqBxoiyw3AIAB3bwKSflASeb68ECAUCuXWoKUi6aLRtCSLPrf2cyMBHpn8SN537jp48GDRww8/3G/EiBHHr7jiik4/Vs1WhXwAKI0slwL7sxSHiIgE1K5du3pcc8015yXaP3fu3PIf/OAHZ3/qU586/6KLLrrgqquuGha7/5FHHjnLzMY98sgjZx07dszGjx8/oqOx/PCHPywrLS295J577ilbsGBB2fXXXz9k3bp1Z9bW1pa88sorvTp63ljZqpA3AGOAjcDoyLqIiEiLZGd7+sY3vlF/6623nrNixYqBf/rTn7p/6EMfagKora3tBfC5z33uMMBvfvObXfHOlYypU6cefuCBB8pvv/32lueju3bt6rF58+b2J9xIUsYqZDMLAWXAJGAZUGFm04AK4OFMxSEiIrlh06ZNPe+9996yb3/724Ovvfbac2+++eZzJkyYMKK5uZnY2Z5KS0u9d+/ezVOmTDnwox/96GyAHTt29Bg2bNj70XPt2LGjx/e+971BAA0NDUV333132Y9//OMB11577bl79uwpvuyyy4bPnz//7IkTJw7ftm1bj/nz55/905/+tP8NN9ww5OTJ09/UXbx4cb/hw4e3nL+urq7bpZdeOvKee+4p+9KXvjTkd7/7XcqJOpO9rGuA3jGb7oj8XJmpGEREpGP+6b/+acifDv2p3STz2uHXwlVp5FlyWz7U70NH539sfsJJK1Kd7enWW2/d97d/+7ejFixY8NYjjzzSb86cOfu++tWvngcwZMiQpoceemjQggUL6u66667yr33ta/Xnn39+k7vbkCFDThw7dqyoqqrq3blz5+678sorz1+0aNFfhg4d2jRjxozSxYsX95s4ceK7jY2N3ebNm3d2Q0NDt127dvWcOXNmy7XLy8tPLlq06PXp06eff/vtt781ceLEo+3df2uBG6lLREQEUp/t6eKLLz5eWVn57gMPPDDQzLxXr14tnX1LSkq8Z8+ezQCbN28uGThw4EmAb33rW/sBioqKGDBgwMlu3brx5z//uWdxcbEDjB49+r0dO3b0nDhx4rulpaUn77zzzn0Qrt5bX3/MmDHHBw0a9P67777bodZnJWSRXBXvneO/vAA9esc/XqQT2qpkY2Wrl/WJEycAuPnmm/d98YtfPH/z5s1/SHTs4MGD33/wwQcH3HbbbfXPP/98r7Fjxx6L3T9q1Kj3nnvuud7Tp08/fPDgwW6XXHLJadXuuHHjjrXe9uSTT5Z+85vf3HfbbbcNmTFjxjtnnXVWcyr3oOkXRXJVvHeOe/SG3mdnJx6RLhY729OOHTt6xs729PTTT5dGZ3uqqanp+cQTT/R9/PHH+0ydOvXI5z//+fqRI0e+v2zZsr4AS5cu7bt169Yzjhw50u3ZZ58tueuuu+qWLFkycNy4cSN37dp1xt69e4vr6uq6/+Y3vykF+NGPfvTXNWvW9F22bFnf4uJiv+666w4/+uijZx06dKj4mWeeafnGe/jw4aJXX32119atW3vt3Lmzx6JFiwZOmTLlyEc+8pGGG264oeLo0aNxK/lEzD0/Xt8NhUJeU1OT7TBEMueHQ8I/v5PcvPGSoxZf3f5oa+WVcOU9HTq9mW1y91C8fVu2bHl9zJgxKb2WWkjvIXfEli1bBo4ZM+bcePvUZC0SVInmMY56/101TxcCzbBVMJSQRYIq0TzGUWqeLgw5NvuWKuOOU0IWCbK2hsHULEAieUWdukREJJHm5ubmlDomSWKR32XCntdKyCIiksjW+vr6s5SUO6+5udnq6+vPArYmOkZN1iK5SjM6SZqdOHHiy3V1dQ/V1dVdjAq4zmoGtp44ceLLiQ5QQhYRkbjGjRu3D/h0tuMoFPrGIyIiEgBKyCIiIgGghCwiIhIASsgiIiIBoE5dIkFV90q2IxCRDMqfhLx/l0YukvyisapFCoqarEWCSmNVixSU/KmQBw7XQAmSX9TiI1JQVCGLiIgEQP5UyCL5Ri0+IgUlcBWymU0ys77ZjkNERCSTMpqQzazSzLq1sb87cDnQ18wuMrPZZvadzEUoIiKSHRlLyGY2HngR6G5mxWY238ymmNlcMysCcPcm4Hhk+Q/AH4HDmYpRREQkWzKWkN19I1AfWZ0FvOnua4BDQHWCj70EXJqB8ERERLIqW8+QJwC1keVa4GpoabIeCgwzs88AHwP+PdFJIk3aNWZWU19fn+gwERGRwMtWL+tyoCGy3AAMgpYm65nJnsTdFwILAUKhkHdxjCIiIhmTrQr5AFAaWS4F9mcpDhERkUDIVkLeAIyJLI+OrIuIiBSspBOymV3cmQuZWQgoAyYBy4AKM5sGVAAPd+bcIiIiuS6VZ8grzWwi8HfAc+6+L5ULuXsNEDt1zR3R86ZyHhERkXyUSpN1P+BW4GLgX83sY+kJSUREpPCkUiHvBv7Z3esAzGx6ekISEREpPKlUyHcAz5jZDDMbQeRVJREREem8pBOyuz8D/CMwHrgXqEtXUCIiIoUm1YFB/gwsAV5z90NdH46IiEhhardCNrNvm9kGM6sGNgE3At81s0+kPToREZECkUyF/N+BTwEfBTa6+5cBzOzKdAYmIiJSSJJJyNvc3YH/MrO3Yrb/I/Dr9IQlIiJSWJLp1HWXmX0YwN13x2z/a3pCEhERKTztJmR3P+zutQBm9vcx278Xuy4iIiIdl+rkEre2sy4iIiId0NnZnqxLohARESlwSb2HbGazCPeyrjSzf4tsXg14ugITEREpJEklZHdfBCwys1+7+5ei283s62mLTEREpICoyVpERCQAUk3IS9tZFxERkQ5IKSG7+y/aWhcREZGO6WyTtYiIiHQBJWQREZEAUEIWEREJACVkERGRAEg6IZvZ+Fbrk7s+HBERkcLU7sAgZjYQ+N/AxWb2l8jmbsDFwNquDsjMJgEvufs7XX1uERGRoGo3Ibv7fjP7MfBx4I+Rzc3AjlQvZmaVhOdXPplgf3fgcmCnmf0dcBAY6+4/SfVaIiIiuSSpJmt33w4sAY4RHr/agGmpXCjS5P0i0N3Mis1svplNMbO5ZlYUuU4TcDzykSvd/XfAyUgiFxERyVtJjWUd8RzwFz5ImMOBB5L9sLtvNLP6yOos4E13X2Nm5UA1sKLVR6LDcjoJJrEws9nAbICKiopkQxEREQmcVHpZr3b3qe7+OXf/HPCZTlx3AlAbWa4FroaWJuuhwDDgKTOrAnq4+9Z4J3H3he4ecvdQWVlZJ8IRERHJrlQq5I+Y2Wrg/cj6eUBVB69bDjRElhuAQdDSZD2z1bEvdPAaIiIiOSOVhLwO+HPM+uhOXPcAUBpZLgX2d+JcIiIiOS+VhFwPfIFwM3cR4dee7u/gdTcAY4CNhBP7hg6eR0REJC+kkpAvIpyA/wbYCXwslQuZWQgoAyYBy4B5ZjYNqADuSuVcIiIi+SaVhNwLKCGckEuArxB+FSop7l4D9I7ZdEfk58oUYhAREclLqfSy/jlwAlhKuLl6SToCEhERKUSpJOQB7v57dz/m7ncBb6YrKBERkUITuLGsRUREClFGx7IWERGR+JLq1OXu283sXeAI4WT8BcITP+xLY2wiIiIFI5VnyLcSHsd6GeGRtqamJSIREZEClEpC/gPhV53OcPc7gbfSE5KIiEjhSSUh1xKedanazD5MuEoWERGRLpDKwCCvEk7g4yLrh7s+HBERkcKU6nzIb/DBbE8pzYcsIiIiiaWSkFe7+z3RFTM7Jw3xiIiIFKRszYcsIiIiMTozH/KYLo5FRESkYKXSy/oR4FJgBuFhM3+WlohEREQKUCoJ+SeRn6sJj9J1S9eHIyIiUphSabLe4O6roytmNiUN8YiIiBSkVBLyUDMbD5wEQsBYYE1aohIRESkwyUy/WBFZXAV8AxgF1KEmaxERkS6TzDPk3cB04JC73+ruVwNzgE+nNTIREZECkkyT9XJ3vzd2Q2SOZA0MIiIi0kWSqZB3JNhe0pWBiIiIFLJkEvIFZtYrdoOZnQlc2NmLm1mlmXVrY/9XzOx2M1tjZj07ez0REZGgSqbJ+v8Cm8zsF4Q7c1UAnwdmdebCkR7bzwADzMyAu4CXgQuAe9y92d0fjBx7k7sf68z1REREgqzdCtndnwEmA/0Jd+TqD/yDuz/VmQu7+0agPrI6C3jT3dcAh4Dq6HFmVgX8vjPXEhERCbqk3kN299eAb6Yxjgl8MBRnLXAjsCKyXuXu96Xx2iIiIlmXytCZ6VQONESWG4BB0R1tJWMzm21mNWZWU19fn+gwERGRwAtKQj4AlEaWS4H9yXzI3Re6e8jdQ2VlZWkLTkREJN2STshmNsrMFpvZY2b2XTPr3YVxbOCD6RxHR9ZFREQKRioV8grgt8AdwEvA/+rMhc0sBJQBk4BlQIWZTSPci/vhzpxbREQk16QyucQ6d18cXTGzwdGf7v52qhd29xogtsq+I/JzZarnEhERyXWpJORRZrYaeD+yPtzMrgDOA6q6PDIREZECkkpC/g/gj4C32j6+68IREREpTKkk5D+0Wj8/0oT9n10Yj4iISEFKJSEvAF6PLPcEDgKLEx4tIiIiSUslIU929wPRFTP7fhriERERKUipJOT7w3NAANALOJ/whBAiIiLSSakk5BeAVyLLJ2OWRUREpJNSGRjkIeBSYAbhUbXeS0tEIiIiBSiVhPyTyM/VhDt03dL14YhIvpm1YRazNnRq+nSRgpBKk/UGd18dXTGzKWmIR0TyxKqdq1j/2npq9tZ0+HMTBk9g0aRFLftmbZjFi2+/eNp2kXyQSkIeambjCT8/DgFjgTVpiUpEckq0Ao4myVU7VzHvhXmnHBNNtFcNuwqA9a+t5+iJo5QUl7Qk30nnTjrlcy++/eIpn4+ux25PJS6RIDP31gNvJTjQ7AvAJcBIwh26Frj7O2mMLSWhUMhralL7Ji4inbNq5yruq7mPxqZGACYMngDAieYTKVfGsS4ccCHbDmwD4M6qOwFOS/ChQaFTkjvAVcOuonpEdcsxlUsrAXj1+lc7HEu+M7NN7h7KdhySWoV8pbtfF10xs0FpiEdEckS8Kjhaufbp3qclYUaPKe1eSrM3c/TEUSCcdEuKS9h2YFvLtqgVk1e0nD/2GrGJumZvTUvS79O9T8sxsQk5NtZ420WCJJWE3GRmvwYORdaHARO6PiQRCaLY5t/YZBytYGOfF4/sP7KlWm2dCBM1I7dO8NHPta5+o03fR08cbUnOI/uPBMJJOl7ynffCPFbvXH1K1a0ELUGTSpP1TOCvfDDb06Xufm+6AkuVmqxF0qN1s3RoUKgl8XZ1Ykv1me/MJ2ZSs7fmtGo8up6oU1loUIjFV2jkX1CTdZC0WyGb2aTI4i8Jv4N8PLKuDl0ieSaZzlmxCbCrq8zOdL6Krag379vM9oPbGdV/VLvJWSQo2q2QzawRmO7u68zsDqA70Az0d/dvZCDGpKhCFumcyY9O5o2GN4BwBfnyvpdp9mbg1GbpdCTijortuR0bU7RyhtOr4db7gnQ/2aAKOTiSeYa80N3XRZZ/Fp1gwsy+nr6wRCRdWj8LXv/aerYf3N7SJA0fVMFwas/loCWueM+oIRxzomo4dl+0Y1jQvmhIYUomIb8VXYid7QlQL2uRHBNbBcc2R0eTb/S94FxPTtUjqlvuLfpqVOy+Da9vAGDSuZNY/9p6dhzc0bJPJFuSScgXmFm5u9dFN5jZUMK9rEUkB0Qr4WgyBk7pJZ3PiSjevcU+q64eUc3MJ2aesl8Dikg2JJOQfwS8ZGb/CewBhgCXAx9PY1wi0gmxCaX1s+FoFQynD6SRT6KDlKSidY9yvb8smZTUa09mdg5wA/A3wBvAktiKOQjUqUvk9PGj0/mKUj6pWl7VkoT7dO9DQ1NDy7587/ilTl3BkdTAIO7+JvCDNMciIp2Q6VeU8sktoVtafncj+49k8RWLmfzoZA4cO3DKiGDt/Q4T9foWSUYqI3V1OTOrBLa5+8k2jrkYuMbdf5i5yERyz3019wEwtM9Qrr/4eiWGFMS+wxztBLZ26lqA04bwjP19RmefinaKi+3Zrd+7pCqV+ZC7VGTmqBeB7mZWbGbzzWyKmc01s6LIMSOBRuCMbMUpkgtW7VxFY1MjoUEh1k5dS/WIahZfsVhJIQWJfmfVI6oZ2mco8MEwnlHRsbtjHxGIdFTWKmR332hm9ZHVWcCb7r7GzMqBamAF8BngCBAys7PdfV+WwhUJpGjnra37twKnv+IjXWPt1LVULa9i+8HtcffHPp+PDjyiDmGSqqxVyK1MAGojy7XA1QDu/n/c/V+BmnjJ2Mxmm1mNmdXU19e33i2S16LzA7/49ost1bESQPqM6j+KUf1HnbItNCh02u+99ZSQIskKSkIuB6LdGhtoNeiIu38v3ofcfaG7h9w9VFZWlt4IRQIm+sw4StVxZq3auSruaGDVI6oJDQqx4+AOqpZXUbm0ksqllazauSoLUUouCUpCPgCURpZLgf1ZjEUkp4QGhfRKU4ZEm6Lh1GkhW7tq2FUtU0JGqWKW9mS1l3WMDcAYYCMwOrIuInHMfGIm9UfrW5qpNY1gZtQfDT8WW//aeqpHVLP94HZKu5fG/SIUO8Z2tCe2SHuy2cs6BJQBk4BlQIWZTQMqgIezFZdI0NUfrW8ZeUvN1JmzdupaSruXtlTJ8Z4px7No0qKWAVrUbC1tyWYv6xqgd8ymOyI/V2YyjgUvLUjYc1Ik2+K9R7yncQ+gkbeyITqASKrNz9Hqet4L81i6dWnLO84isYLyDFlEWtlxcMcp//DPfGImkx+dTLM3J2wqlfSKdtiKHb0rGWunruWMbuHhFN5oeIOZT8xUtSynCcoz5KyZc+mcbIcgElfrGYhim6pvCd2SjZCklVQeGVQOrKT+aD17GvckPRSnFJaCT8giuWDVzlUtyVhN1cGRyt8htvNd1fIqavbWMPnRyWq+lhZqshYJsO0HtxN6ONQyjvLQPkOVjLOsKzrSRVs4Dhw70OlzSf5QQhYJqO0Ht9PY1Mjxk8eBcDIuK9EAONlWPaKaCYMndGi+5dhzlHYvbf9AKShqshbJAUP7DFXTZoAsmrSo0+cY1X8UNXtrqFxaqccQAqhCFgmsAT0HUGRFSsZ5KvoqFJw+DKoUJlXIIgGlJJzf1k5dy4eXfZiTfpLGpkZW7VzF0q1L2dO4hyGlQ/T3L0CqkEVEsuSSsy9peT/5vpr7OHDsAM3ezJ7GPae99ib5TwlZRCRLFl+xmMqBlQA0NjXS2NQIQLM3U7O3hqrlVdkMTzJMCVlEJIsWX7G4pUpuram5KcPRSDYpIYuIZFm0Sga4cMCFFFn4n+bjJ49TtbyqzebrmU/MVPN2nlCnLhGRAOhm3SjpXsKKySuoWl7V0nzd1NzE9oPbEybd7Qe3U9K9JJOhSpooIYuIBECv4l6M7DfytO3HTx7nRPOJLEQkmaaELCKSZbHjXMfTq7hXwmPUXJ0/9AxZREQkAFQhi4gEWJEVtTndZnvVteQOVcgiIgFWUlyica4LhBKyiIhIACghi4gEzAvXvaDpGQuQErKIiEgABD4hm9kkM+ub7ThERETSKasJ2cwqzaxbG/u7A5cDSsgiIpLXspaQzWw88CLQ3cyKzWy+mU0xs7lm4YFc3b0JOJ6tGEVERDIlawnZ3TcC9ZHVWcCb7r4GOASoj7+IFLwiK2JU/1HZDkMyJCjPkCcAtZHlWuBqaGmyHgoMi/chM5ttZjVmVlNfXx/vEBERkZwQlIRcDjRElhuAQRBusnb3me7+TLwPuftCdw+5e6isrCxDoYqIiHS9oCTkA0D0pbtSYH8WYxEREVkARHgAAAf8SURBVMm4oCTkDcCYyPLoyLqIiEjByGYv6xBQBkwClgEVZjYNqAAezlZcIiJBUVJcoskjCkjWZnty9xqgd8ymOyI/V2YhHBERkawKSpO1iIhIQVNCFhERCQAlZBERkQBQQhYREQmArHXqEpFgWr7xL/yq9s24+z7z4XO4bnxFhiMSKQyqkEXkFL+qfZNtbx85bfu2t48kTNQi0nmqkEUCavqDLwCw4itVGb/2hYPPPO260XhEJD3yJiG/Vv+u/sGQvBKtUlP933U6m5W3vX0kpXjUxC2SvLxJyCKFJpqwLxx8Zsu2jbsPsnH3wU41LW97+8gp54z6zIfP6VB8ySRkPbcWyaOEPKysd1aa9kTSpSNN1m0ltmRdOPjMuMn3uvEVKSXG6Q++kLCibp1ko8+tW38RaOsLhhK15Ju8Scgi+aYjXzBTTZrplKiijpdko8m49T0n+oLRFS0BsXEG5XcmhU0JWUTSItGXg3hJNtWqvCtaAiD1xJ5K8u5IjPpyUNjM3bMdQ5cIhUJeU1OT7TBEJIekkjQ37j4IwPjz+mfk+M37NgNwydmXtPvZC//bmdx1zUVJXac1M9vk7qEOfVi6lCpkESlYqTTxp1rxjj+vf9oragg3979x4N0OJ2QJDlXIIiIBVLU8/Dz9hevS+zqnKuTg0EhdIiIiAaCELCIiEgBKyCIiIgGghCwiIhIASsgiIiIBoIQsIiISAErIIiIiAaCELCIiEgBKyCIiIgGQNyN1mVk98Ea240jCQGB/toNIA91XbtF95ZZ03tdQdy9L07klBXmTkHOFmdXk4zB1uq/covvKLfl6X3IqNVmLiIgEgBKyiIhIACghZ97CbAeQJrqv3KL7yi35el8SQ8+QRUREAkAVsoiISAAoIYuIiASAErJIB5lZsZnp/0M5wMwmmVnfbMfRVfLtfiRM/5ikgZlVmlm3FI6vNrPLzOybZlacztg6owP39RUzu93M1phZz3TG1hkduK9+ZrYA+Ja7N6cxtE7pwH1dZGazzew76YyrszpwX92By4GcSGDt3V+u3Y8kTwm5i5nZeOBFoHukgppvZlPMbG4b1dTUyGfeBcZkKtZUdOS+3P1Bd78H+A93P5bRgJPUwb/XOGAw8HbGAk1RB/9efwD+CBzOZKyp6OB9NQHHMxpoByVzf7l0P5IaJeQu5u4bgfrI6izgTXdfAxwCqgHMbLqZPRz9D/gXYDpQBfwlC2G3qyP3ZWYTzawK+H12om5fB/9ex939i4QTcyB19O8FvARcmpWgk9CJ+8oJydyf5C8l5PSaANRGlmuBqwHcfYW7z4j573fADuA/3b0+wbmCJJX7qnL3wCbkVpK6L2CImV0JPJulOFOV7H31Bz4G/Ht2wkxZsvf1IjAUGJadMDss7v1Fmqxz8X6kHYF9XpknyoGGyHIDMCjeQWZWBtS5e02mAuukpO4LwN3vy0hEXSOp+3L35RmLqGske1+/ylhEXSPZ+2oCZmYqqC4U9/5y+H6kHUrI6XUAKI0sl5JgtpYcqYpjJXVfOUj3lVvy9b6i8v3+pBU1WafXBj7opDU6sp4PdF+5RfeVm/L9/qQVJeQuZmYhoAyYBCwDKsxsGlABPJzN2DpD95VbdF+5Kd/vT9qmsaxFREQCQBWyiIhIACghi4iIBIASsoiISAAoIYuIiASAErKIiEgAKCGLiIgEgBKyiIhIACghS0Exs8lm5mb2P83sq2b2QzO7OYPXX2JmXzezoZFp9dzMrmp1zGoz22RmQ+N8/mIze8PM7o9MMoCZfcLMnjKzs83sU2b2eoZuR0S6kMayloLi7mvNDHf/5+g2Mzsvw2Gsdfc3gDfM7M/AN4D1kVj+G+GRml6NHHMKd99qZncDn4lMMgDQC/iOu+8DnlRCFslNqpCloJnZNHffbWZXmtl/mNk3zazWzM4xsxIz+5qZfcPMFpnZWWb2czP7rpltNLOeZvYzM7vezN4xs6lmdmekWj3DzK4xs+vbCWEVMMbMRkXWq4GVMfFdamYzI9efHNn8c+BSMzs/sn5pDk1xKSIJKCFLQYok3m8DN0U2/REY4O4/JjzP8d8CXyJcfe4FekT+c+A1oAo4Dxjh7ksJD/z/FHAPcA7QHRgC/L92QjkOLAJuNrNukWu8G7P/VuA94BXgIwDufhT4N+CmyNSduTZbmIjEoSZrKUiRxIuZrY/Z/H7k53HgDOAi4KfuvhX4ReT4ZuCQuzcDfzSzp83s08A/u/uRyDE/B74IFLn7iSTC+RnwB+AlYC0wPmbfOe7+izif+SlQA+wDFidxDREJOFXIUtDc/Q9mNiXB7j3A9QBmdqGZjYzdaWa9gP3u/pi7Pxez61+BbwO1bV3bzIxw0n4LeBKodvc/tjpsgJlVRo5viTPyfPl3QCjy7FhEcpwqZCkokWoWM/su8A5wPnAW0AwMNrMhhOee7QHcDfzSzH4HPAosAYYTfn77NOFm6a+Y2WzCX27/yd3XuftBM1sH/Fc74fwPYKKZ/Q1wf+T6fYGPAx+OdDa7DVhjZlsIN4fH+gnQr8O/DBEJFE2/KNJBZnYDsN3dX4y8gnQV8DTh5u7r3P3+OJ9ZAnzf3XenMa7fuPvH03V+EUkPVcgiHWfAj81sM7CZcO/oe4FxwCcTfOZ54O/N7OmuTspm1gP4e8Id1EQkx6hCFhERCQB16hIREQkAJWQREZEAUEIWEREJACVkERGRAFBCFhERCQAlZBERkQD4/0es577CEH3TAAAAAElFTkSuQmCC\n",
       "text/plain": [
        "<Figure size 432x288 with 1 Axes>"
       ]
      },
-     "metadata": {},
+     "metadata": {
+      "needs_background": "light"
+     },
      "output_type": "display_data"
     }
    ],
    "source": [
-    "univ3101.plot(['infTot', 'infFlx', 'infMicroFlx'], legend='right');"
+    "univ0.plot(['infTot', 'infFlx', 'infMicroFlx'], legend='right');"
    ]
   },
   {
@@ -1016,17 +1071,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 39,
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZMAAAElCAYAAAAhjw8JAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvOIA7rQAAIABJREFUeJzt3Xt8VNW5N/DfkxsBAgEk3AIkXIIhAQGJ4oVTL2iLWopiKcihr4K3A699j2hbQHmp2tNiPy3VeooXFEFfqlJBRLyglooai7xcFYgJ15BwCRLAQEhIzMxz/piJjCHJ7J2998zsmd/385kPmT177XlWZjZP1tp7rSWqCiIiIiviwh0AERG5H5MJERFZxmRCRESWMZkQEZFlTCZERGRZQrgDCJXNmzd3SUhIeAHAIDCJEhEF4wWwo66u7q7hw4d/HWznmEkmCQkJL3Tr1m1gWlraybi4ON4PTUTUDK/XK8eOHcspKyt7AcBPgu0fS3+hD0pLSzvFREJEFFxcXJympaVVwNebE3x/h+OJJHFMJERExvn/zzSUJ2IpmRARkUOYTIiIyLKYuQDfEmP/mn8hAKy6b2RRuGOh4LxeL2bMmNHjsssuO1NeXp5QWVkZN3v27GPhjitqLLzmQgDAPR/xfHCBUJ8PbJmEUFFRUVJWVlZu4LYHHnigx9y5c7s2V27YsGHZzkYWXFVVlQwePHjghRdemNO/f//cGTNm9Kh/bfz48ZmdOnUa0rBuy5cvb5+ZmTmod+/egx566KFuga81VcaohISE4ZmZmYOys7NzsrOzc375y192/+yzz9pcffXVlRs3bmxbW1srCQkJWl5eHt+yGpPTeD747NmzJ3HEiBED+vbtm9u/f//c3/72t13MxhMJ5wOTiQts3bq10OoxvF4vPB5Pi8snJydrfn5+UVFRUcHOnTsL1q5d237t2rVtAWDq1Knlb7311u7A/evq6jBjxoze77777q5du3btXLFiRafNmzcn17/eWBkzHn744YNZWVnVBQUFBYWFhQV/+tOfjmRnZ9c899xznWtqaiQ/Pz/lk08+adexY8eWV5oiUrSdD4mJiZg/f/7Bffv27dy4ceNXixYt6hJ4rhgRCecDk0mEKCoqSurbt2/uxIkTM/r375975ZVXZlVWVgoAtGnTZhgATJs2Lf3xxx9Pqy/zwAMP9PjNb37TFQCefvrpToMHDx6YnZ2dM2nSpIy6urrvjjl58uTeubm5OXv37k26+uqr+1944YU5WVlZuc8//3zHpso2FBcXh9TUVC8A1NbWSl1dnYgIAOCGG26oTEtL+16hdevWtc3IyKjJycmpTU5O1nHjxp1Yvnx5h/rXGytjxqOPPnq0devW3pkzZ3av35aWluZZs2bNvgULFhxauXJl8erVq/fHx7Nh4kaxdD5kZGR8O3LkyCoA6Nixo7dfv37VJSUlSWZ+X5FwPsTkNZNfLf+i166y022C7bfn68rWwLlrJ80Z0K1d1R9/OqTUSlwlJSXJS5cu3XfFFVccuPHGG/u+/PLLHadPn36i/vXJkyefuP/++3vPmjXrGACsWrWq45o1a3Zv2bIlefny5Z02bdpU2KpVK508eXLvZ5999oLrr7/+dHFxcfLzzz9fvHTp0pIlS5Z06Nat27fr1q3bAwDHjx+Pb6rsfffdd7xhfHV1dRg0aFBOSUlJq9tvv/3ra6+99kxTdSktLU1KT0+vrX/es2fP2g0bNqRY+f009MorrxQPGjQod9SoUadHjx5daeexY8qb/7sXvi4Iej6gfFdrAOeunTSnS04Vbl7A88HP6PlQVFSUVFBQ0Oaqq64y/X0O9/nAlkkI1f/l0tT29PT0miuuuKIaAIYNG1ZVXFzcKnC/K6+8svr48eMJxcXFievXr2+dmprqycrKql2zZk27HTt2tBkyZMjA7OzsnPz8/Pb79u1rBQDdu3evHTVq1BkAuPjii6s//fTT9tOmTUtfs2ZNygUXXOBprmxDCQkJKCwsLCgpKflyy5YtbTdu3NhkU7yxRddExNZxPtu2bWvt8Xhw6aWXVtl5XAoNng/fPx8qKirixo0b1+/xxx8v7dSpk7eZX12jwn0+xGTLxGgLwu67ubp27VpXUVHxvXbmiRMn4vv06VMDAElJSd99ueLj47W6uvq8ZD9mzJiTS5cu7VhWVpZ46623ngAAVZXx48cfX7BgwaHAfYuKipLatGnz3ZfyoosuqtmyZUvBihUrUh9++OH0f/zjH6c6duzoaaxsczp37uwZOXLk6dWrV6decsklZxvbp3fv3rWHDh36rql+8ODBpB49enxr9D3mzZuX9tJLL6UBwJo1a3ZnZmZ+r2x1dbVMnTo18y9/+UtJS048CmC0BWHz3Vw8H86dDzU1NXLTTTf1Gz9+/Inbb7/9m4bl3XA+sGUSQqmpqd4uXbp8u2rVqnYAcPTo0fh169alXnvttYabpD//+c9PrFixotPbb7/dcfLkyScBYPTo0afefvvtjocOHUqoP+6uXbvO63MtLi5ObNeunXf69Okn7r///qPbtm1rY7Ts4cOHE+rvBKmsrJR169a1HzhwYKMnDgBcddVVZ4qLi5MLCwuTzp49K2+88UanW2+99byTpCmzZ88+VlhYWFBYWFjQ8MQBfP3jw4cPPzNu3LhTwY41YcKEDKPvS6HD88F3Pni9XkycODFjwIABZx955JGjjZV3w/kQky2TcHrppZf2T58+vffMmTN7AcDMmTMP5+bm1hQVFRm64JaXl3f2zJkzcV27dq3NyMj4FgCGDx9+ds6cOYdGjRo1wOv1IjExUZ966qmSnj17fu9Lt3nz5tazZ8/uGRcXh4SEBH366acPNFV2wIABtYFlS0tLE++4444+Ho8Hqipjx449cdttt1UAwJgxY/p8/vnn7U6ePJnQtWvXi2bNmnV4xowZ5fPnzy8ZPXr0AI/Hg0mTJpXn5eV9d7I1Vcbo73HhwoXdevXqVZOdnZ0DAJdddtnpJUuWlD744IPdT5w4kdChQwfPE088cbiyslL27NmT/MADD/TYtWtX8pNPPlk6Z86cHu3bt/fceOONFTfffPNpo+9J9uP5AHz44Ycpb7755gVZWVnV9d/nRx999NCECRMqjP4eI+F8kMb68qLRF198UTxkyBDD/1kBHLToNvv370984okn0uLj47Fx48a2+fn5uz/88MO269evbzt37tyvJ02alHHddded+uijj9rNnTu3LCsrqzb4Uek7HLToKnadD1988UXnIUOGZAZ7P7ZMmsEk4i6//vWv0xcuXFhy5MiRhIMHDyYBwPr169sOHTq0GgCqqqripk6denLYsGHV9957b+9FixYd6NOnj+HrODGPScRVQn0+MJlQ1MjJyal+7LHHuh0/fjxh6NChVQBQUFDQuqysLPG1117reNddd5VPmzYt3ePxSM+ePWt79OjR4nEuRJEu1OcDu7mIiKhJRru5eDcXERFZxmRCRESWxVIy8Xq93saH3BIR0Xn8/2caGgQZS8lkx7Fjx1KZUIiIgvN6vXLs2LFUADuM7B8zd3PV1dXdVVZW9kJZWdkgxFYSJSJqCS+AHXV1dXcZ2Tlm7uYiIiLn8C90IiKyjMmEiIgsYzIhIiLLYuYCfOfOnTUzMzPcYRARucrmzZvLVTUt2H4xk0wyMzOxadOmcIdBROQqInLAyH7s5iIiIsuYTIiIyDImEyIisozJhIiILIv6ZCIiY0RkYUWF4eWUiYjIpKhPJqq6WlXvSU1NDXcoRERRK+qTCREROY/JJJjFN/keRETUpJgZtIjy3S1LCmVfAm272B8PEVEUiZ1k0lK1ZwB8He4oiIgiWuwkk85ZwJR3zJdjFxcRUVC8ZkJERJYxmRARkWVMJkREZBmTCRERWcZkQkREljGZEBGRZVGfTDjRIxGR86I+mXCiRyIi50V9MiEiIufFzgj4Ftp5xNc9lhvmOIiIIhlbJkREZBmTCRERWcZkQkREljGZEBGRZUwmRERkGZMJERFZxmRCRESWMZkQEZFlTCZERGQZkwkREVnGZEJERJYxmRARkWVRn0y4ngkRkfOiPplwPRMiIudFfTIhIiLnMZkQEZFlTCZERGQZkwkREVnGZEJERJYxmRARkWUJ4Q4gVPYdO4MJz603Xe6XtR4kxokDERERRQ9DyUREOhnYzauq31iMJ+J4vBruEIiIIp7Rlslh/6O5P9HjAfS2HJFD+qa1xbJ7LzddbuMjbJUQEQVjNJl8parDmttBRLbaEA8REbmQ0QvwRv6kN/9nf6xZfJPvQUQUZQwlE1U9a8c+REQUnUzfGiwiM50IhIiI3CvoNRMR+XvgUwBDAfzBsYiIiMh1jFyAP6Wqd9U/EZFnHIyHiIhcyEg31+8aPH/YiUCIiMi9giYTVd0PACLS2f/8hNNBERGRu5i5AP+iY1EQEZGrmUkmHApORESNMpNMOEkVERE1ii0TIiKyzEwyme1YFERE5GqGk4mq7nAyEKeIyBgRWVhRURHuUIiIopap6VREJE9EVorIFhH5UkS2i8iXTgVnB1Vdrar3pKamhjsUIqKoZXalxb8B+BWA7QC89odDRERuZDaZHFPVtxyJhIiIXMtsMvmNiLwAYC2AmvqNqvqGrVEREZGrmE0mUwBkA0jEuW4uBcBkYsDOI76bAHLDHAcRkd3MJpMhqjrYkUiIiMi1zC6O9bmI5DgSCRERuZbZlslIALeLyH74rpkIAFXVi2yPjIiIXMNsMhntSBRERORqZru5HgNQoaoHVPUAgFMAfmN/WERE5CZmWyYXqeo39U9U9aSIDLM5pojj8SomPLfe8nGqzkzCVYkFvJuLiKKO2ZZJnIh0rH8iIp1gPiG5SmKcID7OngmT93m64uNvef8CEUUfs4lgPoB/ichy+MaX/AznrxEfVRIT4pD17T4sS/ovy8fannQIH3uHAphuPTAiIgPqe1WW3Xu5o+9jKpmo6ssisgnAtfDdyTVOVQsciSxCfNb6GgD2DDTsI0fMtwWJiFzAdBeVP3lEdQIJtLbNjVjb5kYsm2I9q++fO9SGiIiIIo+hv5NFZIsd+xARUXQy2jIZGGTdEgHABUOIiGKU0WSSbWAfj5VAiIjIvQwlE/8ARSIiokZF9RgROzh9Ox0RUTQwuwY8p06xIC5OEGfTAEgiokjSkpUW2wDoBGALgNdU9aT9YRERkZuYHUKnAM4CeB9AL/hGww+xPSoiInIVsy2TQlWt7+paLiJLADwL34h4IiKKUWZbJuUiMrz+iaruApBmb0hEROQ2Zlsm/wfAayKyGcB2ABcB2G97VERE5CpmJ3r8QkSGArgOwCAAHwF41YnAiIhi2SsbSrBq2yHLxyk4cgptk+JtiKh5LZnosQbAO/4HERE5YNW2Qyg4cgo53duHOxRDDCcTEbkUgKrqRhHJgW89+EJVfdex6IiIYlhO9/aWB07bsUqsEYaSiX+w4g0AEkTkQwAjAKwDMEtEhqlqVC+QRUREzTPaMvkpgKEAWgEoA9BTVU+JyB8BbECUr7ZIRETNM3prcJ2qelS1CsBeVT0FAKpaDcDrWHREROQKRpNJrX8aFQD4bpyJiKSCycR+i2/yPYgodpVt9z1cwmg31w/8d3FBVQOTRyKA222Piogoxo3Sz3EltgKLV1k6zotlW3FWkgHssyewJhhqmdQnEgAQkesDtpcD6OZAXEREMe1KbEUmDls+TnFiX2xI/jcbImpeS9Yz+QOAD5t5HhIicjOAmwB0AbBAVT8IdQxEREZseH0+UnavNFWmlx7BPu2OwVOsDel7zH9r8I2WjhKc2bm5GmN6gQ4ReVFEvhaRHQ22jxaRIhHZIyKzmjuGqr6pqncDuAPABLMxEBGFSsrulehVu9dUmQPaDUfiujgUkf3MDFpcDN8U9L1F5EUAUNWpLXzfJQD+CuDlgOPHA1gA4HoABwFsFJG3AMQDmNeg/FRV/dr/8xx/OSKiiFWa1A+5D+Ub3n/n70ciHVUORmQvM91cS/z//huAl6y8qap+IiKZDTZfCmCPqu4DABF5DcBYVZ0H4McNjyEiAuBxAO+p6pbG3kdE7gFwDwD07t3bSshERCGV2z013CGYYjiZqOrHACAip+t/rn/JpljSAZQGPD8I30j7pvwCvgknU0Wkv6o+23AHVV0IYCEA5OXl2RUnEZHzLF4rCbWWXICvDfK8pRq79tJkAlDVpwA8ZdN7ExGRBS2ZNfiy5p5bcBC+pYDr9QRsuC/OhXYeqQAA5IY5DiIio+y4m8suGwFkiUgfEUkCMBHAW2GOiYiIDAhLMhGRVwGsB3ChiBwUkTtVtQ7AfQDeB/AVgL+r6s5wxOdKnIKFiMKoJddMLFPV25rY/i4Aro9CROQykdTN5QgRGSMiCysqKsIdChFR1ApLyySUVHU1gNV5eXl3hzsWAL65doJ0R2V+uw8VcR1CFBERkXVRn0wiyWcYBiD4XVrJWs2J/YnIVZhMQmitXIa1uAzLptzT7H5nH+0RooiIiOxhKpmISCsAtwLIDCyrqo/ZG1b0KqjpjAn+WTybMsfTBR3iqtA2RDERUfRadu/lIXkfsy2TVQAqAGwGUBNkX2pgbPvdwCkA6N7sftVIArzfH8FJRBTJzCaTnqo62pFIHCIiYwCM6d+/f7hDwaQOBZjUoQAI0s21fW4t+sgRU+NGzpRsRUVcB7CDjIjCweytwf8SkcGOROIQVV2tqvekprpnBs6PvUOxX5tvvTSUrNVI9X7jUERERM0z2zIZCeAOEdkPXzeXAFBVvcj2yGLY+3opnqkdg0G1xtsZc7zTeJ2FiMLGbDK5wZEo6HuuSizw/2Q8mfA6C1EEqz0T7ggcZyqZqOoBERkC3wJZAPCpqn5hf1ix7YakbbghaRty751uuMz2uXatBEAUQzYtBrYvd/xtMnEYxVF+RdPsrcH/CeBuAG/4Ny0VkYWq+t+2R0ZE5LCj/1qKlJNfoTixr/FC9a2MJOOdylXeDGyNGxTVy0qY7ea6E8AIVT0DACLyB/hm/2UyISLXKa+sQYlm4E8X/NHx9xo7NN3x9wgns8lEAHgCnnvQ+AqJFGJxcfwYiFqiTVJ8yAb2RTOzyWQxgA0istL//GYAi+wNyV6RNM6EiChamRpnoqp/BjAVwAkAJwFMUdUnnQjMLm4cZ0JE5DYtWQN+M3zTqZBDcrsz8RGRuxhKJiKSr6ojReQ0AA18Cb5Bi+0diS7aTHnHuWObuLOEiMhuhpKJqo70/9vO2XCIiMiNzI4z+YOqzgy2jYgo1Da8Ph8pu1cG3zFAr5o9KBVz8+BR48xO9Hh9I9s4xQoRhV3K7pXoVbvXVJki6YM1ST9yKKLYYvSayTQA0wH0E5EvA15qB+BfTgRGRGRWaVI/5D6Ub6rMJQ7FEmuMdnO9AuA9APMAzArYflpVT9geVaxr4YX6qlpP0FUcGxo7NB2TRvRu0fsREdUz1M2lqhWqWgygFkCFqh5Q1QMAVERedDJAq0RkjIgsrKioCHcojuqc0gptkuJNldl04CTmvfeVQxERUSwxO87kIlX9bgUmVT0pIsNsjslWqroawOq8vLy7wx2Lk7q2S0bXdslYNsX4tBATHl3oYEREFEvMJpM4EemoqicBQEQ6teAY5JSy7aaW+p2rh/EZhgFofhlhIqJgzCaC+QDWi8jr8A1e/BmA39keFZk3+Kemi2TisAOBEFEsMrs41ssisgnAtfCNfh+nqgVBilEo5E3xPUwofiSieyiJyEVMjTMREQFwMYBO/gWxKkXkUkciI+clteU0LERkC7ODFp8GcDmA2/zPTwNYYGtERETkOmavmYxQ1YtFZCvw3d1cSQ7ERURELmK2ZfKtiMTDP3OwiKQB8NoeFRERuYrZZPIUgJUAuojI7wDkA/i97VEREZGrmL2b628ishnAKPju5rpZVSN6CDWX7SUicl5LVlosBFDoQCyOiJUR8ERE4WR01uBLAJSqapn/+f8CcCuAAwAe4WSP7sXJIYnIDkavmTwH3ySPEJEfAHgcwMsAKgBwgieX4uSQRGQXo91c8QGtjwkAFqrqCgArRGSbM6GR07q2S0bXM7uxLOm/DJfZmVQ/nxcXFCKicwwnExFJUNU6+C6+B84MyIke3YrzeRGRTYwmglcBfCwi5QCqAXwKACLSH76uLnKjlszn9fuRDgVDRG5mKJmo6u9EZC2A7gA+UFX1vxQH4BdOBUdERO5guItKVT9vZNsue8MhIiI3MjsCnoiI6DxMJkREZJnZ9UzGi0g7/89zROQNEbnYmdCIiMgtzLZM/q+qnhaRkfANNHgJwDP2h0VERG5iNpl4/P/eBOAZVV0FIKLXMxGRMSKysKKCdzATETnFbDI5JCLPAfgZgHdFpFULjhFSqrpaVe9JTU0NdyhERFHLbCL4GYD3AYxW1W8AdATwK9ujIiIiVzGbTG4C8KGq7haROfCtCV9uf1hEROQmvABPRESWRf0FeCIicl7UX4AnIiLnWb0A3wm8AE9EFPNMJRNVrQKwF8CPROQ+AF1U9QNHIiMiItcwO53KfwL4G4Au/sdSEeEU9EREMc7sKol3AhihqmcAQET+AGA9gP+2OzAiInIPs9dMBOfu6IL/Z7EvHIpKi2/yPYgoapltmSwGsEFEVvqf3wxgkb0hUaSrqvVgwnPrjRcoG4ux7XdjknMhEVGYmUomqvpnEVkHYCR8LZIpqrrVicAoMnVOaYWUk19h7nHjN/FVeWqxtWKQg1ERUbgZTiYiIgB6quoWAFucC4kiWdcrJgPblyPXRJkzBzahDb51LCYiCj8za8CriLwJYLiD8VCky5vie5hQ/Mgwh4Ihokhh9prJ5yJyiapudCQaIiIAG16fj5TdK4PvGKBX7V6UJvVzKCIKxuzdXNcAWC8ie0Xky/qHE4HZhYtjRYCktr4HkUEpu1eiV+1eU2VK0Q2V8R0cioiCMdQyEZH+ALoCuKHBSxkADtsdlJ1UdTWA1Xl5eXeHOxYiMq40qR9yH8oPdxhkkNGWyZMATqvqgcAHgCoATzgXHhERuYHRZJKpqud1Z6nqJgCZtkZERESuYzSZJDfzWms7AiEiIvcymkw2ish51xxE5E4Am+0NiYiI3MborcH3A1gpIv+Oc8kjD75VFm9xIjAiInIPQ8lEVY8CuEJErgFQPy/GO6r6T8cio6jSq3Yvdv5+pOH9vWcrcSSuC374CJfLIXIDs3NzfQTgI4dioShVmXULSk0OQMuQMsRxQmoi1zA7Ap7ItBHjHwTwoKkyZloxRBR+ZkfAExERnYfJhIiILGMyISIiy5hMiIjIMiYTIiKyjHdzUcQyMzaF41KIwostE4pIlVm3mFroKEPKkI5jDkZERM1hy4QiktmxKTu5NDBRWDGZUHTgSo5EYcVuLiIisowtEyJy3IbX5yPFxPxsvWr2oFS6OxgR2Y0tEyJyXMrulehVu9fw/qWt+qMyd7KDEZHd2DIhopAoTeqH3Ifywx0GOSTqWyYiMkZEFlZUVIQ7FCKiqBX1LRNVXQ1gdV5e3nnLDlN0MbsAF+Abz+K7DZmIrIj6lgnFBrODHAHfRd6UnUsdiogotkR9y4RiAxfgIgovtkyIiMgyJhMiIrKMyYSIiCzjNROKaabvAKs9g8rW6Rgx823ngiJyIbZMKGa16A4wlCHF841DERG5F1smFLN4BxiRfZhMiEwy2zUWbatAmp20EfD9zsy2Asld2M1FZEJLusYy4o4iPanKoYhCz+ykjQBQhEysAVt10YwtEyITWto1Fm1TvbRk0sZLHIqFIgOTCZHDKrNuQanJbqHc2u3Azu3YaaYc7zSjMGIyIXJYS1ozLbougTKUeswtX9yi9+HCVdQIJhOiCBSq7rQRtdt9ZZMGGy5T2qo/KrNuMRUbRT8mE6Io0ZLutJ1JgyP62gy5B5MJUZRoSWuGyC68NZiIiCxjMiEiIsuYTIiIyDImEyIisozJhIiILGMyISIiy5hMiIjIMiYTIiKyTFQ13DGEhIgcA3AAQCqACv/mzgDKbTh84DGt7NfU6w23m3le/3Oo6xpsX6N1bWxbY/Vr+LMbPlu31jXYvk5+jwF76svvsfH9MlQ1LWhJVY2pB4CFAT9vsvuYVvZr6vWG2808r/851HUNtq/Ruhqtnxs/W7fW1a7PtiXfY7vqy++x9d9Lw0csdnOtDuMxg+3X1OsNt5t5bnd9zRyvuX2N1rWxbU3Vz22frVvrGmxffo/d+9m2+L1jppurMSKySVXzwh1HKMRSXYHYqm8s1RWIrfq6qa6x2DIJtDDcAYRQLNUViK36xlJdgdiqr2vqGtMtEyIiskest0yIiMgGTCZERGQZkwkREVnGZEJERJYxmTRDRNqKyGYR+XG4Y3GSiAwUkWdFZLmITAt3PE4TkZtF5HkRWSUiPwx3PE4Skb4iskhEloc7Fif4z9GX/J/nv4c7HqdF8ucZlclERF4Uka9FZEeD7aNFpEhE9ojILAOHmgng785EaQ876qqqX6nqfwD4GYCIvqfdpvq+qap3A7gDwAQHw7XEprruU9U7nY3UXibrPQ7Acv/n+ZOQB2sDM/WN5M8zKpMJgCUARgduEJF4AAsA3AAgB8BtIpIjIoNF5O0Gjy4ich2AAgBHQx28SUtgsa7+Mj8BkA9gbWjDN20JbKiv3xx/uUi1BPbV1U2WwGC9AfQEUOrfzRPCGO20BMbrG7ESwh2AE1T1ExHJbLD5UgB7VHUfAIjIawDGquo8AOd1Y4nINQDawvdBVovIu6rqdTTwFrCjrv7jvAXgLRF5B8ArzkVsjU2frQB4HMB7qrrF2Yhbzq7P1m3M1BvAQfgSyja49I9jk/UtCG10xrnyl99C6Tj3Fwzg+xKmN7Wzqj6sqvfD9x/r85GYSJphqq4icrWIPCUizwF41+ngHGCqvgB+AeA6AD8Vkf9wMjAHmP1sLxCRZwEME5HZTgfnoKbq/QaAW0XkGTgzp1W4NFrfSP48o7Jl0gRpZFvQ4f+qusT+UBxnqq6qug7AOqeCCQGz9X0KwFPOheMos3U9DsBtCbMxjdZbVc8AmBLqYEKgqfpG7OcZSy2TgwB6BTzvCeBwmGJxWizVFYit+sZSXQPFWr1dV99YSiYbAWSJSB8RSQIwEcC93Im9AAADmElEQVRbYY7JKbFUVyC26htLdQ0Ua/V2XX2jMpmIyKsA1gO4UEQOisidqloH4D4A7wP4CsDfVXVnOOO0QyzVFYit+sZSXQPFWr2jpb6cNZiIiCyLypYJERGFFpMJERFZxmRCRESWMZkQEZFlTCZERGQZkwkREVnGZEIxT0Q8IrIt4GFkeQLHiUixiGwXkTz/83UiUuKfqLJ+nzdFpDLIcdaJyI8abLtfRJ4WkX7+Ojd7DKJgYmluLqKmVKvqUDsPKCIJ/oFnVl2jquUBz78BcCWAfBHpAKC7gWO8Ct8I6vcDtk0E8CtV3QtgKJMJWcWWCVET/C2DR0Vki7+FkO3f3lZ8CxptFJGtIjLWv/0OEXldRFYD+EBE4vx//e/0ry/yroj8VERGicjKgPe5XkTeMBjWa/AlAsC3MNT3yonIr/xxfSkij/o3LwfwYxFp5d8nE0AP+NavIbIFkwkR0LpBN1fg6ovlqnoxgGcA/NK/7WEA/1TVSwBcA+CPItLW/9rlAG5X1Wvh+88+E8BgAHf5XwOAfwIYKCJp/udTACw2GOtaAD/wL540EcCy+hfEtwRxFnxrYQwFMFxEfuCfafb/49wCTBMBLFNOf0E2YjIh8ndzBTyWBbxW/5f/ZvgSAwD8EMAsEdkG39T9yQB6+1/7UFVP+H8eCeB1VfWqahmAjwDfPOIA/h+Ayf6uqssBvGcwVg98LYoJAFqranHAaz/0P7YC2AIgG77kApzr6oL/31cNvh+RIbxmQtS8Gv+/Hpw7XwTArapaFLijiIwAcCZwUzPHXQzfYk5n4Us4Zq6vvAZgJYBHGmwXAPNU9blGyrwJ4M8icjF8SShiV5gkd2LLhMi89wH8ov6uKhEZ1sR++fCtAhgnIl0BXF3/gqoehm99ijnwrQFuxqcA5uH81sX7AKaKSIo/rnTxrwOvqpXwtaJebKQckWVsmRD5r5kEPF+jqs3dHvxbAE8C+NKfUIrR+PrrKwCMArADwC4AGwBUBLz+NwBpqmpqXW9/N9mfGtn+gYgMBLDen+cqAUwG8LV/l1fh67ab2LAskVWcgp7IQSKSoqqVInIBfBfBr/RfP4GI/BXAVlVd1ETZYgB5DW4NdirOSlVNcfp9KHqxm4vIWW/7Wz2fAvhtQCLZDOAiAEubKXsMwNr6QYtOqB+0COCoU+9BsYEtEyIisowtEyIisozJhIiILGMyISIiy5hMiIjIMiYTIiKy7H8AiwEQBjSOrTUAAAAASUVORK5CYII=\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYgAAAElCAYAAAD+wXUWAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy8QZhcZAAAgAElEQVR4nO3deXhV5bn38e8dkjAFAkIwgETEoogotkSxgscWta1Vah3Avr6tihWsQ9WW6iuWo7X1Eqc6VKkviAPYVqGcoq1WSwUHagsVBGpwgIqCImgCyBQw033+2Cs1xpVk7509Zef3ua5crHHnXuzs/PKsZ61nmbsjIiLSWE66CxARkcykgBARkVAKCBERCaWAEBGRUAoIEREJpYAQEZFQuekuIJFWrFjRJzc3dxYwDIWfiEhz6oCympqai0aMGPFR2AZZFRC5ubmziouLDysqKtqek5OjGzxERJpQV1dn5eXlQ7ds2TIL+FbYNtn2V/awoqKinQoHEZHm5eTkeFFR0Q4iZ1zCt0lhPamQo3AQEYlO8PuyyRzItoAQEZEEafcBcfp9fzv09Pv+dmi66xDJGjO/eigzv6rPVBZo9wEh8M9//rNzTU1NwrZryauvvtpp8uTJfc8888yBc+fOLRwzZswXLrzwwgGtfmGRDJGoz0q0kvWZUkAk2Lx587qb2YjZs2f3ANiyZUuHsWPHHnTttdcWh/3ArFu3Ln/s2LEHJbuuioqKDhMmTBhw3HHHHTJ16tT965cvXry46wknnDCkqqrKAKqrq7nyyiv7zZkzp8e1115bXFtbG7pdS6677rriwsLCo6ZNm1Z02223FZ1//vkDJk+e3Bfgqaee6n7TTTdtufrqqz+cMWNG0eLFi//dr1+/qiQctmSBbPxMbdu2LWfs2LEHHXDAAUecddZZA+vq6lr8fun4TGXVZa6ZYPz48TvPOecczj///I8BiouLa0888cSdX/va13bl5n7+v3vw4MFV8+bNezfZdb355psdZ82a9R7A8ccffwjwIcCYMWP27Lfffv/5lN15551F/fv3rz7vvPM+vvXWW4seeuihnhMnTtzeeLuW3HTTTVuWLVvW9f3338+fPn36JoBnn322AGD06NF7Ro8efciQIUP2nn322dvOPffckpEjR+5J6AFL1sjGz1Rubi6PPfbYux06dGD48OGHvfDCC13HjBnT7GcgHZ+prA2Iq+evHrB2y64uLW337492d4ZIX0RL2x5S3K3y9rOHvxdrLTk5OXTo0IG77rqr9zPPPFM4YsSIPX/84x97Ll269K21a9fmP/30090LCgrqZs2aVbRixYo3n3zyye6bNm3K+853vvPxo48+2nPr1q25NTU1dtddd31w991393rxxRe7VVdX5wwZMmRvcXFxdVlZWefrrrvuw65du9Y13r6+htGjR1cC/OUvfymYMGFCeVO1Llu2rOtll11WDjBixIjK6dOnF02cOHF7PMc8b968d0eMGHHYyJEj95x33nkff+Mb39gNkQ/QihUr3qrf9tJLL90W6+tLGjxx2QA+er3FzxQVazsDRNUP0WdoJd+e3u4+U4899tiGTp06OcDgwYP39enTp8U/vtLxmdIpphQaPHjwJwDTpk3b0q9fv6ply5Z1LikpqZ4xY8b+V111VUVNTY3t27fPtm3b1uGKK66ouPHGG4u7du1aN3jw4H3r1q3rVFtby6BBg6rKy8vznnrqqfWFhYW1lZWVOffee++mnj171oZt39Drr7+e/+CDD/a69dZb+1VWVoaeKvroo4/yCgsLawEKCwtry8vL8+I93l69etX+8pe/3Lh27dqO8b6GSHPa6meqPhwqKyutX79+VcOGDfskmuNN9Wcqa1sQ0f6lX99yePLy0W+1tG20OnXqVFdXV0dOTiR/6+rqyM3NdYD8/HwH6Nixo+/bty+nqKioFiJ/HZx55pnbZs+e3TMvL8/z8vJ48803O99+++0fFBYW1k2aNGl7/XY9evSoBbjiiisqxo4de/CLL77Ybd68ee+Gbd/Q0KFDq+bNm7dh3LhxA1955ZXOJ5xwQmXjbXr27Fmzc+fODgA7d+7sEM1ppWnTphUtWrSoe79+/arnzJmzsX757t27raysrNNNN930IcCuXbtyunXr1vLJVslM0f6lX99ymPS8PlM0/5l68MEH97vjjjs+aLxPpnym1IJIgkMOOWTv6tWrO9XPv//++/klJSXVLe33gx/8YOs999xTfNRRR+0F6N+/f9Wvf/3rXhBpxm7evPkzgV5WVtbxpZdeWjds2LC9M2bM2K+l7esVFhbWHHrooaF/sZx88sk7X3311c4AK1eu7HzyySfvbKnuKVOmlD/33HNvN/xBBrj99tv7XH755VsrKytt586dOXfccUdR430rKyttypQpxS19D2nfsvEzNXfu3MKzzjprR2FhYd3atWvzG+6TKZ8pBUQSTJ8+feM111zTf/LkyX1/8pOf9B01atSevLw8Vq5c2Xnjxo35b7/9dt769es7rlq1qvPzzz/fZefOnR3Kyso6Dhw4sPpb3/rW9lGjRu0FmDp16pbZs2cXHXfccYe8/fbb+X379q1ZunRplw0bNnTcsGFD3hNPPNHjzjvv7J2bm+snnXTS7rDt62v60Y9+1G/cuHEDH3/88cLTTjttR3FxcS3ASy+91GXbtm25CxYs6A5w2WWXbd24cWP+rFmzem7cuDH/kksu2Rq2XUumTp26/89//vMDevfufVTXrl2/VFhY+MXFixd/bl8zY8+ePfo5lGZl22dq5syZPa+88soDTzjhhEMHDRp0+B/+8IfClv4P0vGZMvfsGZli9erV7w4fPrwiln2ScYpJmvfBBx/kPv30093eeOONzoMGDfpk06ZNeXv27Mn53ve+t61Hjx51jz32WI9+/fpVX3TRRTF3jksGSMIpJmleaz5Tq1ev7j18+PCBYa/b7v9ye/Ly0W8pHFJr6tSpfSdMmLB9165dOW+99VanSZMmbS0sLKzt2rVr3QEHHFD9yiuvdL3gggsUDm3VpOffUjikVrI+U+0+ICT1ampq7Nlnn+22d+/enMrKypyNGzfmlZaWVg4dOrTq5ptv7lNaWrpHp51Eopesz1S7P8UkItKe6RSTiIjETAEhIiKhFBAiIhIq2wKirq6uLqrRRkVE2rvg92WTd2JnW0CUlZeXFyokRESaV1dXZ+Xl5YVAWVPbZNVYTDU1NRdt2bJl1pYtW4aRfeEnIpJIdUBZTU3NRU1tkFWXuYqISOLor2wREQmlgBARkVBZ1QfRu3dvHzhwYLrLEBFpM1asWFHh7p8bNhyyLCAGDhzI8uXL012GiEibYWYbmlqnU0wiIhJKASEiIqEUECIiEkoBISIioRQQIiISSgEhIiKhFBAiIhJKASEiIqEUEAAPnxr5EhGR/1BAiIhIKAWEiIiEUkCIiEiorBqsj4p18fUlbPkXdO2T+HpERNqw7AqIeFXtAT5KdxUiIhkluwKi92CY8HTs+00bkPhaRETaOPVBiIhIKAWEiIiEUkCIiEio7OqDiFfxkemuQEQk46gFISIioRQQIiISSgEhIiKhFBAiIhJKASEiIqEUECIiEkoBISIioRQQIiISSgEhIiKhFBAiIhJKASEiIqEUECIiEkoBISIioRQQIiISSgEhIiKhFBAiIhIqZQ8MMrNc4AbgVeAw4BZ3rwvWjQGGAQYsdfdlDfabD/zE3d9NVa0iIpLaJ8pNBDa5+wIzKwbGAXPNrANwG3B0sN0iYAyAmZ0BdExhjSIiEkjlKaZjgVXB9Crg1GC6BKjwAFBtZoPM7IvAe8DWFNYoIiKBVAZEMbArmN4F7B+yvOG6L7j78pZe1MwmmdlyM1teXl6eyHpFRNq1VAbEVqAgmC4AKkKW1687CfiumT1B5HTTTDPrH/ai7j7T3UvdvbSoqCg5lYuItEOp7INYCAwHlgFHAgvNrI+7rzWzbmZmwXYF7v6L+p3M7BHgZ+6+KYW1ioi0e6lsQcwBSsxsPJF+hzLgvmDdFGBy8DUlhTWJiEgTUtaCCC5pnRrMzgv+HR+sWwIsaWK/C5JenIiIfI5ulBMRkVAKCBERCaWAEBGRUAoIEREJpYAQEZFQCggREQmVyhvlMtaazTsAODzNdYiIZBK1IEREJJQCQkREQikgREQklAJCRERCKSBERCRU1Fcxmdn1LWzyL3d/opX1iIhIhojlMteORJ7p0JShraxFREQySCwBMcfd32pqpZl9lIB6REQkQ0TdB9FcOATr32h9OSIikilabEGYWXegR4NFg9z9haRVJCIiGSGaU0wjga8CnwTzJcALySpIREQyQ4sB4e5/NbPn3b0GwMw0fpOISDsQVR9Eg3AYVT8tIiLZLdYb5S5OShUiIpJxYg0IS0oVIiKScTTUhoiIhIo1IP6UlCpERCTjxBQQ7j6vftrM8oOvYxJfloiIpFvMl6ya2W+B44EaIn0ShcB+Ca5LRETSLJ57Gt5395L6GTMbkMB6REQkQ8QTEEvM7DKgOpg/HLgycSWJiEgmiCcgpgAv8unQG4WJK0dERDJFPAGxwN3vqJ8xs+IE1iMiIhkinoD4upmN59NO6iLgCwmtSkRE0i6egJgOrAbqgvnhiStHREQyRcwB0fC502aW6+4bEluSiIhkgpiH2jCzh8xsQjB7uJl9O8E1iYhIBohnLKYl7v4wgLuvBn6c2JJERCQTxNMH0cXM+gEfA98Duia2JBERyQTxBMRDwDVAKfA+cGY0OwVPorsBeBU4DLjF3euCdWOAYUSuilrq7svMbBxwGnAwMM7dN8dRq4iIxCnqgDCzr7j7C+6+F7gxZP1J7v5cMy8xEdjk7guCeyfGAXPNrANwG3B0sN0iMzsZWOfu55vZVcG6P0Zbq4iItF4sLYhbzOz1JtYZkVNOzQXEscD9wfQq4BJgLlACVLi7A5hZNXCgu68KWh1FwIwY6hQRkQSIJSDOaWH97hbWFwO7guldwP4hy/+zzszeAc4Dzgb+DTwc9qJmNgmYBFBSUhK2iYiIxCHqgEjA/Q5bgYJgugCoCFn+n3VBi+IhM3uOSMsjNCDcfSYwE6C0tNRbWaOIiATiuQ9iWJzfayGf3nV9JLDQzPq4+1qgmwWAAndf12C/KqAszu8pIiJxiuc+iHlm1svMzjSzPjHsNwcoCcZxKiHyS/++YN0UYHLwNSV4/dVmdh7wDeAXcdQpIiKtEM9lrj2J/CLfB3zXzH7p7i+3tFNwSevUYLb+0aXjg3VLgCWNdtEYTyIiaRRPQLwD/MrdtwCYWUud1yIi0gbFc4ppKrDYzL5rZofw6dVIIiKSRWIOCHdfDJwFjARuB7YkuigREUm/eE4xAbwNPAKsd/ftiStHREQyRdQtCDO72swWBmMkrSByJ/RPg3GUREQky8TSgjgZ+DpwHLDM3S8CMLNTklGYiIikVywB8Xpwd/PLZvZBg+VnAc8ktiwREUm3WDqpbzCzowDc/Z0Gy99PbEkiIpIJog4Id9/h7qsAzOzEBst/1nBeRESyQzz3QUDkTurm5kVEpI2LNyAaswS9joiIZIiY7oMws4lErmI6wsweChbPBzTMtohIlokpINz9AeABM3vG3S+sX25mlye8sjisL9/DOTP+EfN+P6mqJS9HjSARkYbivZO6sTb927W2Tg0gEZHG4g2I2S3Mp8Wgoq7MvfjLMe/3ys/adL6JiCRFXJ3U7v54c/MiItL2JeoqJhERyTIKCBERCaWAEBGRUAqIRHv41MiXiEgbF/NVTGbWCRgOdAwWHenu9yW0KhERSbt4LnP9G7AR+CSYHwwoIEREskw8ATHf3W+pnzGz/gmsR0REMkQ8AXG0mc0HqoL5g4DY704TEZGMFk9APA283WB+eIJqERGRDBLPVUyPAccA3wWGAfcntCIREckI8QTEPcG/84FtwI8TV46IiGSKeE4xLXT3+fUzZnZGAusREZEMEU9AHGhmI4FaoBT4ErAgoVWJiEjaxRMQjwDXAUOA14BrElmQiIhkhpgDwt23ApPr581sEPBxIosSEZH0i7qT2sx+a2Z5Znalmb1jZuvN7B1gRRLrExGRNImlBXGtu1eb2UJgtrt/DGBmRyenNBERSaeoWxDu/l4w2b0+HAL7J7YkERHJBFG3IMysN3ATMMzMNgaLOxC5We6pJNQmIiJpFHVAuHuFmd0NfAV4I1hcB7wVzf5mlgvcALwKHAbc4u51wboxRILGgKXuvszMvgP8kEgL5Tx3/3u0tYqISOvFdCe1u79JZJiNQe7+IrATOC7K3ScCm9x9AbAdGAdgZh2A24B7gV8B08ysM1Dr7qOA64H/jqVOERFpvXiG2lji7g8DuPtqoh9q41hgVTC9Cqh/7FoJUOEBoBoYAPxPsH4lsDWOOkVEpBXiCYguZtbPzLqY2cVA1yj3KwZ2BdO7+LRzu+Hy+nW96k8/Af9FpIURyswmmdlyM1teXl4e9UGIiEjz4gmIh4icLppLZKjvM6PcbytQEEwXABUhyz+zLrgJb6O7/6upF3X3me5e6u6lRUVFUR+EiIg0L547qfcCNwKYWa/gzupoLCQSKMuAI4GFZtbH3deaWTczs2C7AndfZ2Z9gCHu/ufgOdjd3f2jWOsVEZH4xNyCMLOfmdnvgtkhZnZulLvOAUrMbDyRfocyPn2W9RQiw3dMBqaYWRfgSeA2MysDXiEytLiIiKRIPIP11QBPALj7y2Z2A/C75neBoE9hajA7L/h3fLBuCbCk0S56jKmISBrFExBbgY7BX/kXADrxLyKSheLppJ5PpA/h98G/0XZSi4hIGxLLaK4zzOyngAMziPQjfJtIx7OIiGSZWFoQQ4BpRDqL5xEZf+lgYHQS6mqz1mzewZrNO9JdhohIq8XSB/FXd68zs8lAtbtPATCz95NTmoiIpFMsLYh+ZvYM8FMiN8oR3KtwcTIKExGR9IplNNdLzewo4P1gZNd8IuMp6ZnUIiJZKKbLXN19VYPpKuDhhFckIiIZIZ7LXEVEpB1QQIiISKh4xmIaYGaFwQB7l5rZ4ckoTERE0iueFsRk4BMig+8VozupRUSyUjxjMa0BJgEd3f16M/t+gmtKi9o655wZ/2j161TuOZcT8l5HzSoRaeviaUHUX8k0LrjstTiB9aRFXo7RIcda3jAK62v358XqoQl5LRGRlpwz4x8J+eM2TDwtiC1ETi/lAMcRDP3dluXl5jC4ej1z829q9Wu9lr+JF+uOAi5tfWEiImkUbx/EPrKoD+Llzl/l3bxBCXmtg2wzJ+SsanlDEZEMF28fxMVkUR/Eoi7fZFGXbzJ3QuufUfTO9UcloCIRkfSLtw+iDjg76IPom9iSREQkE8QTEK8BnYB7gFHArQmtSEREMkI8AfGr4N/5RJ4N8ePElSMiIpkinj6Ihe4+v37GzM5IYD0iIpIh4gmIA81sJFALlAJfAhYktKoUm3tx6zunRUSyTTwB8RFwDnAo8C/0PIjPyEnQDXciIukWT0Cc4u7n1s+Y2f4JrEdERDJEPAFRHTx6dHswPwg4NnEliYhIJog6IMysJJhcQeRS1zqgDzAw8WWJiEi6xdKCeAe4Fpjh7jsBzKw3cEoyChMRkfSKJSB+5+63N1zg7hVm1j/BNYmISAaI5Ua5t5pY3iURhYiISGaJpQVxmJl1dve99QvMrDughx+IiMTod8s28uSqTa1+ndc376RrfocEVPR5sQTEg8AKM3ucyDMhSoD/C0xMRmEiItnsyVWbeH3zTob27Z7uUpoUdUC4+2IzOw24AjgG2Ah8291XJ6s4EZFsNrRv91aP5JCsp8lBjPdBuPt64Kok1SIiIhkkntFcRUSkHYjnTmpJhIdPjfw74en01iEiaXHi5gcYxUp4uF+rXuehLSvZZ52A9YkprIGMbkGYWb6ZHZbuOkREEm0UKxnIB+kuo1kpa0GYWS5wA/AqcBhwi7vXBevGAMMAA5a6+zIz6wHcAVQQuYNbRCQjLfv9LylYF9tTDwb4ZtZ7X45o5VmEC4NO6rmtepVwqWxBTAQ2ufsCIgP9jQMwsw7AbcC9RJ5WNw3A3T8G/pbC+kRE4lKwbgEDqt6OaZ8NXszmnD5JqigxUtkHcSxwfzC9CriESOiVABXu7gBmVm1mg4IrpkRE2oT38g/m8Oti+Jv24VM5InnlJEQqA6IY2BVM7wL2D1necF1UAWFmk4BJACUlJS1sLSKSIdrABSqpPMW0FSgIpguI9C00Xt54XYvcfaa7l7p7aVFRUUIKFRGR1AbEQmB4MH0ksNDM+rj7WqCbBYACd1+XwrrSYs3mHazZvCPdZYiINCmVATEHKDGz8UT6HcqA+4J1U4DJwdcUADMrBI4DhuuxpkTum6i/d0JEJAVS1gcRXNI6NZidF/w7Pli3BFjSaPsdBH0LIiKSerqTOgkG8kGLf+0PrF7PjpweKapIRCR2CogEe5kvAnB4C9t18r2Rp3qLiGQoBUSCLbJjufeT0xha1bfZ7abWXUKPnEq6pqguEclOrR0uvDkKiAQ7vfs62AnQfEDsJZ+DfHPUHc97Nq5kR04PWjesl4hI9BQQCXZuj9c5t8frMKH5/vX7pg6FHOga5aWuB9bVUus1iShRRCQqCog02ZdbwC+qL6BLry9Gtf3kTVfS2asYkOS6RLLO8ofhtflJ/RYDq9bxbha27xUQaXJK/ipOyV/F4RdfGtX2r11fleSKRLLTh3//DQXb3+DdvEHR71S1J/JvfnS9hJV1B7IyZ1iLF6e0NQqINiInx9JdgkibVLH7Ezb6gdzR6/akfp/Tj+qf1NdPBwWEiGS9Lvkdknq1T7ZSQCRalCM0Ht63MLbXjbKpKyKSKAoIEWkz4npy2yf/5j1r/rJzCaeAaEMqq2o5J3i8YLROP6o/547UczIkO9Q/ue29/IOj3ue9jl9g9+AzklhV9lJApEuMDwvpXdCRgu1vcP3Wq6Pep3JfFSs3D4ORD8VanUjGivnJbRI3BUQbsf9x34XX5sd0Gd2eDcvpQnXSahKR7KaAaCtKJ0S+YvDuzaOTVIyItAepfGCQiIi0IQoIEREJpVNMWW5A1dusifFU0+7BZzBy3OQkVSQibYVaEFls9+AzYrocECKBEut15iKSndSCyGKRVkBsLYFYWxsikr3UghARkVAKCBERCaWAEBGRUOqDkM/RmE8iAgoIaURjPkmqxDUya4wD9UnrKCDkM+Ia82njSrrk5SetJslOcY3Mmn+wRmZNIQWEfFacYz7phjyJh0ZmzWwKCGm13YPP4L0YTxUcXvUarHmNNTHup1ARSR0FhLRaPDfkxf1ksDW/AQVExlF/QnZSQEhaxHuXt05lZSb1J2QnBYS0Gak8lZWpUhF2rWkNqD8huyggpM1I1amsTJWqsBtZ9RoAa/KPiHoftQayk7l7umtImNLSUl++fHm6yxBJilSGnU7LtR9mtsLdS8PWqQUh0kbE04ISaQ2NxSQiIqEUECIiEiplp5jMLBe4AXgVOAy4xd3rgnVjgGGAAUvdfVnYslTVKiIiqe2DmAhscvcFZlYMjAPmmlkH4Dbg6GC7RWZ2cuNlwJgU1ioi0u6l8hTTscCqYHoVcGowXQJUeACoBgY2XmZmg8Je1MwmmdlyM1teXl6e3CMQEWlHUhkQxcCuYHoXsH/I8vp1fUKW7U8Id5/p7qXuXlpUVJTYikVE2rFUBsRWoCCYLgAqQpbXr9sWsqwCERFJmVQGxEJgeDB9JLDQzPq4+1qgmwWAAnd/K2TZuhTWKiLS7qXsTmozywF+DvyLSEAsAP6fu483s+OBkcGmy9x9SdiyKL5HObABKAR2BIt70/rWR8PXa822Ta0LW954WcP5pqYTcazN1RnrdtEcV9iypo6v4Xyqj7WlbaN9b2OZ189x62TSz3Hj+Uz6OT7Q3cPPz7t71n0BMxtML0/k67Vm26bWhS1vvKzRMTU13epjjeV4W9oumuOK5Vgbzqf6WBP13sYyr5/j7Pk5bup4M+3nuPFXtt4o96c0vl5z2za1Lmx542V/imI6UaJ9zZa2i+a4wpY1d3xt/b2NZb6tH2vYsvb6c9x4PlPf28/IqsH6wpjZcm9iIKpso2PNXu3peHWsmSNbWxANzUx3ASmkY81e7el4dawZIutbECIiEp/20IIQEZE4KCBERCSUAkJEREK1+YAwsyOCEWFj2WeYmU1JVk3JFOvxmtnhwYCGbe544zjWo83sF2b222TWlUnM7Gtm1iPddcSrpffYzE43s+PN7MpU1pVOmfSetumAMLORwFIgz8xyg18OZ5jZdcGd22H7HArsBjqmstZEiOd43X0N8AbR32WZEeI5VqDM3f8b2Ji6ShMnjkDMA74KZMQvk1hF+R6f4pFRFGrN7Ij0VZsYUQRiRr2nbfqZ1B55sFD9GN9NPW/iHGBsg93WAR8CpcFYUB+ltur4xXm8M4B/At8Hfp3Sglsh3mM1sy1k+KWDYYJflouBXsH4Y6EP12rI3avN7JPUVpo40bzHRB4YBuDBV5sVzXucae9pmw6IRo4F7g+mVwGXAHPdfS6RH7TPMLPithQOIaI6XjM7HRgF/E/KK0ycaI/1bOAc4GMze8DdN6S80ji1IvyzReh7DDxnZl8G8t29LF3FJUKUgZhRsikgmnreRCh3/1myC0qyqI7X3Z9MWUXJE+2xzgfmp6qoJIo2EPOAC4FBwLsprjHRQt9jd/99sOwf6SgqiULf4+A9PZAMeU+zKSCaet5EtmpPx9uejhWiD8RqYEKqikoyvcdk3nvapjupG/nc8ybSWEsqtKfjbU/HCu3vlyXoPc7I97hNB4SZlQJFwNeAOUCJmY0n8pzr36SztmRoT8fbno41RLv4Zan3OPPfY43FJJIBgl+WLwL/B3iKzz5c6wZ3r01jeZIAbfE9VkCIiEioNn2KSUREkkcBISIioRQQIiISSgEhIiKhFBAiIhJKASEiIqEUENLumNlpZuZmdoWZ/cDMppnZD1P4/R8xs8vN7MBgeGs3s2822ma+ma0wswND9h9mZhvM7N5g7B7MbIyZPWdmfczs62b2booOR7JYNo3FJBIVd3/KzHD3X9UvM7ODUlzGU8FosxvM7G3gSuDPQS39iNxh/FrYiG77wHoAAAKBSURBVLTuXmZmNwOnB2P3AHQGpgQjFP9FASGJoBaEtHtmNt7d3zGzU8zsr2Z2lZmtMrP+ZtbFzC4zsyvN7AEzKzSzR83sp2a2zMw6mdn9Zna+mX1sZmea2fXBX/MdzWysmZ3fQgm/B4ab2ZBgfhwwr0F9x5jZhOD7nxYsfhQ4xswODuaPcfdXEvofI+2eAkLarSAIrgYuDRa9AfRy97uB54H/IjKcdmciD5nKD74cWA98GTgIOMTdZxMZT+c54BagP5AHDABaegTqJ8ADwA+Dp43lA3sarJ8M7CUyLMPRAO5eCTwEXGpmRUA5IgmmU0zSbgVBgJn9ucHiquDfT4g8lvZwYHrwsJrHg+3rgO3BU97eMLNFZvYt4FfuvjPY5lHgPCDH3WuiKOd+YA2Rp/89BYxssK6/uz8ess90YDnwEfBwFN9DJCZqQUi75+5rzOyMJla/B5wPYGZDLfJM8/8ws85Ahbv/0d3/1mDV/weuJvIwmCYFj57McfcPgL8A49z9jUab9ap/HnPDOoP+iSVAaRt/OqJkKLUgpN0J/trHzH4KfAwcDBQCdUBfMxtAZITNfOBm4AkzWwL8AXgEGEzk/P8iIqeRLjazSUT+4Ppvd3/a3beZ2dPAyy2U833geDM7ALg3+P49gK8ARwWd59cAC8xsNZHTVw3dA/SM+z9DpBkazVWkFczsAuBNd18aXHL6TWARkdNT57r7vSH7PALc6O7vJLGuF9z9K8l6fWkf1IIQaR0D7jazlcBKIlcf3Q6MAE5qYp+/Ayea2aJEh4SZ5QMnEulwF2kVtSBERCSUOqlFRCSUAkJEREIpIEREJJQCQkREQikgREQklAJCRERC/S/0+ZzZYhaSLQAAAABJRU5ErkJggg==\n",
       "text/plain": [
        "<Figure size 432x288 with 1 Axes>"
       ]
      },
-     "metadata": {},
+     "metadata": {
+      "needs_background": "light"
+     },
      "output_type": "display_data"
     }
    ],
@@ -1055,32 +1112,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 40,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Setting are all defined in 'rc'\n",
     "from serpentTools.settings import rc"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 41,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "dict_keys(['branching.areUncsPresent', 'branching.intVariables', 'branching.floatVariables', 'depletion.metadataKeys', 'depletion.materialVariables', 'depletion.materials', 'depletion.processTotal', 'detector.names', 'results.expectGcu', 'verbosity', 'sampler.allExist', 'sampler.freeAll', 'sampler.raiseErrors', 'sampler.skipPrecheck', 'serpentVersion', 'xs.getInfXS', 'xs.getB1XS', 'xs.reshapeScatter', 'xs.variableGroups', 'xs.variableExtras', 'microxs.getFlx', 'microxs.getXS', 'microxs.getFY'])"
+       "dict_keys(['branching.intVariables', 'branching.floatVariables', 'depletion.metadataKeys', 'depletion.materialVariables', 'depletion.materials', 'depletion.processTotal', 'detector.names', 'verbosity', 'sampler.allExist', 'sampler.freeAll', 'sampler.raiseErrors', 'sampler.skipPrecheck', 'serpentVersion', 'xs.getInfXS', 'xs.getB1XS', 'xs.reshapeScatter', 'xs.variableGroups', 'xs.variableExtras', 'microxs.getFlx', 'microxs.getXS', 'microxs.getFY'])"
       ]
      },
-     "execution_count": 38,
+     "execution_count": 41,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "# Obtain the user defined keys\n",
     "rc.keys()"
    ]
   },
@@ -1088,51 +1143,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The user can modify the settings and only then use the `ResultsReader`"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 39,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The version defined by default is 2.1.30\n",
-      "The version set by the user is 2.1.30\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Change the serpent version to 2.1.30\n",
-    "versionOriginal = rc['serpentVersion']\n",
-    "print('The version defined by default is {}'.format(versionOriginal)) # print the original version\n",
-    "rc['serpentVersion'] = '2.1.30'\n",
-    "print('The version set by the user is {}'.format(rc['serpentVersion'] )) # print the modified version"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 40,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Explicitly state which groups of variables should be stored\n",
-    "# The variables for these groups are defined according to the .yaml file\n",
-    "rc['xs.variableGroups'] = ['versions', 'xs', 'eig', 'burnup-coeff']"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 41,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# The user can state which cross-sections to store\n",
-    "rc['xs.getInfXS'] = True # Obtain the infinite xs\n",
-    "rc['xs.getB1XS'] = False # Do not store the leakage corrected xs"
+    "The `rc` object and various `xs.*` settings can be used to control the `ResultsReader`. Specifically, these settings can be used to store only specific bits of information. Here, we will store the version of Serpent, various cross sections, eigenvalues, and burnup data."
    ]
   },
   {
@@ -1141,13 +1152,37 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Read the file again with the updated settings\n",
-    "resFilt = serpentTools.readDataFile(resFile)"
+    "rc['xs.variableGroups'] = ['versions', 'xs', 'eig', 'burnup-coeff']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Further, instruct the reader to only read infinite medium cross sections, not critical spectrum B1 cross sections."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 43,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rc['xs.getB1XS'] = False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "resFilt = serpentTools.readDataFile(resFile)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
    "metadata": {},
    "outputs": [
     {
@@ -1156,45 +1191,13 @@
        "dict_keys(['version', 'compileDate', 'debug', 'title', 'confidentialData', 'inputFileName', 'workingDirectory', 'hostname', 'cpuType', 'cpuMhz', 'startDate', 'completeDate'])"
       ]
      },
-     "execution_count": 43,
+     "execution_count": 45,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "# Print all the stored variables in metadata\n",
     "resFilt.metadata.keys()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 44,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "dict_keys(['burnMaterials', 'burnMode', 'burnStep', 'burnup', 'burnDays', 'nubar', 'anaKeff', 'impKeff', 'colKeff', 'absKeff', 'absKinf', 'geomAlbedo'])"
-      ]
-     },
-     "execution_count": 44,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# All the variables can be obtained by using 'resdata.keys()'\n",
-    "resFilt.resdata.keys() # contains all the variable as a dict_keys"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 45,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# obtain the results for universe=0 and index=1 (burnup and timeDays are inserted but not used)\n",
-    "univ0Filt = resFilt.getUniv('0', burnup=0.0, index=1, timeDays=0.0)  "
    ]
   },
   {
@@ -1205,7 +1208,7 @@
     {
      "data": {
       "text/plain": [
-       "dict_keys(['infTot', 'infCapt', 'infAbs', 'infFiss', 'infNsf', 'infNubar', 'infKappa', 'infInvv', 'infScatt0', 'infScatt1', 'infScatt2', 'infScatt3', 'infScatt4', 'infScatt5', 'infScatt6', 'infScatt7', 'infTranspxs', 'infDiffcoef', 'infRabsxs', 'infRemxs', 'infChit', 'infChip', 'infChid', 'infS0', 'infS1', 'infS2', 'infS3', 'infS4', 'infS5', 'infS6', 'infS7'])"
+       "dict_keys(['burnMaterials', 'burnMode', 'burnStep', 'burnup', 'burnDays', 'nubar', 'anaKeff', 'impKeff', 'colKeff', 'absKeff', 'absKinf', 'geomAlbedo'])"
       ]
      },
      "execution_count": 46,
@@ -1214,29 +1217,56 @@
     }
    ],
    "source": [
-    "# Obtain all the variables stored in 'infExp' field\n",
-    "univ0Filt.infExp.keys() "
+    "resFilt.resdata.keys()"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 47,
    "metadata": {},
+   "outputs": [],
+   "source": [
+    "univ0Filt = resFilt.getUniv('0', index=1)  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 48,
+   "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "dict_keys([])"
+       "dict_keys(['infTot', 'infCapt', 'infAbs', 'infFiss', 'infNsf', 'infNubar', 'infKappa', 'infInvv', 'infScatt0', 'infScatt1', 'infScatt2', 'infScatt3', 'infScatt4', 'infScatt5', 'infScatt6', 'infScatt7', 'infTranspxs', 'infDiffcoef', 'infRabsxs', 'infRemxs', 'infChit', 'infChip', 'infChid', 'infS0', 'infS1', 'infS2', 'infS3', 'infS4', 'infS5', 'infS6', 'infS7'])"
       ]
      },
-     "execution_count": 47,
+     "execution_count": 48,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "# Obtain all the variables stored in 'gc' field\n",
-    "univ0Filt.gc.keys() "
+    "univ0Filt.infExp.keys() "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{}"
+      ]
+     },
+     "execution_count": 49,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "univ0Filt.b1Exp"
    ]
   }
  ],
@@ -1256,7 +1286,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.2"
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,

--- a/serpentTools/objects/containers.py
+++ b/serpentTools/objects/containers.py
@@ -8,8 +8,8 @@ Contents
 
 """
 from itertools import product
+from collections import namedtuple
 
-from six import iteritems, PY2
 from matplotlib import pyplot
 from numpy import arange, hstack, ndarray, zeros_like
 
@@ -51,8 +51,42 @@ HOMOG_VAR_TO_ATTR = {
     'MACRO_E': 'groups', 'MACRO_NG': 'numGroups'}
 
 __all__ = (
-    'HomogUniv', 'BranchContainer',
+    'HomogUniv', 'BranchContainer', "UnivTuple"
 )
+
+UnivTuple = namedtuple("UnivTuple", ["universe", "burnup", "step", "days"])
+
+try:
+    UnivTuple.__doc__ = """Convenient identifier for universes
+
+Properties can be accessed by position or by attribute name.
+The latter is preferable as it will be consistent across
+potential API changes
+
+Attributes
+----------
+universe : str
+    Universe from Serpent input
+burnup : float
+    Burnup for this universe [MWd/kgU]
+step : int
+    Burnup step
+days : float
+    Burnup day
+
+Example
+-------
+
+>>> x = UnivTuple("0", 0.1, 1, 10.0)
+>>> x.universe
+"0"
+>>> x[0] == x.universe
+True
+
+"""
+except AttributeError:
+    # Can't set docs for namedtuples in PY2
+    pass
 
 
 class HomogUniv(NamedObject):
@@ -121,7 +155,7 @@ class HomogUniv(NamedObject):
                 "Will not create universe with negative burnup\n{}"
                 .format(', '.join(tail)))
         NamedObject.__init__(self, name)
-        if step is not None and step == 0:
+        if step == 0:
             bu = bu if bu is not None else 0.0
             day = day if day is not None else 0.0
         self.bu = bu

--- a/serpentTools/objects/containers.py
+++ b/serpentTools/objects/containers.py
@@ -12,6 +12,7 @@ from collections import namedtuple
 
 from matplotlib import pyplot
 from numpy import arange, hstack, ndarray, zeros_like
+from six import iteritems
 
 from serpentTools.settings import rc
 from serpentTools.objects.base import NamedObject, BaseObject
@@ -203,11 +204,9 @@ class HomogUniv(NamedObject):
     def __str__(self):
         extras = []
         if self.bu is not None:
-            extras.append('burnup: {:5.3f} MWd/kgu'.format(self.bu))
-        if self.step:
-            extras.append('step: {}'.format(self.step))
+            extras.append('burnup: {:11.5E} MWd/kgU'.format(self.bu))
         if self.day is not None:
-            extras.append('{:5.3f} days'.format(self.day))
+            extras.append('{:11.5E} days'.format(self.day))
         if extras:
             extras = ': ' + ', '.join(extras)
         return '<{} {}{}>'.format(self.__class__.__name__, self.name,

--- a/serpentTools/parsers/__init__.py
+++ b/serpentTools/parsers/__init__.py
@@ -15,7 +15,7 @@ from serpentTools.parsers.fissionMatrix import FissionMatrixReader
 from serpentTools.parsers.history import HistoryReader
 from serpentTools.parsers.xsplot import XSPlotReader
 from serpentTools.parsers.sensitivity import SensitivityReader
-from serpentTools.parsers.microxs import MicroXSReader
+from serpentTools.parsers.microxs import MicroXSReader, MicroXSTuple
 from serpentTools.parsers.depmatrix import DepmtxReader, readDepmtx
 from serpentTools.io.hooks import matlabHook
 
@@ -57,7 +57,7 @@ __all__ = ['read',
            'BumatReader', 'ResultsReader', 'FissionMatrixReader',
            'MicroXSReader', 'SensitivityReader', 'XSPlotReader',
            'HistoryReader', 'DepmtxReader',
-           'depmtx', 'readDepmtx',
+           'depmtx', 'readDepmtx', "MicroXSTuple",
            ]
 
 


### PR DESCRIPTION
This PR introduces two new [`namedtuples`](https://docs.python.org/3/library/collections.html?highlight=namedtuple#collections.namedtuple) that serve as keys for various dictionaries. Both are drop in replacements for the previous dictionary keys, as namedtuples are basically tuples you can access by name. These changes are done related to #338 

First, we have `UnivTuple` that stores universe ID, burnup [MWd/kgU], step, and time [d]. This is used by the ResultsReader.universes to allow a more pythonic and straightforward way to iterate over the keys. The following code is now valid:
```
for key, universe in res.universes.items():
    if key.universe == "0":
        # do something to universe 0 at any burnup
    elif key.burnup == 10:
        # do something to any universe with a burnup of 10 MWd/kgU
```
This is easier to understand rather than trying to remember which index in the key corresponds to universe id and burnup. Plus, if we, for whatever reason, decide to add a custom class for universe keys (little excessive), the attribute-based approach gives us a more consistent API.

Similarly, this PR also introduces MicroXSTuple that serves as keys to MicroXSReader.xsVal and
xsUnc. The items are zai, reaction MT, and metastable flag. Again, this is a drop in replacement for the old tuple, and is more expressive.