### PR TITLE
API BranchContainer inherits from dict: UnivTuple -> HomogUniv

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,6 +12,8 @@ Next
 * Better handling of discontinuity factors
 * |HomogUniv| objects no longer automatically convert data to arrays
 * Serpent 2.1.31 is the default version for :ref:`serpentVersion` setting
+* :class:`~serpentTools.objects.BranchContainer` now inherits from
+  :class:`dict`
 
 Incompatible API Changes
 ------------------------
@@ -23,6 +25,10 @@ Incompatible API Changes
 * Keys to |BranchedUniv| objects stored in
   :attr:`serpentTools.xs.BranchCollector.universes` are stored as strings,
   rather than integers, e.g. ``0`` is replaced with ``"0"`` - :pull:`321`
+* Keys to |HomogUniv| instances stored on
+  :class:`~serpentTools.objects.BranchContainer` are now
+  :class:`~serpentTools.objects.UnivTuple`, or tuples with
+  ``universe, burnup, step, days`` - :pull:`344`
 
 .. _v0.7.1
 

--- a/docs/examples/Branching.rst
+++ b/docs/examples/Branching.rst
@@ -43,21 +43,23 @@ Basic Operation
     >>> branchFile = 'demo.coe'
     >>> r0 = serpentTools.readDataFile(branchFile)
 
-The branches are stored in custom |BranchContainer| objects in the
-:attr:`~serpentTools.BranchingReader.branches` dictionary
+The branches are stored in custom dictionary-like |BranchContainer|
+objects in the :attr:`~serpentTools.BranchingReader.branches` dictionary
 
 .. code:: 
     
-    >>> r0.branches
-    {('B1000', 'FT1200'): <serpentTools.objects.BranchContainer at 0x7fa068b42978>,
-     ('B1000', 'FT600'): <serpentTools.objects.BranchContainer at 0x7fa068b58a58>,
-     ('B1000', 'nom'): <serpentTools.objects.BranchContainer at 0x7fa068aac860>,
-     ('B750', 'FT1200'): <serpentTools.objects.BranchContainer at 0x7fa068b3a908>,
-     ('B750', 'FT600'): <serpentTools.objects.BranchContainer at 0x7fa068b509e8>,
-     ('B750', 'nom'): <serpentTools.objects.BranchContainer at 0x7fa068a9c860>,
-     ('nom', 'FT1200'): <serpentTools.objects.BranchContainer at 0x7fa068b33898>,
-     ('nom', 'FT600'): <serpentTools.objects.BranchContainer at 0x7fa068b47978>,
-     ('nom', 'nom'): <serpentTools.objects.BranchContainer at 0x7fa068a8b860>}
+    >>> r0.branches.keys()
+    dict_keys([
+        ('nom', 'nom'),
+        ('B750', 'nom'),
+        ('B1000', 'nom'),
+        ('nom', 'FT1200'),
+        ('B750', 'FT1200'),
+        ('B1000', 'FT1200'),
+        ('nom', 'FT600'),
+        ('B750', 'FT600'),
+        ('B1000', 'FT600')
+    ])
 
 Here, the keys are tuples of strings indicating what
 perturbations/branch states were applied for each ``SERPENT`` solution.
@@ -94,54 +96,44 @@ Group Constant Data
     Group constants are converted from ``SERPENT_STYLE`` to
     ``mixedCase`` to fit the overall style of the project.
 
-The |BranchContainer| stores group constant data in |HomogUniv| objects in the 
-:attr:`~serpentTools.objects.BranchContainer.universes` dictionary
+The |BranchContainer| stores group constant data in |HomogUniv| objects as a dictionary.
 
 .. code:: 
     
-    >>> for key in b0.universes:
+    >>> for key in b0:
     ...     print(key)
-    ('0", 1.0, 1)
-    ('10", 1.0, 1)
-    ('20", 1.0, 1)
-    ('30", 1.0, 1)
-    ('20", 0, 0)
-    ('40", 0, 0)
-    ('20", 10.0, 2)
-    ('10", 10.0, 2)
-    ('0", 0, 0)
-    ('10", 0, 0)
-    ('0", 10.0, 2)
-    ('30", 0, 0)
-    ('40", 10.0, 2)
-    ('40", 1.0, 1)
-    ('30", 10.0, 2)
+    UnivTuple(universe='0', burnup=0.0, step=0, days=None)
+    UnivTuple(universe='10', burnup=0.0, step=0, days=None)
+    UnivTuple(universe='20', burnup=0.0, step=0, days=None)
+    UnivTuple(universe='30', burnup=0.0, step=0, days=None)
+    UnivTuple(universe='40', burnup=0.0, step=0, days=None)
+    UnivTuple(universe='0', burnup=1.0, step=1, days=None)
+    UnivTuple(universe='10', burnup=1.0, step=1, days=None)
+    UnivTuple(universe='20', burnup=1.0, step=1, days=None)
+    UnivTuple(universe='30', burnup=1.0, step=1, days=None)
+    UnivTuple(universe='40', burnup=1.0, step=1, days=None)
+    UnivTuple(universe='0', burnup=10.0, step=2, days=None)
+    UnivTuple(universe='10', burnup=10.0, step=2, days=None)
+    UnivTuple(universe='20', burnup=10.0, step=2, days=None)
+    UnivTuple(universe='30', burnup=10.0, step=2, days=None)
+    UnivTuple(universe='40', burnup=10.0, step=2, days=None)
 
-The keys here are vectors indicating the universe ID, burnup, and burnup
-index corresponding to the point in the burnup schedule. ``SERPENT``
-prints negative values of burnup to indicate units of days, which is
-reflected in the :attr:`~serpentTools.objects.BranchContainer.hasDays`
-attribute. ``hasDays-> True`` indicates
-that the values of burnup, second item in the above tuple, are in terms
-of days, not MWd/kgU.
+The keys here are :class:`~serpentTools.objects.UnivTuple` instances
+indicating the universe ID, and point in the burnup schedule.
 These universes can be obtained by indexing this dictionary, or by using
 the :meth:`~serpentTools.objects.BranchContainer.getUniv` method
 
 .. code:: 
     
-    >>> univ0 = b0.universes["0", 1, 1]
+    >>> univ0 = b0["0", 1, 1, None]
     >>> print(univ0)
     <HomogUniv 0: burnup: 1.000 MWd/kgu, step: 1>
-    >>> print(univ0.name)
-    0
-    >>> print(univ0.bu)
-    1.0
-    >>> print(univ0.step)
-    1
-    >>> print(univ0.day)
-    None
-    >>> print(b0.hasDays)
-    False
+    >>> univ0.name, univ0.bu, univ0.step, univ0.day
+    ('0', 1.0, 1, None)
+    >>> univ1 = b0.getUniv('0', burnup=1)
+    >>> univ2 = b0.getUniv('0', index=1)
+    >>> univ0 is univ1 is univ2
+    True
 
 Group constant data is spread out across the following sub-dictionaries:
 
@@ -209,7 +201,7 @@ bin-index.
 
 .. code:: 
     
-    >>> univ0.plot(['infFiss', 'b1Tot'], loglog=False, xlabel="Energy Group");
+    >>> univ0.plot(['infFiss', 'b1Tot'], loglog=False);
 
 .. image:: Branching_files/Branching_33_0.png
 

--- a/examples/Branching.ipynb
+++ b/examples/Branching.ipynb
@@ -70,7 +70,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The branches are stored in custom [`BranchContainer`](http://serpent-tools.readthedocs.io/en/latest/api/containers.html#serpentTools.objects.containers.BranchContainer) objects in the `branches` dictionary"
+    "The branches are stored in custom dictionary-like [`BranchContainer`](http://serpent-tools.readthedocs.io/en/latest/api/containers.html#serpentTools.objects.containers.BranchContainer) objects in the `branches` dictionary"
    ]
   },
   {
@@ -81,24 +81,7 @@
     {
      "data": {
       "text/plain": [
-       "{('nom',\n",
-       "  'nom'): <serpentTools.objects.containers.BranchContainer at 0x7ff7e6664c88>,\n",
-       " ('B750',\n",
-       "  'nom'): <serpentTools.objects.containers.BranchContainer at 0x7ff7bd7b6f28>,\n",
-       " ('B1000',\n",
-       "  'nom'): <serpentTools.objects.containers.BranchContainer at 0x7ff7bd7c8208>,\n",
-       " ('nom',\n",
-       "  'FT1200'): <serpentTools.objects.containers.BranchContainer at 0x7ff7bd7d34e0>,\n",
-       " ('B750',\n",
-       "  'FT1200'): <serpentTools.objects.containers.BranchContainer at 0x7ff7bd7df668>,\n",
-       " ('B1000',\n",
-       "  'FT1200'): <serpentTools.objects.containers.BranchContainer at 0x7ff7bd76a978>,\n",
-       " ('nom',\n",
-       "  'FT600'): <serpentTools.objects.containers.BranchContainer at 0x7ff7bd776c18>,\n",
-       " ('B750',\n",
-       "  'FT600'): <serpentTools.objects.containers.BranchContainer at 0x7ff7bd780f28>,\n",
-       " ('B1000',\n",
-       "  'FT600'): <serpentTools.objects.containers.BranchContainer at 0x7ff7bd793278>}"
+       "dict_keys([('nom', 'nom'), ('B750', 'nom'), ('B1000', 'nom'), ('nom', 'FT1200'), ('B750', 'FT1200'), ('B1000', 'FT1200'), ('nom', 'FT600'), ('B750', 'FT600'), ('B1000', 'FT600')])"
       ]
      },
      "execution_count": 3,
@@ -107,7 +90,7 @@
     }
    ],
    "source": [
-    "r0.branches"
+    "r0.branches.keys()"
    ]
   },
   {
@@ -126,7 +109,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "<BranchContainer for B1000, FT600 from /home/drew/.local/lib/python3.7/site-packages/serpentTools-0.7.0+30.g3066be7.dirty-py3.7.egg/serpentTools/data/demo.coe>\n"
+      "<BranchContainer for B1000, FT600 from /home/ajohnson400/github/my-serpent-tools/serpentTools/data/demo.coe>\n"
      ]
     }
    ],
@@ -191,7 +174,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The [`BranchContainer`](http://serpent-tools.readthedocs.io/en/latest/api/containers.html#serpentTools.objects.containers.BranchContainer) stores group constant data in [`HomogUniv`](http://serpent-tools.readthedocs.io/en/latest/api/containers.html#serpentTools.objects.containers.HomogUniv) objects in the `universes` dictionary. "
+    "The [`BranchContainer`](http://serpent-tools.readthedocs.io/en/latest/api/containers.html#serpentTools.objects.containers.BranchContainer) stores group constant data in [`HomogUniv`](http://serpent-tools.readthedocs.io/en/latest/api/containers.html#serpentTools.objects.containers.HomogUniv) objects as a dictionary."
    ]
   },
   {
@@ -203,26 +186,26 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "('0', 0, 0)\n",
-      "('10', 0, 0)\n",
-      "('20', 0, 0)\n",
-      "('30', 0, 0)\n",
-      "('40', 0, 0)\n",
-      "('0', 1.0, 1)\n",
-      "('10', 1.0, 1)\n",
-      "('20', 1.0, 1)\n",
-      "('30', 1.0, 1)\n",
-      "('40', 1.0, 1)\n",
-      "('0', 10.0, 2)\n",
-      "('10', 10.0, 2)\n",
-      "('20', 10.0, 2)\n",
-      "('30', 10.0, 2)\n",
-      "('40', 10.0, 2)\n"
+      "UnivTuple(universe='0', burnup=0.0, step=0, days=None)\n",
+      "UnivTuple(universe='10', burnup=0.0, step=0, days=None)\n",
+      "UnivTuple(universe='20', burnup=0.0, step=0, days=None)\n",
+      "UnivTuple(universe='30', burnup=0.0, step=0, days=None)\n",
+      "UnivTuple(universe='40', burnup=0.0, step=0, days=None)\n",
+      "UnivTuple(universe='0', burnup=1.0, step=1, days=None)\n",
+      "UnivTuple(universe='10', burnup=1.0, step=1, days=None)\n",
+      "UnivTuple(universe='20', burnup=1.0, step=1, days=None)\n",
+      "UnivTuple(universe='30', burnup=1.0, step=1, days=None)\n",
+      "UnivTuple(universe='40', burnup=1.0, step=1, days=None)\n",
+      "UnivTuple(universe='0', burnup=10.0, step=2, days=None)\n",
+      "UnivTuple(universe='10', burnup=10.0, step=2, days=None)\n",
+      "UnivTuple(universe='20', burnup=10.0, step=2, days=None)\n",
+      "UnivTuple(universe='30', burnup=10.0, step=2, days=None)\n",
+      "UnivTuple(universe='40', burnup=10.0, step=2, days=None)\n"
      ]
     }
    ],
    "source": [
-    "for key in b0.universes:\n",
+    "for key in b0:\n",
     "    print(key)"
    ]
   },
@@ -230,9 +213,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The keys here are vectors indicating the universe ID, burnup, and burnup index corresponding to the point in the burnup schedule. `SERPENT` prints negative values of burnup to indicate units of days, which is reflected in the `hasDays` attribute. `hasDays-> True` indicates that the values of burnup, second item in the above tuple, are in terms of days, not MWd/kgU.\n",
-    "\n",
-    "These universes can be obtained by indexing this dictionary, or by using the [`getUniv`](http://serpent-tools.readthedocs.io/en/latest/api/containers.html#serpentTools.objects.containers.BranchContainer.getUniv) method."
+    "The keys here are `UnivTuple` instances indicating the universe ID and point in burnup schedule.\n",
+    "These universes can be obtained by indexing into the `BranchContainer`, or by using the [`getUniv`](http://serpent-tools.readthedocs.io/en/latest/api/containers.html#serpentTools.objects.containers.BranchContainer.getUniv) method."
    ]
   },
   {
@@ -241,38 +223,44 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "<HomogUniv 0: burnup: 1.000 MWd/kgu, step: 1>\n",
-      "0\n",
-      "1.0\n",
-      "1\n",
-      "None\n",
-      "False\n"
-     ]
+     "data": {
+      "text/plain": [
+       "<serpentTools.objects.containers.HomogUniv at 0x7fb40bfa9a10>"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
-    "univ0 = b0.universes['0', 1, 1]\n",
-    "print(univ0)\n",
-    "print(univ0.name)\n",
-    "print(univ0.bu)\n",
-    "print(univ0.step)\n",
-    "print(univ0.day)\n",
-    "print(b0.hasDays)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Since the coefficient files do not store the day value of burnup, all [`HomogUniv`](http://serpent-tools.readthedocs.io/en/latest/api/containers.html#serpentTools.objects.containers.HomogUniv) objects created by the [`BranchContainer`](http://serpent-tools.readthedocs.io/en/latest/api/containers.html#serpentTools.objects.containers.BranchContainer)  default to day zero."
+    "univ0 = b0['0', 1, 1, None]\n",
+    "univ0"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "('0', 1.0, 1, None)"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "univ0.name, univ0.bu, univ0.step, univ0.day"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -304,7 +292,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -317,7 +305,7 @@
        " 'infDiffcoef': array([1.83961 , 0.682022])}"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -328,7 +316,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -337,7 +325,7 @@
        "{}"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -348,7 +336,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -361,33 +349,13 @@
        " 'b1Diffcoef': array([1.79892 , 0.765665])}"
       ]
      },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "univ0.b1Exp"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{}"
-      ]
-     },
      "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "univ0.gc"
+    "univ0.b1Exp"
    ]
   },
   {
@@ -407,6 +375,26 @@
     }
    ],
    "source": [
+    "univ0.gc"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{}"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
     "univ0.gcUnc"
    ]
   },
@@ -419,7 +407,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -428,7 +416,7 @@
        "array([0.00271604, 0.059773  ])"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -439,7 +427,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -468,24 +456,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<matplotlib.axes._subplots.AxesSubplot at 0x7ff7bd7a3cf8>"
+       "<matplotlib.axes._subplots.AxesSubplot at 0x7fb3f42d3d50>"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYgAAAEGCAYAAAB/+QKOAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy8QZhcZAAAYU0lEQVR4nO3de7BlZX3m8e8DCIgNZIRuGhgaxCRyC5iZRhAmKe3Ryhi8YaQ1jOMlFSDqlBiJ0VYU0VTCoE55IWXE8YblBYYMXodUK0arNUOXDbaIKKCiXNSxG0XalAMt/Zs/1nvg0K7Tffbuc/be3ef7qTq113rXXnv/evWq85x1e99UFZIkbW23cRcgSZpMBoQkqZcBIUnqZUBIknoZEJKkXgaEJKnXHuMuYC4deOCBdcQRR4y7DEnaaVx33XUbq2px37JdKiCOOOII1q1bN+4yJGmnkeSHMy3zFJMkqZcBIUnqZUBIknpNdEAkeVSSlyR58rhrkaSFZmQXqZPsAVwAXA8cDVxUVVvashXAcUCAa6tqbZIDgY8BZ1XVjBdRJEnzY5R3MZ0F3FVVVyVZCpwBXJ5kd+Bi4MT2vmuAFcDbgQ8bDpI0HqM8xXQysL5NrwdOa9PLgI3VAJuTPI4uQA5OclmSC0dYpySJ0R5BLAU2telNwEE97VPLDgR+UFVvA0jyrSTvq6o7t/7QJGcDZwMsW7ZsnkqXhvextbfzqfV3jbsM7cKOOWQ/LnjGsXP+uaM8grgbWNSmFwEbe9qnlv0SeGBa2y3AIX0fWlWXVtXyqlq+eHHvw4DSWH1q/V3c9ON7x12GNLBRHkGsBk4A1gLHA6uTLKmqW5LsmyTtfYuq6htJNiTZt6o2AY8Ebh1hrdKcOubg/bj8nCeOuwxpIKM8grgMWJZkJd11hxuBS9qyVcB57WdVa3sNcGGSM4GPVNXPR1irJC14IzuCaLe0nt9mr2ivK9uyNcCard7/NeBro6pPkvRwE/2gnCRpfAwISVIvA0KS1MuAkCT1MiAkSb0MCElSLwNCktTLgJAk9TIgJEm9DAhJUi8DQpLUy4CQJPUyICRJvQwISVIvA0KS1MuAkCT1MiAkSb0MCElSLwNCktTLgJAk9TIgJEm9DAhJUi8DQpLUy4CQJPUyICRJvQwISVKvnSIgkuw37hokaaHZY1RflGQP4ALgeuBo4KKq2tKWrQCOAwJcW1VrkxwA/AuwO/Bx4A2jqlWSNMKAAM4C7qqqq5IsBc4ALk+yO3AxcGJ73zXACuAlwLOq6jsjrFGS1IzyFNPJwPo2vR44rU0vAzZWA2xOciSwGPhski+1owlJ0giNMiCWApva9CbgoJ72B5dV1WuAx9GFyYUzfWiSs5OsS7Juw4YNc1+1JC1QowyIu4FFbXoRsLGn/WHLquoB4M10Rxm9qurSqlpeVcsXL14850VL0kI1yoBYDZzQpo8HVidZUlW3APumARZV1a1J9mrvXQJcO8I6JUmMNiAuA5YlWUl3RHAjcElbtgo4r/2sSvIY4LokrwCeBLx9hHVKkhjhXUztltbz2+wV7XVlW7YGWLPVKseNqDRJUo+d4kE5SdLoGRCSpF4GhCSplwEhSeplQEiSehkQkqReBoQkqdesn4NI8sbtvOWGqvrkDtYjSZoQgzwotxdddxkzOWYHa5EkTZBBAuKyqrp5poVJfjoH9UiSJsSsr0FsKxza8m/veDmSpEmx3SOINh70b01rOrKqvjRvFUmSJsJsTjGdBDwZuK/NLwO+NF8FSZImw3YDoqo+n+Sfq+rXAElGOY61JGlMZnUNYlo4nDo1LUnatQ36oNw581KFJGniDBoQmZcqJEkTx642JEm9Bg2Iz8xLFZKkiTNQQFTV1FjSJNmz/Txh7suSJI3bwLesJvko8AfAr+muSewPPHqO65IkjdkwzzTcWVXLpmaSHDaH9UiSJsQwAbEmycuBzW3+WODcuStJkjQJhgmIVcCXeajrjf3nrhxJ0qQYJiCuqqq3Tc0kWTqH9UiSJsQwAfFHSVby0EXqxcBvz2lVkqSxGyYg/h74BrClzZ8wm5VaJ38XANcDRwMXVdWWtmwFcBxd4FxbVWunrXcl8FdV9YMhapUkDWnggJg+7nSSParqh7Nc9Szgrqq6qp2WOgO4PMnuwMXAie191wAr2uefTjfUqSRpxAbuaiPJB5K8pM0em+TZs1z1ZGB9m14PnNamlwEbqwE2Jzkyye8DdwB3D1qjJGnHDdMX05qq+iBAVX0DeNUs11sKbGrTm4CDetqnL/vtqlq3vQ9NcnaSdUnWbdiwYZalSJK2Z5iA2CfJIUn2SXIO8KhZrnc3sKhNLwI29rRPLXsK8IIkn6Q73XRpkkP7PrSqLq2q5VW1fPHixYP+WyRJMxjmIvUHgL8GlgN3As+Z5Xqr6S5orwWOB1YnWVJVtyTZN8lUV+KLquotUysl+RDwpqq6a4haJUlDmvURRJInAVTVr6rqwqp6RlW9dOoidZKnbOcjLgOWtVtklwE3Ape0ZauA89rPqsH+CZKk+TDIEcRFSW6aYVmAe4AvzLRyu6X1/DY71SvsyrZsDbBmhvVePECNkqQ5MkhAPG87y3+5I4VIkibLrANigOcdJEm7gGGegzhuPgqRJE2WYW5zvSLJAUmek2TJnFckSZoIwwTEv6G72+g44B+SnDq3JUmSJsEwz0HcBryrqn4CkGR7F68lSTuhYY4gzge+mOQFSX6Xh7rMkCTtQgYOiKr6IvAnwEnAW4GfzHVRkqTxG+YUE8D3gA8B36+qn89dOZKkSTFIVxuvTrI6yRnAdcBLgde3wX4kSbuYQY4gngr8EXAKsLaq/hwgydPmozBJ0ngNEhA3tQF9vprkR9Pa/wS4em7LkiSN2yAXqS9I8niAqrptWvudc1uSJGkSzDogquoXVbUeIMl/nNb+punzkqRdwzDPQUD3JPW25iVJO7lhA2Jr2f5bJEk7k4Geg0hyFt1dTL+X5AOt+Uqg5rowSdJ4DRQQVfU+4H1Jrq6qP5tqT/Jf57wySdJYeYpJktRr2ID48HbmJUk7uaECoqo+sa15SdLOb65OMUmSdjEGhCSplwEhSeplQEiSeg08YFCSvYETgL1a0/FVdcmcViVJGrthRpT7CnA7cF+b/x3AgJCkXcwwAXFlVV00NZPk0NmslGQP4ALgeuBo4KKq2tKWrQCOo3vg7tqqWttGrns68FjgjKr68RC1SpKGNExAnJjkSuD+Nv8Y4ImzWO8s4K6quirJUuAM4PIkuwMXAye2912T5KnArVX1oiSvbMs+PUStkqQhDRMQnwO+N23+hFmudzLwnja9nm5M68uBZcDGNlodSTYDh1fV+nbUsRh47xB1SpJ2wDB3MX0ceALwArrTQu/Z9tsftBTY1KY3AQf1tD+4LEmAFwLPBZ4/04cmOTvJuiTrNmzYMOt/hCRp24YJiHe21yuBnwGvmuV6dwOL2vQiYGNP+4PLqvMB4Kl0IdGrqi6tquVVtXzx4sWzLEWStD3DnGJaXVVXTs0kOX2269GdjloLHA+sTrKkqm5Jsm87YgBYVFW3TlvvfuDGIeqUJO2AYY4gDk9yUpLlSf4CeNos17sMWJZkJd11hxt56PbYVXTDlp4HrEpyQJJvJHkh8J+AtwxRpyRpBwxzBPEh4HXAUcA3gb+ezUrtltbz2+wV7XVlW7YGWLPVKrO9+C1JmgcDB0RV3U33lz4ASY4E7pnLoiRJ4zfrU0xJPprkEUnOTXJbku8nuQ24bh7rkySNySBHEK+tqs1JVgMfrqp7AJKcuJ31JEk7oVkfQVTVHW1yv6lwaA7qe78kaec26yOIJAcCfwMcl+T21rw73cNyn52H2iRJYzTrgKiqjUneATwJ+HZr3gLcPA91SZLGbKDnIKrqO3TdbBxZVV8G7gVOmY/CJEnjNcyDcmuq6oMAVfUNZt/VhiRpJzLMg3L7JDmE7tmH/wI8am5LkiRNgmEC4gN0T08vB+4AnjOnFUmSJsIwT1L/CrgQIMkB7clqSdIuZuBrEEnelORjbfaoJGfOcU2SpAkwzEXqXwOfBKiqrwIvnsuCJEmTYZhrEHcDeyXZhy4cHKVHknZBwxxBXEk34M//bK9epJakXdAgvbm+N8nrgQLeSzfoz7Nx3AZJ2iUNcgRxFPB3dONQX0HX/9Jjgf8wD3VJksZskGsQn6+qLUnOAzZX1SqAJHfOT2mSpHEa5AjikCRXA68HzgJIsgQ4Zz4KkySN1yC9ub4syeOBO1vPrnsCpzHLMaklSTuXgW5zrar106bvBz445xVJkibCMLe5SpIWAANCktRrmL6YDkuyf5J9k7wsybHzUZgkabyGOYI4D7gPuAxYik9SS9IuaZiA+BZwNrBXVb0R+NHcliRJmgTDBMTUnUxntNtel85hPZKkCTFMQPyE7vTSbsAptK6/tyfJHknekuT0JK9Lstu0ZSuSvCLJuUlOam3PT/LVJN9NcsoQdUqSdsCw1yD+H4NfgzgLuKuqrgJ+DpwBkGR34GLg3cC7gL9L8kjggao6FXgj8IYh6pQk7YBhr0Gcw+DXIE7modNT6+mewoauV9iN1QCbgcOAf2zLv043BoUkaYSGvQaxBXhuuwZx8CzXWwpsatObgIN62qeWHVBVW9r8H9IdYfRKcnaSdUnWbdiwYZalSJK2Z5iA+CawN/BO4FTgv81yvbuBRW16EbCxp/1hy5IcCdxeVTfM9KFVdWlVLa+q5YsXO7idJM2VYQLiXe31SrqxIV41y/VW89DgQscDq5MsqapbgH3TAIuq6tbWU+xRVXV1kr3bvCRpRIYZk3p1VV05NZPk9Fmudxnw5iQr6a47XAVcAqwEVtFd/AZY1ca7/hRdcFxMN4rd7w9RqyRpSMMExOHtVtQHgOXAv6P7Zb9N7ZrC+W32iva6si1bA6zZapUnDlGbJGmODBMQPwWeBzwOuAHHg5CkXdIwAfG0qjpzaibJQdt6syRp5zRMQGxuQ4/+vM0fSfeMgyRpFzLrgEiyrE1eR3er6xZgCXDE3JclSRq3QY4gbgNeC7y3qu4FSHIg8LT5KEySNF6DBMTHquqt0xuqamOSQ+e4JknSBBjkQbmbZ2jfZy4KkSRNlkEC4ujWy+qDkuwHHDO3JUmSJsEgp5jeD1yX5BN0Y0IsA/4zXTfekqRdzKyPIKrqi8DTgUcDz2yvz66qL8xTbZKkMRroOYiq+j7wynmqRZI0QYbpzVWStAAYEJKkXgaEJKmXASFJ6mVASJJ6GRCSpF4GhCSplwEhSeplQEiSehkQkqReBoQkqZcBIUnqZUBIknoZEJKkXhMdEEn2THL0uOuQpIVooPEgdkSSPYALgOuBo4GLqmpLW7YCOA4IcG1VrU3yW8DbgI3Aa0dVpySpM7KAoBua9K6quirJUuAM4PIkuwMXAye2910DrKiqe5J8BThqhDVKkppRnmI6GVjfptcDp7XpZcDGaoDNSY4cYV2SpB6jDIilwKY2vQk4qKd962XbleTsJOuSrNuwYcOcFCpJGm1A3A0satOL6K4tbN2+9bLtqqpLq2p5VS1fvHjxnBQqSRptQKwGTmjTxwOrkyypqluAfdMAi6rq1hHWJUnqMcqAuAxYlmQl3XWHG4FL2rJVwHntZxVAkv2BU4ATksz6lJMkaW6M7C6mdkvr+W32iva6si1bA6zZ6v2/AM4eVX2SpIeb6AflJEnjY0BIknoZEJKkXgaEJKmXASFJ6mVASJJ6GRCSpF4GhCSplwEhSeplQEiSehkQkqReBoQkqZcBIUnqZUBIknoZEJKkXgaEJKmXASFJ6mVASJJ6GRCSpF4GhCSp1x7jLmASXPiZb3HTj+4ddxnaRd3043s55uD9xl2GNDCPIKR5dszB+/Gsxx867jKkgXkEAVzwjGPHXYIkTRyPICRJvQwISVIvA0KS1MuAkCT1GtlF6iR7ABcA1wNHAxdV1Za2bAVwHBDg2qpa29c2qlolSaO9i+ks4K6quirJUuAM4PIkuwMXAye2912T5KlbtwErRlirJC14ozzFdDKwvk2vB05r08uAjdUAm4Ejtm5LcuQIa5WkBW+UAbEU2NSmNwEH9bRPLVvS03YQPZKcnWRdknUbNmyY24olaQEb5Smmu4FFbXoRsLGnfWrZz3raNtKjqi4FLgVIsiHJD4es78CZvmPMrGsw1jUY6xrMrljX4TMtGGVArAZOANYCxwOrkyypqluS7Jsk7X2LqurmnrZbt/cFVbV42OKSrKuq5cOuP1+sazDWNRjrGsxCq2uUAXEZ8OYkK+muO1wFXAKsBFYB57X3rZr2unWbJGlERhYQ7ZbW89vsFe11ZVu2Bliz1ft/o02SNDo+KPeQS8ddwAysazDWNRjrGsyCqivdXaSSJD2cRxDTJNlpRnUZRa1Jfq89yDhRhqlrErbXuPavSd1eu5pJ2GZzXcOCCIgkeyR5S5LTk7wuyW7Tlh2Q5OYk3wVe3dpWJHlFknOTnDTqutK5fur5jiS3zlTrPNZ2EnAt8Iit2n9j24xqe22nrucn+WqS7yY5pbVNwvYa2/41U10Tsn/tl+TjSb6f5EPT7lgc6z62nbrGto9tp67528eqapf/AV4K/MW06edNW/ZXwFHT5ncH1tH1ARXgi6OuCzgMOLBNLwL+e1+tI9huPwD23ta2GeX22kZdjwTOaNNnAldPwvYa9/61je019v0LeG77f9sL+CZw0iTsY9uoa6z72Ex1zfc+tiCOIJi5mw+AxcBnk3wpyQH0dP2R+evmo7euqrqjqqYeejkN+KcZah21Se0WZTPwj23663QPX8L4t1dfDaPcv3pNyP716ar6VVXdB9zEQ/9n497HZqpr3PvYTHX11TBn+9hCCYiZuvmgql4DPI7uF/SF9Hf90dvNx3zWNc0K4J9nqHXUdqhblPlSVb+u1jMw8Id0HT1OwvYa9/41G2PZv6rqfoAkewN3VtV326Kx7mMz1TXufWwb22te97GFEhAzdfMBQFU9ALyZLnn7uv6Yr0frt1lXkj1bfZtnqHXUdqhblPnW/kq6vapumGob8/bqq2GU+9c2Tcj+9Ty6YQCmTMo+tnVdwETsY711zdc+tlACYqqbD5jWzQdAkr1a+xK6cSduAfZtF/LCLLv5mOu6mqfQnYOlr9Z5quk3JNktrVsUfnPb3NzTNl/bq7euNr2E7jzs1Un2TrJk3NurTY9z/5qxrmas+1eSPwb+d1X9Msnhk7KP9dXV2se6j22jrnnbxxbEcxDp7g56M3AD3S/iq4DXtJ/P0D1kcj/wwaq6L8kfAFNX/tdW91T3yOqqqpVt+d8Dq6rq3iSP6at1Pupq370c+DLwp8DtwOuqamXfthnV9pqpLuDFdGOG7NveVsBz6Lbn2LYXY96/ZqprQvav5wNvBX5Bd1H1I8Djx72PzVQXY97HtlHXvO5jCyIgJEmDWyinmCRJAzIgJEm9DAhJUi8DQpLUy4CQJPUyICRJvUY55Kg0EZI8ne7e8XPp7h0/HPhRVb17RN+/B91wugfSPSX8dGD3qjp5FN8vzZbPQWhBSlJVNb3L5MdU1W0j+u63AbtV1ava/O50PaqeO4rvl2bLU0xa8JKsrKrbkjwtyeeTvDLJ+iSHJtknycvT9av/viT7J/lIktcnWdu6XHhPkhcluSfJc5K8MckXkuyV5BlJXjTtu/ak69r9PVNtrR+dC9tnvT3JRUn+T5JDkrwmybOS/I8kByV5ZpJrkyxK8skkL05yapKvJfnLJNcl+dMxbEbtggwILVgtCF4NvKw1fRs4oKreQdfD6R8Cf0bXD///BfZsPwV8H3gi8Bjgd6vqw3R9a30BuAg4lG6QnsOAj0772kcD+wB3TKvjyXTdKBwG/Ctddwqn0o0BcHtVfap99gV03bJQVb8EvtM+4l+AI4F3ACuBv93hjSNhQGgBq6p3VNVbgZdPa76/vd5HNzjLscA/VdUnqupFVbUB2AL8vKq2VNW3gWuSPBN4V1Xd27pm/gjwQrpTSb+e9vk/BX4F/NtpbV8GTmsdqj342cBRwAPtPTfQdenc9+8oYHPr/v97bDWqnTQsA0ILXlV9K8npMyy+A3gRQJJjkjzsl3SSR9INzvLpqvrKtEX/QDf84/rp72+/+N9Nd5F6elufbwLL2/Sj22c9QHdEA7D31iskeRRw4wyfJw3Eu5i04LS/9knyeuAe4LHA/nR/vR+c5DC63nX3pDtd88kka4D/BXwI+B3gCUmuoftr/ZwkZ9P9wfWGqvpcVf0syeeAr/aUsAr4yyTvpzut9UjgbS1sjgOWtl/07wfeleRMun7+/7bV+69J3tk+67D2+qgkf043MMyr5mI7Sd7FJO2AJC8GvlNV1yZ5BPDHdN1C7wWcOcJbZ39SVUtH8V1aODyCkHZMgHck+TrdWMVX0F1w/vd0A/LMfwHJScB+SY6fPtKZtKM8gpAk9fIitSSplwEhSeplQEiSehkQkqReBoQkqZcBIUnq9f8B94miWr4d0HcAAAAASUVORK5CYII=\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAkQAAAG0CAYAAADTmjjeAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAPYQAAD2EBqD+naQAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy8QZhcZAAAgAElEQVR4nOzde1jUZf7/8dfIQREQGTylmFi5WLKpaYolm1rappmHpfJQrmnmWp5K01ULz5CmWbpqtrVpl5uuuSRo6ZZIi7XkCclT30xDJVJBQTBOnj6/P7yYX9OgMcwgM87zcV1z7c79ubnnfTN7Ly8/R5NhGIYAAAA8WI3qLgAAAKC6EYgAAIDHIxABAACPRyACAAAej0AEAAA8HoEIAAB4PAIRAADweN7VXYC7uHLlin766ScFBgbKZDJVdzkAAKACDMPQ+fPn1bhxY9Woce39QASiCvrpp5/UtGnT6i4DAABUQmZmpkJDQ6+5nUBUQYGBgZKu/kLr1KlTzdUAAICKKCgoUNOmTS1/x6+FQFRBZYfJ6tSpQyACAMDN/NbpLpxUDQAAPB6BCAAAeDwCEQAA8HgEIgAA4PEIRAAAwOMRiAAAgMfzyEB0/PhxJSQkKCsrq7pLAQAALsAl70NkGIYWLlyo7Oxs+fr66tSpU1q0aNE1b6p0+PBhxcbGKiIiQmlpaRo4cKB69+5t02/btm169dVX9cgjj+iZZ55RkyZNqnoqAADADbhkIIqNjdW2bduUlJQkSYqJidHgwYOVmJho0zc7O1tdu3bV2rVrFRUVpdzcXIWHh2vTpk3q2LGjpd/bb7+tqVOn6vPPP1e7du1u2FwAAIDrc7lDZrm5uZo7d66GDh1qaRs2bJg2btyo7du32/RfuHChatWqpaioKEmS2WxWr169NHXqVEufpKQkvfDCC1q6dClhCAAA2HC5QLR582YVFxdbBZewsDCFhIRo3bp1Nv3j4+NtQk779u2VnJysnJwcGYahF198US1bttTAgQOrvH4AAOB+XC4QHThwQJJsnkgbGhqq9PR0q7aSkhIdPXq03L6GYWjfvn1KT0/X/v371ahRIw0aNEhhYWH63e9+p/Xr11ftRAAAgNtwuXOIcnNzJUn+/v5W7QEBAcrJybFqy8vLk2EY5faVpJycHB05ckSS9PDDD2vSpEmSpAkTJmjAgAHat2+f7rrrrnLrKC0tVWlpqeV9QUGBA7MC4MoMw1DxxcvVXQbg8fx8vH7zIaxVxeUCka+vryTbp9KaTCb5+PhUuK8k+fj46OzZs5KkkSNHWrbPmDFDy5cv14oVK/TWW2+VW0dcXJxmzpzpwEwAuAPDMBT9dqr2HM+r7lIAj3do1sOq7Vs90cTlDpnVr19fklRYWGjVXlhYqMaNG1u1mc1meXt7l9tXkho3bqy6detKkry9//8vODAwUM2bN9fRo0evWceUKVOUn59veWVmZlZ+UgBcVvHFy4QhAK63h6h169aSpKysLLVs2dLSnpWVpa5du1r1NZlMioiIsLnBYlZWlry9vRUeHq7z589Lunp5fvPmzS19goKCrnlfI0mqWbOmatas6fB8ALiP3a88pNq+XtVdBuCx/Hyqb/25XCDq0aOHateurbS0NEsgyszMVHZ2tqKjo2369+vXT6tXr7Zq2717t7p16yaz2awuXbrIbDbryy+/tApEP/30k/r371+1kwHgVmr7elXb7noA1cvlDpn5+flp/PjxWrVqlaVt5cqV6ty5syIjI7V161a1aNFCBw8elHT13KAzZ84oNTVVkpSfn6+EhARNnDhR0tXzjMaPH6+///3vunLliiRpx44dKi4u1nPPPXeDZwcAAFyRS/5TaPbs2YqJidHYsWMVHBysjIwMJSQkyGQyqaCgQDk5OSoqKpIkNWzYUElJSYqLi1NKSor279+vZcuWqXv37pbxpk2bpitXrmjgwIG6/fbbdezYMW3btk116tSprikCAAAXYjIMw6juItxBQUGBgoKClJ+fT5ACbiJFFy7prpj/SKreK1wAVI2K/v12uUNmAAAANxqBCAAAeDwCEQAA8HgEIgAA4PEIRAAAwOMRiAAAgMcjEAEAAI9HIAIAAB6PQAQAADwegQgAAHg8AhEAAPB4BCIAAODxCEQAAMDjEYgAAIDHIxABAACPRyACAAAej0AEAAA8HoEIAAB4PAIRAADweAQiAADg8QhEAADA4xGIAACAxyMQAQAAj0cgAgAAHo9ABAAAPB6BCAAAeDwCEQAA8HgEIgAA4PEIRAAAwOMRiAAAgMcjEAEAAI9HIAIAAB6PQAQAADwegQgAAHg8AhEAAPB4BCIAAODxCEQAAMDjEYgAAIDHIxABAACPRyACAAAej0AEAAA8HoEIAAB4PAIRAADweAQiAADg8QhEAADA43lsIMrOzlZBQUF1lwEAAFyAd3UXUB7DMLRw4UJlZ2fL19dXp06d0qJFixQYGFhu/8OHDys2NlYRERFKS0vTwIED1bt3b6s+7777rkaMGGF5f9ttt+nIkSNVOg8AAOAeXDIQxcbGatu2bUpKSpIkxcTEaPDgwUpMTLTpm52dra5du2rt2rWKiopSbm6uwsPDtWnTJnXs2NHSLyEhQe+//77l/T333COTyVT1kwEAAC7P5QJRbm6u5s6dqxUrVljahg0bpubNm2v79u2Kioqy6r9w4ULVqlXL0m42m9WrVy9NnTrVEqi++OILRUZGaujQoTdsHgAAwH243DlEmzdvVnFxsdq1a2dpCwsLU0hIiNatW2fTPz4+3qqvJLVv317JycnKycmRJL311lt69dVX1aZNG7322msqKSmp2kkAAAC34nKB6MCBA5Kk0NBQq/bQ0FClp6dbtZWUlOjo0aPl9jUMQ/v27ZMkdenSRSNHjtSZM2c0ZcoUde7cWT///PN16ygtLVVBQYHVCwAA3JxcLhDl5uZKkvz9/a3aAwICLHt8yuTl5ckwjHL7SrL0HzdunJYvX66MjAy9+uqr2rNnj6ZNm3bdOuLi4hQUFGR5NW3a1KF5AQAA1+VygcjX11eSbE54NplM8vHxqXBfSTb9fXx8NGvWLI0YMULx8fHXrWPKlCnKz8+3vDIzM+2fDAAAcAsuF4jq168vSSosLLRqLywsVOPGja3azGazvL29y+0ryaZ/maFDhyo7O/u6ddSsWVN16tSxegEAgJuTywWi1q1bS5KysrKs2rOyshQREWHVZjKZFBERUW5fb29vhYeHl/sZdevWtQQvAAAAlwtEPXr0UO3atZWWlmZpy8zMVHZ2tqKjo2369+vXz6qvJO3evVvdunWT2Wwu9zN2796tnj17OrdwAADgtlwuEPn5+Wn8+PFatWqVpW3lypXq3LmzIiMjtXXrVrVo0UIHDx6UJMvVY6mpqZKk/Px8JSQkaOLEiZKkTZs26cknn7RcvXb69GmtXLlSs2bNusEzAwAArsrlbswoSbNnz1ZMTIzGjh2r4OBgZWRkKCEhQSaTSQUFBcrJyVFRUZEkqWHDhkpKSlJcXJxSUlK0f/9+LVu2TN27d5ckBQUFae/evbrvvvv01FNPqVGjRlqzZo0aNmxYnVMEAAAuxGQYhlHdRbiDgoICBQUFKT8/nxOsgZtI0YVLuivmP5KkQ7MeVm1fl/x3IoBKqujfb5c7ZAYAAHCjEYgAAIDHIxABAACPRyACAAAej0AEAAA8HoEIAAB4PAIRAADweAQiAADg8QhEAADA4xGIAACAxyMQAQAAj0cgAgAAHo9ABAAAPB6BCAAAeDwCEQAA8HgEIgAA4PG87f2BEydOVOqD/Pz8VL9+/Ur9LAAAQFWyOxCFhYXJZDJVuL9hGDKZTHr44Yf16aef2vtxAAAAVc7uQNSnTx/Nnz9fvr6+Ff6ZwsJCvfvuu/Z+FAAAwA1hdyDq0qWLWrRoYfcHNWvWzO6fAQAAuBHsPqm6R48elfqgyv4cAABAVbM7EN15552V+qDK/hwAAEBV47J7AADg8ZwSiI4fP+6MYQAAAKpFhU+q/vbbb/X++++Xu23Pnj1KSkpyWlEAAAA3UoX3EDVv3lwHDhyQv7+/zatWrVpVWSMAAECVqvAeolq1amnZsmUKCwuz2VbZu1cDAAC4ArvOISovDEnSrbfe6oxaAAAAqoVDJ1Xv3bvXWXUAAABUG4cC0ciRI51VBwAAQLVxKBAZhuGsOgAAAKqNQ4HInqfeAwAAuCruVA0AADwegQgAAHg8ziECAAAez6FAtGLFCmfVAQAAUG0cCkT33HPPdbdv3LjRkeEBAABuiAo/uuNaTp8+raVLl2r//v0qKCiwHEYzDEOHDh3S6dOnHS4SAACgKjkciHr37q0zZ86oY8eOqlu3rqX98uXLOnbsmKPDAwAAVDmHA1FGRoaOHTsmf39/m20pKSmODg8AAFDlHL7svlevXte82oyHvgIAAHfg8B6iBQsW6PXXX9eDDz5o1X7p0iX94x//0OrVqx39CAAAgCrlcCB6//33FRcXp9mzZ9tsM5lMBCIAAODyHA5Es2fP1uLFi9WtWzfVrFnT0n758mV98MEHjg4PAABQ5RwORM2aNdPIkSPLfdDruHHjHB0eAACgyjl8UvWrr76qzz77rNxtX3/9taPDAwAAVDmH9xBt2LBB//vf/8q9ouy7776r1I0ZDcPQwoULlZ2dLV9fX506dUqLFi1SYGBguf0PHz6s2NhYRUREKC0tTQMHDlTv3r3L7VtUVKTf//73SkpKUlhYmN21AQCAm4/DgahGjRq67bbb1KxZM6v2y5cv68cff6zUmLGxsdq2bZuSkpIkSTExMRo8eLASExNt+mZnZ6tr165au3atoqKilJubq/DwcG3atEkdO3a06T9t2jT98MMPlaoLAADcnBwORCNGjFCHDh3k5+dns+2LL76we7zc3FzNnTvX6sGxw4YNU/PmzbV9+3ZFRUVZ9V+4cKFq1aplaTebzerVq5emTp1qCVRlvvrqq3LPdQIAAJ7N4XOIOnbsqKVLl+r48eOWto0bN+rYsWPq0qWL3eNt3rxZxcXFateunaUtLCxMISEhWrdunU3/+Ph4q76S1L59eyUnJysnJ8fSVlJSonfffVejR4+2uyYAAHBzczgQjRkzRtOmTdO+ffssbb1799bMmTO1a9cuu8c7cOCAJCk0NNSqPTQ0VOnp6VZtJSUlOnr0aLl9DcOwqmnu3LmaPHmyatSo2JRLS0tVUFBg9QIAADcnhwNRXl6esrKybE5ijo6OrtRl97m5uZJk82y0gIAAqz0+ZZ9tGEa5fSVZ+u/cuVNBQUFq2bJlheuIi4tTUFCQ5dW0aVO75wIAANyDw4GodevWqlevnk37iRMn9M0339g9nq+vryTZnOtjMpnk4+NT4b6S5OPjowsXLmjp0qV68cUX7apjypQpys/Pt7wyMzPt+nkAAOA+HA5Ely9ftjmU9c0332jGjBlq1aqV3ePVr19fklRYWGjVXlhYqMaNG1u1mc1meXt7l9tXkho3bqzXXntNEydOlJeXl1111KxZU3Xq1LF6AQCAm5PDV5lNnDhRjz76qKSrAeTEiRNKTU1VvXr1tHz5crvHa926tSQpKyvL6hBXVlaWunbtatXXZDIpIiJCWVlZVu1ZWVny9vZWeHi4nnrqKc2fP9+yzTAMSVKrVq30hz/8QZs3b7a7RgAAcHNxOBAFBAQoOTlZGzZs0Pbt2xUSEqJBgwbp6aefvuaNFK+nR48eql27ttLS0iyBKDMzU9nZ2YqOjrbp369fP5sHyO7evVvdunWT2WzWtm3bdPHiRcu2rKwsdenSRZ9++qnuuOMOu+sDAAA3H4cDkXR1T02/fv3Ur18/h8fy8/PT+PHjtWrVKg0aNEiStHLlSnXu3FmRkZHaunWrRo0apQ0bNqhVq1YaOXKk3nzzTaWmpqpTp07Kz89XQkKC1qxZI0k2N4z09va2tDdp0sThegEAgPuz+xyixYsXV+qD7Pm52bNn695779XYsWM1ffp0ff/990pISJDJZFJBQYFycnJUVFQkSWrYsKGSkpK0aNEizZs3Ty+88IKWLVum7t27V6pOAADgeezeQ5Sfn1+pDyq7nL4iatSooTlz5pS7rX///urfv79VW9u2bcu9aWN5wsLCLOcRAQAASJUIRK+//rq2bdtm1yMw8vLybK4QAwAAcBV2B6IJEyZU6oM4gRkAALgquwPR9OnTq6IOAACAauPwjRkBAADcHYEIAAB4PAIRAADweE4JRL169dLp06edMRQAAMAN55RAtHnzZp09e1YFBQVKTk6u9L2KAAAAqoPTDpllZGTo7rvv1oMPPqhmzZopISHBWUMDAABUKac8y8zX11erV69WfHy8zGazUlJS9Ne//lXNmjVTmzZtnPERAAAAVcYpe4iaN2+u4cOH65577lFYWJiGDBmiHTt2aMOGDc4YHgAAoEo5JRA9/vjjmjp1qoqLiy1tderUUUREhDOGBwAAqFJOCUQTJkzQ2bNnFRUVpR07dljaDx8+7IzhAQAAqpRTAlFQUJC2bNmikpIS3XfffWrQoIFuvfVW/d///Z8zhgcAAKhSTjmpWpJatGihb775Rps2bdLevXvVpEkTDR061FnDAwAAVBmnBSJJ8vLyUp8+fdSnTx9nDgsAAFClnProjvPnz1udWA0AAOAO7A5EhmFoxYoVGjt2rDZv3ixJSktL0z333KO6desqICBAkZGR+t///uf0YgEAAKqC3YfMXnzxRS1ZskRt2rTRli1bdOjQIS1atEjFxcV6//331aFDB/3000+aN2+e5s6dy6X3AADA5dm9h+if//yn3n//fe3Zs0eHDx9W3bp19dNPP2nZsmUaMmSIWrZsqW7duunf//43j+8AAABuwe49RDVq1FDPnj0t74cPH67PP/9c3bt3tx7Y21unTp1yvEIAAIAqZvceoj/96U/auXOnVdv06dMVHBxs1fbTTz/pww8/dKw6AACAG8DuQPT6669ry5Yt2rVrl6XtzjvvlMlksuq3ePFim5AEAADgiuwORP7+/lq8eLEaNGhw3X4jR45UYmJipQsDAAC4USp9H6JmzZpZvR8xYoROnjxped+8eXPdddddNu0AAACuxmk3Zly1apXy8vIq3A4AAOAqnBaIDMOwqx0AAMBVOPXRHQAAAO6o0g93PXv2rA4ePGh5bxiGdu/erTNnzkiSTCaToqKiHK8QAACgilU6EO3atUujRo2yvL9y5YqmTp0qHx8fSVcD0ZEjRxyvEAAAoIpVOhD98Y9/VEZGhuW9j4+PPvvsM911111OKQwAAOBG4RwiAADg8QhEAADA4xGIAACAx3NaIEpKSlLz5s0r3A4AAOAqKn1S9a/94Q9/sKsdAADAVXDIDAAAeDwCEQAA8HgEIgAA4PEIRAAAwOMRiAAAgMcjEAEAAI9HIAIAAB6vSgNRSUlJVQ4PAADgFE67MePp06dVWlpqeX/lyhUtX75c8+bNc9ZHAAAAVAmHA9GaNWs0duxY5ebmWrUbhiGTyUQgAgAALs/hQDRu3DgNGDBAjz32mHx9fS3tpaWleueddyo1pmEYWrhwobKzs+Xr66tTp05p0aJFCgwMLLf/4cOHFRsbq4iICKWlpWngwIHq3bu3ZXt2drbGjRunLVu2yM/PT6NHj9bUqVMrVRsAALj5OByI6tatq0WLFsnb23ao1q1bV2rM2NhYbdu2TUlJSZKkmJgYDR48WImJiTZ9s7Oz1bVrV61du1ZRUVHKzc1VeHi4Nm3apI4dO+rKlSt6+eWX9Ze//EVvvvmm/vGPf2jq1Klq27atHnnkkUrVBwAAbi4On1QdGxurhISEcrft3r3b7vFyc3M1d+5cDR061NI2bNgwbdy4Udu3b7fpv3DhQtWqVUtRUVGSJLPZrF69eln2AO3atUszZszQAw88oIYNG2rKlCkym806ePCg3bUBAICbk8N7iD7++GOlpqZq6dKlVu2GYWj//v06c+aMXeNt3rxZxcXFateunaUtLCxMISEhWrdunSX4lImPj7fqK0nt27fXBx98oJycHHXs2NFqW2lpqS5duqSHHnrIrroAAMDNy+FA5O3trfDwcDVq1Miq/dKlS/rhhx/sHu/AgQOSpNDQUKv20NBQpaenW7WVlJTo6NGjVucLlfU1DEP79u3Tgw8+aLUtNjZW77zzjtq0aXPdOkpLS62umisoKLB7LgAAwD04HIhGjRqle++9V15eXjbbduzYYfd4ZVer+fv7W7UHBAQoJyfHqi0vL0+GYZTbV5JV/9TUVE2fPl2ff/65wsPD1aFDBzVv3vyadcTFxWnmzJl21w8AANyPw+cQRUZG6ttvv9VTTz2lVq1aqU2bNnrhhRd04sQJm8NVFVF2pZrJZLJqN5lM8vHxqXBfSVb97733Xn3wwQdaunSpjh07phdffPG6dUyZMkX5+fmWV2Zmpt1zAQAA7sHhPUSpqal68MEHVbduXUVERKhevXo6ePCg2rdvr23btikiIsKu8erXry9JKiwstLrMvrCwUI0bN7bqazab5e3trcLCQqv2sve/7O/t7a1GjRrp+eefV05Ojt56663r1lGzZk3VrFnTrtoBAIB7cngP0eTJkzVv3jydOHFCn332mT788EN98cUX2rlzpxYvXmz3eGWX6mdlZVm1Z2Vl2YQrk8mkiIiIcvuWndtUng4dOpR7mwAAAOCZHA5ELVu21JgxY2wCRlhYmG655Ra7x+vRo4dq166ttLQ0S1tmZqays7MVHR1t079fv35WfaWrl/t369ZNZrO53M84efKkunTpYndtAADg5uRwIPr1YawyFy5c0K5du+wez8/PT+PHj9eqVassbStXrlTnzp0VGRmprVu3qkWLFpb7CI0cOVJnzpxRamqqJCk/P18JCQmaOHGiJGnPnj2KiYlRXl6eJOn8+fP64IMPNGfOHLtrAwAANyeHjxudO3dOb7/9tp544gn5+/vrxx9/1Jdffqk33njD5p5BFTV79mzFxMRo7NixCg4OVkZGhhISEmQymVRQUKCcnBwVFRVJkho2bKikpCTFxcUpJSVF+/fv17Jly9S9e3dJVwPSe++9p7///e8aOHCgQkJC9P7771/3CjMAAOBZTIZhGI4M8PPPP6tXr1768ssvLW2GYejhhx9WfHy8/Pz8HC7SFRQUFCgoKEj5+fmqU6dOdZcDwEmKLlzSXTH/kSQdmvWwavtyfiFwM6no32+HV35AQID++9//auvWrUpLS5OXl5ciIyN1//33Ozo0AADADeG0fwo99NBDNo/DOH/+/DWfUA8AAOAqHD6p+np+eWI0AACAq7J7D1GHDh3UqVMnvfXWWzIMQ5GRkTaP1JCuXmV26tQpjR492imFAgAAVBW7A1GXLl0sN0g0mUy67777dPr0aZubIF68eFGffPKJc6oEAACoQnYHovnz51u979evn+68807LIzfK7N+/X+3atXOsOgAAgBvA4XOINmzYYBOGJOnOO+/UypUrHR0eAACgylXqKrPS0lItWbJERUVF+vrrrzVr1iyr7YZh6LvvvtMXX3zhjBoBAACqVKUCUc2aNfXYY48pOjpax48f18mTJ622m0wmmc1mLVq0yClFAgAAVKVK34fod7/7nVJSUvTxxx/rmWeecWZNAAAAN5RD5xDVrVuXMAQAANyewydVl5aWasGCBTp+/LilLTExUceOHXN0aAAAgBvC4UA0evRoTZs2Tfv27bO0PfbYY5o5c6Z27drl6PAAAABVzuFAlJeXp6ysLPXu3duqPTo6WuPGjXN0eAAAgCrncCBq3bq16tWrZ9N+4sQJffPNN44ODwAAUOUcDkSXL19Wenq6Vds333yjGTNmqFWrVo4ODwAAUOUqfdl9mYkTJ+rRRx+VJDVu3FgnTpxQamqq6tWrp+XLlztcIAAAQFVzOBAFBAQoOTlZGzZs0Pbt2xUSEqJBgwbp6aefVmBgoDNqBAAAqFIOHzKTpBUrVujAgQN644039MYbb+jcuXP66quvnDE0AABAlXM4EE2ePFnPP/+8tmzZIkny8fHR1KlTtWbNGn388ccOFwgAAFDVHA5EmzdvVlpamjp06GDVPmzYME2fPt3R4QEAAKqcw4Goffv2atOmjU376dOndeTIEUeHBwAAqHIOB6K6deuquLhYJpPJ0rZ//35NmjRJLVu2dHR4AACAKufwVWYvvviiHn/8cf3www/Kzs5WRkaGdu7cKX9/f61evdoZNQIAAFQphwNR06ZNlZiYqPXr12vv3r0ym80aMGCAnnrqKQUHBzujRgAAgCrlcCCSpBo1auiJJ57QE088oXPnzqlOnTqqUcMpV/QDAABUObtTy+uvv64JEyZo+PDh+ve//21p//7779WxY0eFhIQoMDBQL730ki5duuTUYgEAAKqC3XuIJk+erE6dOmndunVq0qSJpKtXlD3wwAM6deqUunbtqnbt2mnz5s2KjY1VTEyM04sGAABwJrv3EAUEBCgxMdEShiRp+PDhOnXqlMaMGaOkpCTNnz9fO3fu1H//+1+nFgsAAFAV7A5E9957r0JCQizv161bp08//VRt27bVokWLLO1+fn5q0KCBc6oEAACoQnYHop9//lmlpaWSpCNHjuj5559XjRo1tHz5cpsTqQ8ePOicKgEAAKqQ3ecQdenSRXfffbd+//vf6/PPP9f58+c1YcIEm0d3LFmyhEAEAADcgt2BaO7cuapbt642bNigO+64Q4MHD9ZLL71k2f7DDz9ozpw5WrlypdWhNQAAAFdlMgzDcOaAu3fvlo+Pj2677TYFBgY6c+hqVVBQoKCgIOXn56tOnTrVXQ4AJym6cEl3xfxHknRo1sOq7euU27MBcBEV/fvt9JXfvn17Zw8JAABQpbidNAAA8HgEIgAA4PEIRAAAwOMRiAAAgMdzOBDt27dP+/bt07lz5yRJqamp6t+/v0aPHq28vDyHCwQAAKhqDgei7t2768iRIwoICNDx48fVs2dP5eTkqEWLFpoyZYozagQAAKhSDl92P2HCBPXv31+SNGrUKAUGBmrLli3y9/fXihUrHC4QAACgqjntPkTLly/Xli1b9O9//1v+/v6SpEOHDjlreAAAgCrj8CGzW265RY0bN9a4ceM0d+5c9dHFEpgAACAASURBVOvXT/v379fo0aO1bNkyZ9QIAABQpZzy6I7S0lJdvHhRAQEBkqTs7GwVFxdLkpo1a+bo8C6BR3cANyce3QHc3G7ooztq1qypmjVrWt43aNDAGcMCAADcEC552b1hGFqwYIEmTZqkV155Rc8++6zOnz9/zf6HDx/W0KFDtWDBAg0aNEgbN2602p6VlaXo6GiFhIQoNDRUf/3rX3XhwoVK1QYAAG4+LnnZfWxsrDZv3qz58+drzpw5aty4sQYPHlxu3+zsbHXt2lXDhw/XxIkT9be//U3Dhg3Tjh07JEmXLl3SM888oy5dumjZsmW65557NG/ePM2YMaOyUwYAADcZh88hmj9/viZNmiRJ6tmzpw4cOKBvv/3Wctn9yJEj7RovNzdXoaGhWrFihZ5++mlJ0rFjx9S8eXOlpKQoKirKqv/kyZO1fv16HT161NI2dOhQZWZmKikpSRs2bJC/v7+6d+8uSbpy5Yrat2+vnJwcZWZmVrguziECbk6cQwTc3Cr699tpj+4ou+z+rbfecuiy+82bN6u4uFjt2rWztIWFhSkkJETr1q2z6R8fH2/VV5Lat2+v5ORk5eTkKCQkxBKGJKlGjRrq1q2b8vPz7a4NAADcnFzusvsDBw5IkkJDQ63aQ0NDlZ6ebtVWUlKio0ePltvXMAzt27fPZo9S2c916NDhunWUlpaqoKDA6gUAAG5ODgeip59+WhkZGcrNzbWcM9SoUSO9/PLLOnLkiN3j5ebmSpJlL1OZgIAA5eTkWLXl5eXJMIxy+0qy6V9m+/btGj9+/HXriIuLU1BQkOXVtGlTu+YBAADch1MOmX3//ff6y1/+olatWqlNmzaaPn26TCZTpe5B5OvrK0kymUxW7SaTST4+PhXuK8mmvyRt3bpV4eHhevTRR69bx5QpU5Sfn2952XO+EQAAcC8Onz2YmpqqBx98UHXr1lVERITq1aunQ4cOqX379tq2bZsiIiLsGq9+/fqSpMLCQgUGBlraCwsL1bhxY6u+ZrNZ3t7eKiwstGove//r/ufOndOyZcv0wQcf/GYdv763EgAAuHk5vIdo8uTJmjdvnk6cOKHPPvtMH374ob744gvt3LlTixcvtnu81q1bS7p676BfysrKsglXJpNJERER5fb19vZWeHi4pe3y5cuaNGmSlixZYjmkBgAAIDkhELVs2VJjxoyRt7f1zqawsDDdcsstdo/Xo0cP1a5dW2lpaZa2zMxMZWdnKzo62qZ/v379rPpK0u7du9WtWzeZzWZL25QpUzRu3Dg1adLE0sbDZwEAgOSEQPTrw1JlLly4oF27dtk9np+fn8aPH69Vq1ZZ2lauXKnOnTsrMjJSW7duVYsWLXTw4EFJ0siRI3XmzBmlpqZKkvLz85WQkKCJEydafn7OnDkqKSnRt99+q/Xr12v9+vVasGCBPvnkE7vrAwAANx+HzyE6d+6c3n77bT3xxBPy9/fXjz/+qC+//FJvvPFGuZe8V8Ts2bMVExOjsWPHKjg4WBkZGUpISJDJZFJBQYFycnJUVFQkSWrYsKGSkpIUFxenlJQU7d+/X8uWLbPce2jNmjV69dVXJUlLliyx+pzvv//egZkDAICbhcN3qv7555/Vq1cvffnll5Y2wzD08MMPKz4+Xn5+fg4X6Qq4UzVwc+JO1cDN7YY97X7z5s2aPXu2Ll68qD179sjLy0uRkZG6//77HR0aAADghnA4EI0cOVKjR4/WrFmz9OCDD1ptMwzD5h5BAAAArsbhk6pnzpyprl27lrutvGePAQAAuBqH9xCdOXNGL7/8sn73u9+pVq1alvZLly4pOTlZTz75pKMfAQAAUKUcDkRlj7Y4efKkVfuVK1f0888/Ozo8AABAlXM4EA0ZMkSjR4/WHXfcYbOtIo/IAAAAqG52B6LExETLf/f19dUf//hHmz67du3SrbfeqiFDhjhWHQAAwA1g90nVffv2Vf/+/ZWSkqI777yz3D6tWrXS6NGjbR66CgAA4IoqdZXZvHnztGDBAjVr1qzc7bVr19bkyZP1+uuvO1QcAADAjWB3IAoNDdWECRN+s1/79u21d+/eShUFAABwI9kdiCIiIircl0NmAADAHdgdiMoeqloRx48ft3d4AACAG87uQGQYhvbs2fOb/RITE2U2mytVFAAAwI1kdyAaMWKE+vbtq127dl2zT3JysoYNG6ann37aoeIAAABuBLvvQ/TUU0/p008/VadOndS1a1c98MADuuWWW3Tp0iVlZmYqOTlZX3/9tf7whz9o1KhRVVEzAACAU1XqTtWrV69WRESE5s2bp6SkJMsT7Q3DkLe3t5599lm9+eab8vLycmqxAAAAVaFSgahGjRqaOnWqxowZo+TkZB0+fFiXL19W06ZN1bVrV91yyy3OrhMAAKDKOPQss8DAQD322GPOqgUAAKBaVOpO1QAAADcTAhEAAPB4BCIAAODxCEQAAMDjEYgAAIDHIxABAACPRyACAAAej0AEAAA8HoEIAAB4PAIRAADweAQiAADg8QhEAADA4xGIAACAxyMQAQAAj0cgAgAAHo9ABAAAPB6BCAAAeDwCEQAA8HgEIgAA4PEIRAAAwOMRiAAAgMcjEAEAAI9HIAIAAB6PQAQAADwegQgAAHg8AhEAAPB4BCIAAODxCEQAAMDjeVd3AeUxDEMLFy5Udna2fH19derUKS1atEiBgYHl9j98+LBiY2MVERGhtLQ0DRw4UL1797bpl5iYqJUrVyo+Pr6qpwAAANyISwai2NhYbdu2TUlJSZKkmJgYDR48WImJiTZ9s7Oz1bVrV61du1ZRUVHKzc1VeHi4Nm3apI4dO1r6bNy4Ua+88opq1qx5Q+cCAABcn8sdMsvNzdXcuXM1dOhQS9uwYcO0ceNGbd++3ab/woULVatWLUVFRUmSzGazevXqpalTp1r6NGjQQMOHD9dDDz1U5fUDAAD343KBaPPmzSouLla7du0sbWFhYQoJCdG6dets+sfHx1v1laT27dsrOTlZOTk5Vu1eXl5VUzQAAHBrLheIDhw4IEkKDQ21ag8NDVV6erpVW0lJiY4ePVpuX8MwtG/fvkrXUVpaqoKCAqsXAAC4OblcIMrNzZUk+fv7W7UHBATY7PHJy8uTYRjl9pVk098ecXFxCgoKsryaNm1a6bEAAIBrc7lA5OvrK0kymUxW7SaTST4+PhXuK8mmvz2mTJmi/Px8yyszM7PSYwEAANfmcleZ1a9fX5JUWFhodZl9YWGhGjdubNXXbDbL29tbhYWFVu1l73/d3x41a9bkijQAADyEy+0hat26tSQpKyvLqj0rK0sRERFWbSaTSREREeX29fb2Vnh4eNUWCwAAbgouF4h69Oih2rVrKy0tzdKWmZmp7OxsRUdH2/Tv16+fVV9J2r17t7p16yaz2Vzl9QIAAPfncoHIz89P48eP16pVqyxtK1euVOfOnRUZGamtW7eqRYsWOnjwoCRp5MiROnPmjFJTUyVJ+fn5SkhI0MSJE23GLi0t1ZUrV27MRAAAgNtwuXOIJGn27NmKiYnR2LFjFRwcrIyMDCUkJMhkMqmgoEA5OTkqKiqSJDVs2FBJSUmKi4tTSkqK9u/fr2XLlql79+6W8fLz8/XRRx9py5YtKigo0KJFi9SnTx/ddttt1TVFAADgQkyGYRjVXYQ7KCgoUFBQkPLz81WnTp3qLgeAkxRduKS7Yv4jSTo062HV9nXJfycCqKSK/v12uUNmAAAANxqBCAAAeDwCEQAA8HgEIgAA4PEIRAAAwOMRiAAAgMcjEAEAAI9HIAIAAB6PQAQAADwegQgAAHg8AhEAAPB4BCIAAODxCEQAAMDjEYgAAIDHIxABAACPRyACAAAej0AEAAA8HoEIAAB4PAIRAADweAQiAADg8QhEAADA4xGIAACAxyMQAQAAj0cgAgAAHo9ABAAAPB6BCAAAeDwCEQAA8HgEIgAA4PEIRAAAwOMRiAAAgMcjEAEAAI9HIAIAAB6PQAQAADyed3UX4OkMw1DxxcvVXQbgsYousP4AEIiqXfHFy7or5j/VXQYAAB6NQ2YAIKl9s2D5+XhVdxkAqgl7iKqZn4+XDs16uLrLADyen4+XTCZTdZcBoJoQiKqZyWRSbV++BgAAqhOHzAAAgMcjEAEAAI9HIAIAAB6PQAQAADwegQgAAHg8AhEAAPB4BCIAAODxCEQAAMDjueQdAQ3D0MKFC5WdnS1fX1+dOnVKixYtUmBgYLn9Dx8+rNjYWEVERCgtLU0DBw5U7969LdsvXLig6dOnq1atWiooKJBhGJo3b558fHxu1JQAAIALMxmGYVR3Eb82d+5cbdu2TUlJSZKkmJgYpaenKzEx0aZvdna22rZtq7Vr1yoqKkq5ubkKDw/Xpk2b1LFjR0nSiBEjdOXKFb333nuSpCFDhqhu3bpavHhxhWsqKChQUFCQ8vPzVadOHSfMEgAAVLWK/v12uUNmubm5mjt3roYOHWppGzZsmDZu3Kjt27fb9F+4cKFq1aqlqKgoSZLZbFavXr00depUSdK3336rd99912a8ZcuWKSMjo0rnAgAA3IPLBaLNmzeruLhY7dq1s7SFhYUpJCRE69ats+kfHx9v1VeS2rdvr+TkZOXk5Cg+Pl6SdM8991htv3z5smUbAADwbC4XiA4cOCBJCg0NtWoPDQ1Venq6VVtJSYmOHj1abl/DMLRv3z4dOHBAwcHB8vf3t2wPCAhQUFCQzXi/VFpaqoKCAqsXAAC4ObncSdW5ubmSZBVgpKshJicnx6otLy9PhmGU21eScnJylJuba7P9WuP9UlxcnGbOnGnTTjACAMB9lP3d/q1Tpl0uEPn6+kqSTCaTVbvJZLK5Kux6fSXJx8dHvr6+NtuvNd4vTZkyRS+99JLlfVZWlu666y41bdrUjtkAAABXcP78eQUFBV1zu8sFovr160uSCgsLrS6zLywsVOPGja36ms1meXt7q7Cw0Kq97H3jxo1Vv359m+3XGu+XatasqZo1a1reBwQEKDMzU4GBgeUGLEcUFBSoadOmyszMvCmvYGN+7u9mnyPzc383+xyZX+UZhqHz589f92++5IKBqHXr1pKu7pFp2bKlpT0rK0tdu3a16msymRQREaGsrCyr9qysLHl7eys8PFytW7fWypUrVVxcLD8/P0lSUVGR8vLyFBERUeG6atSoYXOukrPVqVPnpvwfehnm5/5u9jkyP/d3s8+R+VXO9fYMlXG5k6p79Oih2rVrKy0tzdKWmZmp7OxsRUdH2/Tv16+fVV9J2r17t7p16yaz2ax+/frJMAzt3bvXsn3Pnj0ymUzq379/1U0EAAC4DZcLRH5+fho/frxWrVplaVu5cqU6d+6syMhIbd26VS1atNDBgwclSSNHjtSZM2eUmpoqScrPz1dCQoImTpwoSbr11ls1aNAgm/EGDRqkJk2a3MCZAQAAV+U1Y8aMGdVdxK917dpVhw8f1oYNG/T111/r6NGjWrVqlWrXrq309HStWbNGAwcOVJMmTRQQEKAePXro9ddf1w8//KD3339fL730kh577DHLeD179tRnn32mr776Sp9//rmuXLmipUuXytvbdY4Yenl5qUuXLi5VkzMxP/d3s8+R+bm/m32OzK9queSjOwAAAG4klztkBgAAcKMRiAAAgMcjELmg77//vrpLqHbZ2dncFdzNuft3yDp0/+/Q07n793ej1yCByMkMw9CCBQs0adIkvfLKK3r22Wd1/vz56/5M586dZTKZLK81a9ZYtl24cEFTpkzRzJkzNWHCBL300ku6ePFiVU/juuyZ47p166zmVvYquwFnmXfffddqe6dOnaxuzFkdUlJSbO59VZ7Dhw9r6NChWrBggQYNGqSNGzdabXfF77BMRef4ySefqG3btgoICFCbNm20ZcsWmz7u/B1K7rcOy1Rkju64Ds+dO6fhw4erUaNGatiwoZ577rnr/nF3t3Vo7/zcbQ3aOz+p+tcgJ1U72dy5c7Vt2zYlJSVJkmJiYpSenq7ExMRy++/du1evv/66evToIenqWfZ9+/a1/I94xIgRunLlit577z1J0pAhQ1S3bl0tXrz4BsymfPbMcfDgwXrggQes7hD6ySefqKioyOpWCL1799af/vQny/t77rlHd999dxXO4trOnz+vxMREzZ49W9999911n3+TnZ2ttm3bau3atYqKilJubq7Cw8O1adMmdezYUZJrfof2zHHHjh2KiYnR8OHDdebMGcXFxen06dNKS0uzurmpu36HknuuQ3vm6I7rcMCAAWrbtq1uv/12bdq0SatWrdLAgQP14Ycf2vR1x3Voz/zccQ3aMz/JRdagAac5e/as4efnZ3zwwQeWtoyMDEOSkZKSUu7PDBs2zDh+/Hi52w4dOmTzs8nJyYaXl5fxww8/OLf4CrJnjiUlJcann35qM0bfvn2Njz76yPI+OTnZmDNnTtUVXUmvvPKK8VtLZNKkScZtt91m1fbnP//Z6Natm2EYrvkd/lJF5jhhwgSjqKjI8n7v3r2GJOOVV16xtLnzd2gY7rcOf+m35uiO63Dv3r3GO++8Y9XWp08fw8vLyygpKbHp727r0N75udsatHd+huEaa5BA5ESrV682JBkHDx60ag8JCTFGjx5t0//06dNGzZo1DX9/f+PRRx81Nm/ebLV9zpw5hiTj559/trSdP3/ekGQsWLCgaibxG+yd468VFxcbwcHBRkFBgaWtb9++hslkMlq3bm3ExcUZxcXFTq+7MqZPn/6bf0zvuOMO4/HHH7dqW7JkiWEymYzs7GyX/A5/qSJzLC/Mh4SEGGPGjLG8d+fv0B3X4S9VZI6/5urrMDU11bhw4YJV25IlSwxJxtmzZ236u9s6tHd+7rYG7Z2fq6xBziFyogMHDkiSzTPPQkNDlZ6ebtP//Pnzmjp1qh566CH95z//0SOPPKLY2Fir8YKDg+Xv729pCwgIUFBQULnj3Qj2zvHXPv/8c7Vv397quHaXLl0sdxyfMmWKOnfurJ9//tm5hVeBkpISHT16tNzfhWEY2rdvn0t+h/aKioqyaSstLVWHDh0s7931O5Tccx06ytXXYWRkpHx8fKzaSkpKdPvtt8tsNtu0u9s6tGd+kvutQXvn5yprkEDkRLm5uZJk9aVJV7+4nJwcm/633367YmJitGHDBh0+fFiRkZF65ZVXLM9my83NtRnreuPdCPbO8dcSEhKs7iIuSePGjdPy5cuVkZGhV199VXv27NG0adOcV3QVycvLk2EY5f4uJCknJ8clv0NH7d27V8HBwVbnKrjrdyi55zp0lDuuw+3bt2v8+PE27TfLOrzW/MrjjmvwevNzlTVIIHIiX19fSZLJZLJqN5lMNmn518LCwrRlyxbVq1dPH3/8sWW8X49V0fGqiiNzvHLlijZt2qRHH3203O0+Pj6aNWuWRowYofj4eOcUXIWu97uQrs7HFb9DR73xxhtatmyZ/Pz8bLa523f4a+6yDh3hjuvw22+/VV5enkaNGmWz7WZYh9ebX3ncbQ3aM7/qXIMEIicqu4S1sLDQqr2wsNDq6o5rCQoKUt++fZWdnW0Z79dj2TNeVXBkjjt27FCDBg0UFhZ23X5Dhw61/A5cmdlslre3d7m/C0lq3LixS36Hjti4caNatGhxzT+mZdzlOyyPO6xDR7jbOrxw4YJiYmK0du1aeXl52Wx393X4W/P7NXdbg/bOT6q+NUggcqLWrVtLkrKysqzas7KyrC6NvJ66detaQkfr1q2Vl5en4uJiy/aioiLl5eVVeDxnc2SOCQkJ6t27929+xi9/B67MZDIpIiKi3N+Ft7e3wsPDXfI7rKxDhw4pOTlZMTExv9nXXb7Da3H1degId1uH06ZNU0xMzDX/8Ln7Ovyt+f2SO65Be+b3S9WxBglETtSjRw/Vrl3bctxTkjIzM5Wdna3o6OgKjbF792498sgjkqR+/frJMAzt3bvXsn3Pnj0ymUzq37+/c4uvIEfmWNH/I969e7d69uzpcK03Qr9+/ax+F9LV+rt16yaz2eyS32FlnDx5UosXL9b8+fMtbYZh6Ntvvy23vzt9h+Vx9XXoCHdahwsWLFDPnj31+9//3tJ26NAhm37uug4rOj/JPdegPfP7tepYgwQiJ/Lz89P48eOtbnS2cuVKde7cWZGRkdq6datatGihgwcPSpLGjh2radOmqaioSJL00UcfqUWLFrr//vslSbfeeqsGDRpkM96gQYPUpEmTGziz/8/eOZY5fPiwcnNzra6KkKRNmzbpySeftFy9dvr0aa1cuVKzZs2q+sn8htLSUklXz7ko8+v5lV3VkZqaKknKz89XQkKCJk6cKMk1v8Nfqsgcz58/rwEDBqhTp07asGGD1q9fr7Vr1+rPf/6zfHx83P47dMd1+EsVmWMZd1qHq1evVlpams6ePav169dr/fr1+tvf/qYPPvjgpliH9szPHdegPfNzlTXo7bSRIEmaPXu2YmJiNHbsWAUHBysjI0MJCQkymUwqKChQTk6O5UsPCAjQ8uXL9fHHH6tXr16KiIjQ8uXLrcZ799139dJLL2nKlCm6cuWKatWqpaVLl1bH1CzsmWOZhIQE9erVSzVqWGfwoKAg7d27V/fdd5+eeuopNWrUSGvWrFHDhg1v5JSsXLx4Uf/6178sd1SNiYnRgAEDFBERYTO/hg0bKikpSXFxcUpJSdH+/fu1bNkyde/e3TKeK36H9szx8ccfV0pKilJSUqzG6Ny5s+644w6dPHnSrb9Dd12H9syxjLusw5SUFA0bNkwXL160enyDdDXs5efnu/U6tHd+7rYG7Z2fq6xBHt0BAAA8HofMAACAxyMQAQAAj0cgAgAAHo9ABAAAPB6BCAAAeDwCEQAA8HgEIgAA4PEIRAAAwOMRiAAAgMcjEAFwmrVr16pVq1YymUxq2bKloqOjFR0drUcffVS33367TCaTzp07V91lVsrOnTv15JNPqkOHDurVq5datWolLy8vmUwmDRgwoLrLA+AgnmUGwGkGDBigM2fOaMyYMfrrX/+qoUOHWrYZhlGhp6y7oiVLlmjixIlatGiR1q5dK5PJJEn66quv9MQTT1RzdQCcgT1EAJwqICCg3HaTyaRBgwbZPFjU1X3++ecaN26cXn31VT3//POWMCRJ999/v/75z39atQFwT+whAnDDDBo0qLpLsNurr76qWrVqady4ceVu79Kli/Ly8m5wVQCczb3+qQbAbb322ms6duyYJOngwYMaNWqUunbtqi+++EKtW7dWcHCw5s+fb/Uz77zzjsaMGaNHHnlEHTt21J49eyRJ//3vfzVs2DAtX75ckydPltls1pdffilJSktL09ixY/XCCy/Iy8tLgYGBio6O1t69e/Xyyy/LZDKpf//+yszMlCSlp6frlltu0SeffGJTc05Ojnbu3Kl27dopMDDwmnPr16+fJCkzM1NxcXHq27evUlJS1KRJE0uQ+u677/Tcc89pxowZ6tOnj5544gllZWVJkpKSkmQ2my2HGPft26c+ffpY9jydPn1ar732mu68806lpaWpQ4cO8vPzU48ePXTq1KnKfB0AfoU9RACqxOLFi7VhwwZJ0rFjx/TNN99YTj5u2bKlrly5on379unIkSPauXOnFi9erKlTp+qZZ55R/fr19a9//UsXLlzQkiVLJEl9+vTRY489pmPHjik4OFjr169XRkaGYmNjVVJSouDgYJ0/f169evXSjh07dOutt+ry5cv6xz/+odWrV6tWrVpq3bq14uPj5ePjo6ZNm0qSWrRoocjISPXq1ctmDseOHZNhGGrSpInNtrNnzyo+Pl6XL1+WJPn4+OiPf/yjvvnmG3399dc6evSo5s6dq8LCQp06dUoPPPCAtm7dqoiICBmGoccff1xdunRRenq6HnzwQUVERFjGvvvuu9W3b18lJiZKkry9vXXy5En93//9n7Zt26aEhASlpKToz3/+s0aOHKmEhAQnfnOAZyIQAagSY8eOtezxMAxDQ4YMsWzz8vLSLbfcosDAQD377LOSrgaeSZMm6ciRI6pfv75mzJihjh07avz48ZIkX19fNW3aVNnZ2br77rtlNpvVsWNHderUSZ06dZIkffrppzp16pQaNWokSXr88ce1YsUK5efnq1atWqpRo4ZeeOEFTZkyRadPn1bDhg31ySef6LHHHit3DmVhp7zznkJCQhQdHa2IiAjl5eXpxIkTqlevnlq2bKkvvvhCzzzzjKXvK6+8onr16llCj8lk0vTp03X33Xfrn//8p5577jmbz/jleUkhISFq27atJGnChAkymUx68sknlZKSomXLlik7O1sNGjSo4DcDoDwcMgNQ5Uwm0zVDRxlfX19JUmlpqYqLi/Xdd99p6tSpevPNN/Xmm2/qo48+0tdff221t6ZWrVpWY1y4cEGSdPz4cUlSaGio/P39rcLC8OHD5ePjo/fee0+StHHjRsshr1+79dZbJclyaOvXgoODdfvtt6tBgwaqV6/eNevas2eP/P39rdoiIiLk6+urvXv3XuM3Ur5fBqUHHnhAkpSRkWHXGABsEYgA3BD9+vWzBIzfUlRUJMMwyv1DXxZ6yvPQQw+pefPmeueddyRJBw4csOxRKRMUFKQhQ4bonXfeUWFhoS5fvqy6deuWO17jxo0VERGhnTt3XvP+SRW5as7Ly0s//vijVZvJZJLZbJaPj89v/vy11KlTx+o/AVQegQjADeHt7a0aNWpo6tSpv9k3JCREZrPZEmzKpKen67PPPrvmzwUEBGjdunXat2+f5syZo5KSEs2YMcOm35gxY3TixAmNGTOm3HOHfmnmzJkqKSnRnDlzfrPua4mMjNTJkyd19OhRS9vFixd15swZ3XfffZKuBqQrV65Ytl8v+JU5duyYmjRpovDw8ErXBuAqAhEApyoqKpJ09dDXr7399tsqKCiQJF26dEmGSRn7iAAAAyRJREFUYVi2lQWAslDw/PPPKz4+XqNGjdL27du1cuVKzZ49Wz179rT0u3TpktX4R44c0Ysvvqinn35ad9xxh7y8vP5fe/cTCs0fxwH8PTjNQSz5c3NQ/jWss+RC2uRgl9NGNgfZi6gpJa5SZHNxoeFCYqk9kHKh3Dc5IKcpJGxtLrTp/RyebI+o3/N7nt8vf+b9On5npvlMU9N7Zr6fGezv779Zr6amBq2trVhbW/vHV3nBYBCzs7OIxWKYnJx8dVzpdBqu68I0zezYe3UNDQ2hvLwc09PT2bH19XXU19cjFAoBACoqKnB4eIjLy0ucnp5iZ2cHALKdeS9c1wXwM1AtLS1hamrqy33bSeRToojIf2RjY4N+v58AWFJSwu7ubobDYXZ1dbG6upoAuLW1xZOTE/r9fubl5dFxHKbTaQ4ODhIA+/r6eHd3x6enJ0ajURYUFNDn87G3t5e3t7fMZDKMxWLMzc1lXV0dE4lEdv+u67KxsZGVlZU0TZOGYRAA29vb39S6urrKYDD428d2fHzM/v5+WpbFtrY2dnZ2sqmpibZt8+rqiiR5cHBAy7JoGAbn5+d5c3OT3f7i4oIdHR0Mh8OcmJhgNBrl/f19dvn5+TkbGhpomiYjkQjj8TgDgQAdx+Hz8zMdxyEAjo6OcmRkhKFQiIuLi39ymkTkHQb5yy2aiMgXFo/H8fDw8Kq7LZVKwbZtzMzMwOfzZdddWFhAcXExenp6Pqjaf2d5eRmRSAS6ZIv8P9R2LyLfwuPjIwYGBl69YjIMA0VFRbAsC4WFhdlxkkgkEtje3v6ASkXkM1IgEpFv4WXuzvj4OMbGxlBaWorr62tsbm6itrYWhmFgbm4OR0dHyMnJQXNz85v2+M/s5ZtImUzmrzrTROR9moknIt+CaZrY3d1FMplEVVUVysrKMDw8jJaWFgQCAQBAKpXC3t4e8vPzYdv2B1f8+5LJJFZWVgD8/Lfa2dnZB1ck8v1oDpGIiIh4np4QiYiIiOcpEImIiIjnKRCJiIiI5ykQiYiIiOcpEImIiIjnKRCJiIiI5ykQiYiIiOcpEImIiIjn/QBYLPtW8r4KuQAAAABJRU5ErkJggg==\n",
       "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
+       "<Figure size 640x480 with 1 Axes>"
       ]
      },
      "metadata": {},
@@ -498,14 +486,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYMAAAEGCAYAAACHGfl5AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy8QZhcZAAAbzElEQVR4nO3dfZQV9Z3n8fdHQVpAHYKNrdHmIZooCrqzbdC4YxjXPYYhalBpjXFjMgcxMbvjRJP1cTTEOLI+5Gh01pEYMCbxgeAiGjXpKElOSFAD2gGCYgwINsoGEKWd4wPId/+oar3gbbj39r1V/fB5ndPn1sO9dT+UZX+76lf1+ykiMDOzvm23vAOYmVn+XAzMzMzFwMzMXAzMzAwXAzMzw8XAzMyAfnkHqNS+++4bI0aMyDuGmVmPsXjx4g0RUV9sXY8tBiNGjGDRokV5xzAz6zEkre5snS8TmZmZi4GZmbkYmJkZPbjNoJgtW7bQ1tbG22+/nXeUTNXV1XHggQfSv3//vKOYWQ/Vq4pBW1sbe+21FyNGjEBS3nEyERFs3LiRtrY2Ro4cmXccM+uhetVlorfffpuhQ4f2mUIAIImhQ4f2ubMhM6uuXlUMgLILwZl3LOTMOxbWKE02+lLxM7Pa6FWXicxyt2gWLJ2TdwrrzRrGwITpVd+si0EVrVmzhksuuYR777236Prp06czaNAgFixYwMKFCzn55JMZM2YM7e3trFq1inPOOYcHH3yQ66+/PuPkVjVL58C6pcn/sGY9iItBFTU2NnLXXXcVXffaa68xb948Fi5cyJQpU5gwYQKTJ09m/PjxAKxevZrhw4fT1NSUXWCrjYYx8OVH8k5hVpZuUwwkDQKagZci4ldd3d60h//E8lc27/J9y19N3lNKu8HoA/bm6pMP73xby5fT0tJCe3s7K1eu5IADDmDhwoU88cQT/PSnP2XDhg3cd999nHXWWdt97vHHH6epqYmnn36aJUuWMGXKFGbOnMmwYcN44IEHmDVrFrfccgsHH3wwP//5z7n11lt3mdXMrByZNSBL6ifpGkmTJF0uabeCdfsCc4H51SgEedl///25+eabOeiggxgyZAjXXnstmzZtYt26dZx00kkMHTp0u0IwZ84cvvvd73LllVcC0L9/f3784x8D8Itf/IJhw4bxne98B4BHHnmEj3/841x66aXZ/8PMrNfL8szgPGBtRMyV1ABMBu5P190E/DAiOu1EqVw7+wu+UMcZwf3nH9vl7xwyZMj703vssQcAAwYM4J133in6/jPOOIPx48czadIk6urqtvv8tGnTOO200zj99NO55ppruOqqqzjppJP4xje+wQUXXNDlrGZmhbK8tfQYoDWdbgUmAkjqT1IY9pd0t6RpGWbqFkaOHEldXd12y9566y2effZZnnzySZYtW8agQYN45plnuOOOO9i8edeXv8zMypHlmUED0J5OtwP7pdP1JO0ENwJI+pOk70dE244bkDQVmApJY2138/TTT7Np0ybmzZvHtm3bWL16NW1tbSxZsoTNmzfT1tbGCy+8wLZt21i5ciXz589n3Lhx7Lnnnu9/fu3atbzyyivceOONNDc3c8QRRzBq1CjOPPNMvvKVr3DiiSey11575fwvNbPeRhGRzRdJ9wC3RMRTko4B/mdEfEHSQOCpiBiTvm8ucF1EPL2z7TU1NcWO4xk899xzHHbYYWXlquZlojxV8m+3Gpg1MXn13UTWDUlaHBFFb1nM8sygBTgSeAoYC7RIGhYRf5W0XtJeEdEO7An8OatQPb0ImJlVQ5ZtBncDjZKagUZgGXBbuu4SYJqks4EfRcSmDHOZmfV5mZ0ZRMQ24Mp0dnb62pyu+wPwh6yymJnZ9npdR3VmZlY+FwMzM3MxYNbED+4A6aLHH3+c2bNnf2j5Sy+9xBtvvFGV7zAzqwUXgyp66623ePTRR7dbtnz5co4//nheffVVAL7whS9w2WWXcdZZZ3H00Udz7bXX7vSW0PXr19c0s5kZuBhUVbGHwUaPHs2oUaPen586dSrXXXcdn/nMZzj88MO54ooruP3224tu78033+Tcc8+tWV4zsw4uBlW2Zs0apkyZQlNTEytXrvzQ+k9/+tMfWjZ+/HgightuuIGHHnqI888/nxUrVvDyyy/z+9//nnnz5mUR3cz6sG7ThXXVPXZpMsjIrqxbkryW0m5QwghDgwcP5s477+T2229n+vTpzJgxo4Sw8PDDD7N161ZOOeUUGhoa+PrXv86jjz5KXV0dp556aknbMDOrlM8MqmzgwIEAHHvssaxdu7bkzz3//PPsvvvuAIwdO5YVK1bUJJ+ZWTG998yg1DFCa9SXzGuvvcaxx5be1cWYMWOYNWvW+5896qijAMiq7ygz69t8ZlBFI0eOZMuWLdxzzz20trZy0UUX8fzzz7Nq1Srmz5/P1q1bAdi0aRMLFixg6dKlvPDCCwBMmDCBxsZGZs6cyb333suNN94IwCGHHMJNN93Eu+++m9u/y8x6v957ZpCD4cOH88ADD2y37NBDD2X16u3H7BkyZAh33nnnhz7fUQAKLViwoLohzcyK8JmBmZn5zMD9zpuZ+czAzMzohcWgL9590xf/zWZWXb2qGNTV1bFx48Y+9csxIti4cSN1dXV5RzGzHqxXtRkceOCBtLW19bnO3erq6jjwwAPzjmFmPVivKgb9+/dn5MiReccwM+txetVlIjMzq4yLgZmZuRiYmZmLgZmZ4WJgZmZ0w2Igae+8M5iZ9TWZFQNJ/SRdI2mSpMsl7VawbqikFZJeBL6ZVSYzM0tk+ZzBecDaiJgrqQGYDNyfrvsycGpEPJ9hHjMzS2V5megYoDWdbgUKBx2uB34m6deShmaYyczMyLYYNADt6XQ7sF/Hioi4BPgESZGY1tkGJE2VtEjSor7W5YSZWS1lWQw2AoPT6cHAhsKVEfEe8G2gsbMNRMSMiGiKiKb6+vqaBTUz62uyLAYtwJHp9FigRdIwAEkD0uXDgCczzGRmZmRbDO4GGiU1k/z1vwy4TdJIYLGkfwLGAzdlmMnMzMjwbqKI2AZcmc7OTl+b09cjssphZmYf1u0eOjMzs+y5GJiZmYuBmZmV0WYg6apdvGVJRDzYxTxmZpaDchqQB5DcHtqZ0V3MYmZmOSmnGNwdESs6Wynpr1XIY2ZmOSi5zWBnhSBd/1zX45iZWR52eWaQji/wNwWLRkXEr2uWyMzMMlfKZaJxwN8D76TzjcCvaxXIzMyyt8tiEBG/lPSriNgKySA1tY9lZmZZKqnNoKAQHNcxbWZmvUe5D52dX5MUZmaWq3KLgWqSwszMcuXuKMzMrOxi8HBNUpiZWa7KKgYR0TEOAZL2SH8+Wf1YZmaWpbJvE5X0E+DvgK0kbQj7AB+pci4zM8tQJc8MtEXE+4PWSzqoinnMzCwHlRSD30r6GrAlnT8cuLB6kczMLGuVFIPLgN/wQfcU+1QvjpmZ5aGSYjA3Im7smJHUUMU8ZmaWg0qKwUmSmvmgAbkeOLiqqczMLFOVFIN/A/4IbEvnj6xeHDMzy0PZxaBwnGNJ/SJidXUjmZlZ1srujkLSTElfTmcPl/S5Ej/XT9I1kiZJulzSh75b0hxJI8rNZGZmXVNJ30S/jYhZABHxR+CiEj93HrA2IuYCm4DJhSslTQIGVJDHzMy6qJJiMFDSAZIGSjofGFTi544BWtPpVmBixwpJ/wl4GdhYQR4zM+uiSorBTJK/8u8HjgJOK/FzDUB7Ot0O7AcgaQhwcEQs2tUGJE2VtEjSovXr15cd3MzMiiu5GEgaDxARb0XEtIg4OSK+2tGALOnEXWxiIzA4nR4MbEinJwLnSHoQOAGYIemjxTYQETMioikimurr60uNbmZmu1DO3UTTJS3vZJ2A14HHd/L5FpLbUJ8CxgItkoZFxI+BHwNIugv4VkSsLSOXmZl1UTnF4MxdrH9zF+vvBr6dPrDWCMwFbgOay8hgZmY1UHIx6OrzBBGxDbgyne0YF6F5h/d8qSvfYWZmlankOYMjahHEzMzyU8ndRLMlDZV0mqRhVU9kZmaZq6QYDAEuBo4A/l3ScdWNZGZmWauko7pVwPciYh2ApF01LJuZWTdXyZnBlcB8SedI+jjpw2NmZtZzlV0MImI+cDowDrgBWFftUGZmlq1KLhMB/AW4C1gZEZuqF8fMzPJQTncU35TUImkysBj4KnCFpBNqls7MzDJRzpnBfwNOAj4FPBURUwAkTahFMDMzy045xWB5RATwO0mvFCw/HXisurHMzCxL5TQgXy3pKICIWFWwvK26kczMLGslF4OIeCMiWgEk/deC5d8qnDczs56nkucMIHkCeWfzZmbWg1RaDHakKm3HzMxyUNZzBpLOI7mbaIykmeniOUBUO5iZmWWnrGIQEd8Hvi/psYj4x47lkv5H1ZOZmVlmfJnIzMwqLgY/3MW8mZn1IBUVg4i4b2fzZmbWs1TrMpGZmfVgLgZmZuZiYGZmlY9n0HM9dimsW5p3Cuut1i2FhjF5pzArW9nFQFIdcCQwIF00NiJuq2oqs56qYQyMOSPvFGZlq+TMYAGwBngnnT8E2GUxkNQPuBp4BjgMmB4R29J1k4HPAh8DJkfEqxXkKs2E6TXbtJlZT1VJm8GciDgtIj4fEZ8HTi3xc+cBayNiLrAJmAwgaXfgzxFxLknXFkdXkMnMzLqgkmJwtKQ5ku6RdA/JL/BSHAO0ptOtwESAiHgvIlrTM4d64JcVZDIzsy6o5DLRI8BfCuaPLPFzDUB7Ot0O7NexQpKALwJnAC8Cs4ptQNJUYCpAY2NjWaHNzKxzlZwZ3At8EjgHOAK4vcTPbQQGp9ODgQ0dKyIxk2Sc5U5b3yJiRkQ0RURTfX19BdHNzKyYSorBLenrHOA14KISP9fCB2cRY4EWScN2eM+7wLIKMpmZWRdUUgxaIuKGiPhFRNwLvFDi5+4GGiU1A40kv/RvkzRU0h8lfRH4DHBNBZnMzKwLKmkzGC5pHPAe0AT8LTB3Vx9KbyO9Mp2dnb42p6+ltjuYmVkNVFIM7gIuBw4FlgL/q5qBzMwse2UXg4jYCFzcMS9pFPB6NUOZmVm2Sm4zkPQTSf0lXShplaSVklYBi2uYz8zMMlDOmcGlEbFFUgvww4h4HUCSnxg2M+vhSj4ziIiX08m9OwpBar9i7zczs56j5DMDSfsC3wGOkLQmXbw7yYNnP6tBNjMzy0jJxSAiNki6GRgPPJcu3gasqEEuMzPLUFkPnUXE8yRdUYyKiN8Am4FP1SKYmZllp5InkH8bEbMAIuKPlN4dhZmZdVOVPHQ2UNIBJM8W/HdgUHUjmZlZ1iopBjNJnjpuAl4GTqtqIjMzy1wlTyC/BUwDkDQ0fSLZzMx6sLLbDCR9Kx3hDOBQSWdXOZOZmWWskgbkrcCDABHxO+BL1QxkZmbZq6TNYCMwQNJAkkLgIcfMzHq4Ss4M5pCMVPbT9NUNyGZmPVw5vZbeIekKIIA7SEYr+xwemMbMrMcr58zgUOA6knGPZ5P0R/Qx4L/UIJeZmWWonDaDX0bENkkXA1si4jIASW21iWZmZlkp58zgAEmPAVcA5wFIGgacX4tgZmaWnXJ6Lb1A0lFAW9qD6R7ARDwGsplZj1fWraUR0Vow/S4wq+qJzMwsc5XcWmpmZr2Mi4GZmVXUN9FBkvaRtJekCyQdXuLn+km6RtIkSZdL2q1g3VmSfifpRUkeLMfMLGOVnBlcDLwD3A00UPoTyOcBayNiLrAJmAwgaU/gvYg4DrgK+JcKMpmZWRdUUgz+BEwFBkTEVcArJX7uGKCjAbqV5E4kgC3AA+n0syR9H5mZWYYqKQYdv9Anp7eaNpT4uQagPZ1uB/YDiIitEbEtXX48cH1nG5A0VdIiSYvWr19ffnIzMyuqkmKwjuQS0W7Ap0i7sy7BRmBwOj0Y2FC4UtIoYE1ELOlsAxExIyKaIqKpvt6dpZqZVUulbQZvU36bQQsfdGo3FmhJn2DueJL50Ih4TFJdx3IzM8tGpW0G51N+m8HdQKOkZpIeT5cBt6XjIswDrpe0DPgDSWd4ZmaWkUoGt2klaQw+I20z2L+UD6XtAlems7PT1+b09dgKcpiZWZVUcmawFKgDbgGOA/53VROZmVnmKikG30tf55BczrmoenHMzCwPlVwmaomIOR0zkiZVMY+ZmeWgkmIwXNI44D2gCfhbYG5VU5mZWaYqKQZ/Bc4EPgEsweMZmJn1eJUUgwkRcXbHjKT9qpjHzMxyUEkx2JIOf7kpnR9FcqupmZn1UCUXA0mN6eRikttLtwHDgBHVj2VmZlkq58xgFXApcEdEbAaQtC8woRbBzMwsO+UUg3si4obCBRGxQdJHq5zJzMwyVs5DZys6WT6wGkHMzCw/5RSDw9JRyd4naW9gdHUjmZlZ1sq5TPQDYLGk+0jGNGgEvkAynKWZmfVgJZ8ZRMR84LPAR4BT0tfPRcTjNcpmZmYZKes5g4hYCfxzjbKYmVlOKum11MzMehkXAzMzczEwMzMXAzMzw8XAzMxwMTAzM1wMzMwMFwMzM6MbFQNJe0g6LO8cZmZ9UWbFQFI/SddImiTpckm7Faz7G+D/AOdmlcfMzD6Q5ZnBecDaiJhLMmTm5I4VEfE6sCDDLGZmViDLYnAM0JpOtwITM/xuMzPbiSyLQQPQnk63A/uVuwFJUyUtkrRo/fr1VQ1nZtaXZVkMNgKD0+nBwIZyNxARMyKiKSKa6uvrqxrOzKwvy7IYtABHptNjgRZJwzL8fjMz60SWxeBuoFFSM8koacuA2wAk7QN8CjhSUtmXj8zMrGvKGtymKyJiG3BlOjs7fW1O170BTM0qi5mZba/bPHRmZmb5cTEwMzMXAzMzczEwMzNcDMzMDBcDMzPDxcDMzMjwOQOzvuCep9Ywr3Vt3jGsFxt9wN5cffLhVd+uzwzMqmhe61qWv7o57xhmZfOZgVmVjd5/b+4//9i8Y5iVxWcGZmbmYmBmZi4GZmaGi4GZmeFiYGZmuBiYmRkuBmZmhouBmZnhYmBmZrgYmJkZLgZmZoaLgZmZ4WJgZma4GJiZGRl2YS2pH3A18AxwGDA9Iral604AjgAEPBkRT2WVy8zMsh3P4DxgbUTMldQATAbul7Q7cD1wdPq+J4ATMsxlZtbnZVkMjgFuT6dbga8C9wONwIaICABJWySNioiVtQgx7eE/sfwVj0RltbH81c2M3n/vvGOYlS3LNoMGoD2dbgf2K7J8x3VmPcro/ffm1KM+mncMs7JleWawERicTg8GNhRZvuO67UiaCkwFaGxsrChELQaSNjPr6bI8M2gBjkynxwItkoZFxAvAXkoBgyPiz8U2EBEzIqIpIprq6+szim1m1vtlWQzuBholNZO0EywDbkvXXQZcnP5clmEmMzMDlLbb9jhNTU2xaNGivGOYmfUYkhZHRFOxdX7ozMzMXAzMzMzFwMzMcDEwMzNcDMzMjB58N5Gk9cDqCj++L5082JYz5yqPc5XHucrTG3MNj4iiD2n12GLQFZIWdXZ7VZ6cqzzOVR7nKk9fy+XLRGZm5mJgZmZ9txjMyDtAJ5yrPM5VHucqT5/K1SfbDMzMbHt99cwAST1mBJIsskoak446161Ukqs77K+8jq/uur96m+6wz6qdodcVA0n9JF0jaZKkyyXtVrBuqKQVkl4EvpkuO0HSP0m6UNK4rHOlPXc/I2lR+vPnzrLWMNs44Emg/w7LP7Rvstpfu8h1lqTfSXpR0qfSZd1hf+V2fHWWq5scX3tLulfSSkl3pV3Vd6zL7RjbRa7cjrFd5KrdMRYRveqHZDjNrxRMn1mw7hvAoQXzuwOLAKU/87POBRwE7JtODwa+WyxrBvvtJaBuZ/smy/21k1x7ApPT6bOBx7rD/sr7+NrJ/sr9+ALOSP+7DQCWAuO6wzG2k1y5HmOd5ar1MdbrzgxIxlpuTadbgYkF6+qBn0n6taShFIy/HMme3SJpVJa5IuLliOh4gGQi8PNOsmbtQ/sGGLHjshrur85sAR5Ip58lGSkP8t9fxTJkeXwV1U2Or4ci4q2IeAdYzgf/zfI+xjrLlfcx1lmuYhmqdoz1xmLQ2VjLRMQlwCdIfhlPI9vxlzvNVeAE4FedZM1asX0zrMiyTMerjoitEbEtnT0euD5dnvf+yvv4KkUux1dEvAsgqQ5oi4gX01W5HmOd5cr7GNvJ/qrpMdYbi0FnYy0DEBHvAd8mqaglj79c61yS9kjzbekka9aK7ZvXiizL5XH99K+fNRGxpGNZzvurWIYsj6+d6ibH15nA1QXz3eUY2zEX0C2OsaK5anWM9cZiUHSsZQBJA9Llw4Ano4zxl2uZK3UiyTVTimWtUaYPkbSbOh+bekWRZbXaX0VzpdPDSK6bPiapTtKwvPdXOp3n8dVprlSux5ekfwAejYg3JQ3vLsdYsVzp8lyPsZ3kqtkx1uueM1Byl863gSUkv3TnApekPw+TPLDxLjArIt6R9HdARwv8UxHx2yxzRURzuv7fgMsiYrOkkcWy1iJX+t1NwG+AzwNrgMsjornYvslqf3WWC/gS8ASwV/q2AE4j2Z+57S9yPr46y9VNjq+zgBuAN0gaPH8EHJX3MdZZLnI+xnaSq6bHWK8rBmZmVr7eeJnIzMzK5GJgZmYuBmZm5mJgZma4GJiZGS4GZmYG9Ms7gFktSfosyb3ZF5Lcmz0ceCUibs3o+/sBF5MMYv4a8Flg94g4JovvNyuVnzOwXk9SRERhN8AjI2JVRt99I7BbRFyUzu9O0nPohVl8v1mpfJnI+hRJzRGxStIESb+U9M+SWiV9VNJASV9T0i/89yXtI+lHkq6Q9FTaLcHtks6V9Lqk0yRdJelxSQMknSzp3ILv2oOku/LbO5al/cpMS7d1k6TpkhZKOkDSJZJOlXSnpP0knSLpSUmDJT0o6UuSjpP0B0lfl7RY0udz2I3WC7kYWJ+Q/tL/JnBBuug5YGhE3EzSk+fxwD+S9CP//4A90p8AVgLHAiOBj0fED0n6mnocmA58lGRAmYOAnxR87UeAgcDLBTn+nqSrgYOA/yDpcuA4kj7s10TEvHTbV5N0XUJEvAk8n27i98Ao4GagGfjXLu8cM1wMrI+IiJsj4gbgawWL301f3yEZSORw4OcRcV9EnBsR64FtwKaI2BYRzwFPSDoF+F5EbE67G/4R8EWSy0FbC7b/V+At4MCCZb8BJqadib2/beBQ4L30PUtIuiku9u8IYEvaff1f2GG0NbNKuRhYnxIRf5I0qZPVLwPnAkgaLWm7X8iS9iQZSOShiFhQsOrfSYYgbC18f/pL/laSBuTCZcUsBZrS6Y+k23qP5EwFoG7HD0gaBCzrZHtmZfHdRNarpX/FI+kK4HXgY8A+JH+V7y/pIJJeZPcgueTyoKTfAv8XuAs4BPikpCdI/go/X9JUkj+k/iUiHomI1yQ9AvyuSITLgK9L+gHJpak9gRvTwnIE0JD+Uv8B8D1JZ5P0U/+vad7/kHRLuq2D0tdBkqaQDGJyUTX2k5nvJjIrkaQvAc9HxJOS+gP/QNLV8QDg7AxvV10XEQ1ZfJf1HT4zMCudgJslPUsyNu5sksbg/0wyeEztA0jjgL0ljS0cgcusq3xmYGZmbkA2MzMXAzMzw8XAzMxwMTAzM1wMzMwMFwMzMwP+P91GnnvOGF7bAAAAAElFTkSuQmCC\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAjwAAAG0CAYAAAA2BP2yAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAPYQAAD2EBqD+naQAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy8QZhcZAAAgAElEQVR4nOzdeVxVdf7H8fcVAdkFd0TFlNJkNNOUCidtJlvMrTCbbFWrsXGhLBvNyCU1zdLUdGxatNEWKxPNsHIprcwNzHU0C5VwAQW5CAiI5/eH4/15A5TLuXov19fz8eDxmPu93/M9n69nztz3nNViGIYhAAAAD1bN1QUAAABcagQeAADg8Qg8AADA4xF4AACAxyPwAAAAj0fgAQAAHo/AAwAAPF51VxfgLs6cOaNDhw4pKChIFovF1eUAAIAKMAxDubm5Cg8PV7Vq5R/HIfD8z6FDh9SoUSNXlwEAACohLS1NERER5X5P4PmfoKAgSWf/wYKDg11cDQAAqAir1apGjRrZfsfLQ+D5n3OnsYKDgwk8AABUMRe7HIWLlgEAgMcj8AAAAI9H4AEAAB6PwAMAADweFy1XQklJiYqLi11dBs7j7e0tLy8vV5cBAHBTBB4HGIahI0eOKCcnR4ZhuLocnMdisSgkJET169fnwZEAgFIIPA7IycnRiRMnVKdOHQUEBPDD6iYMw1BeXp4yMzPl5+enmjVrurokAICbIfBUkGEYysjIUHBwsGrXru3qcvAHfn5+KiwsVEZGhkJCQgijAAA7XLRcQSUlJSopKeGhhG4sODjYtp0AADgfgaeCTp8+LUmqXp2DYu7q3LY5t60AADiHwOMgZ58qyS86rch/LlfkP5crv4gfajM4jQUAKA+BBwAAeDzOzwDwfIYhFee7ugoA3v6Si47GE3ig5557Tt9++602bdpU4WV+/fVXvffee9q9e7e2bt2qhx9+WC+//LJOnz6t2267zXZx98mTJ7Vhwwb17NlT8+bNU58+fSRJn3zyySWZC1CKYUjv3i6lbXB1JQBGHZJ8AlyyagIPFB0drVOnTjm0zCOPPKI333xTrVq10t///nfdeeedWr58uTZt2qSvvvrK7nqagwcPavz48ZKk9u3bc1ExLq/ifMIOAAIPzoaXRx55pML9U1NT9cMPPygkJETVq1fX22+/LUny9/eXVPri4caNGys2NlaS9PzzzzupaqASnt0n+fi7ugrgyuXtuv2PwGOSYRgqKK78c1/OvzPLGXdp+Xl7VepupTNnzqhatYpdw56enu7w+OcHKkfWBTiVj7/LDqcDcC0Cj0kFxSW6NuErp4zV/uVVpsfYNe52+ftUfLPu2LFDb7/9tn788UetX79e//73v7VgwQINGjRIP/74oxYuXKjmzZtryZIlioiI0Mcff2y7/mbcuHEKDg7Wc889p4YNG5Y5flZWlt544w2NHTtW69ev1zvvvKPMzEwlJibavh8zZoyio6P11VdfqaSkREuWLJEkvfbaa6pevbqys7M1depU/f7777w2AgBQKR4XeEpKSpScnKy0tDTdc889ri7H7dWtW1dHjx5VRkaGqlWrpu7du2vQoEEKDQ3V66+/rnHjxqlt27aaOnWqpk+frr59+6pevXr67LPPlJCQoMjIyFJj9urVS5KUn5+vn376Sf3795d09tTWnj177N5qPn36dDVv3lxPPPGEBg4cqLFjx0qSfvvtNy1cuFDJycmSpMDAwEv8LwEA8GRuGXgMw9Brr72mjIwM+fj46MiRI5o2bZqCgoLKXaaoqEivvvqqli9frueff1533XXXZanVz9tLu8bdXunl84tO247sbB79F4eOzpRXjyPq1q2ra665RuvXr5fFYrEdqbn33nsVFRUlSYqNjdXu3bsrPOa5IzSSlJycrAULFkiSGjZsqGbNmmn//v227wsLC/X222/rvvvuU/369TVo0CBb+/bt25WYmKiePXuqf//+tmuEAABwlFsGnokTJ2r16tVatepsEEhISFC/fv20dOnSMvvn5+erZ8+e8vLy0tdff31ZjwZYLBbTIeUcf5/qThvLmXx8fFRYWFipZa+//nqtXr263O+HDRumjz/+WC1bttTkyZP1xBNPSJJatmypxx57TL169dKDDz6oadOmycfHp1I1AADgdleOZmVlacKECXr00Udtbf3799eyZcu0bt26MpcZNGiQdu3apYULF3Lqww3Fx8eX+114eLg2b96su+++W08++aTtOT2SNHfuXM2ZM0fLly9X69attXfv3stRLgDAA7ld4ElKSlJBQYHatWtna4uMjFStWrW0aNGiUv23bNmi999/X/Hx8apVq9blLBUVdKEXrn7zzTeqXbu2/vOf/2jx4sX69NNPtXXrVm3btk0ZGRn6+9//rl27dikoKEizZ8++jFUDADyJ2wWeHTt2SJIiIiLs2iMiIrR169ZS/d9//31JZ58Nc8cddyg0NFR33XWX0tLSLriewsJCWa1Wu78rVXFxsYqKiiT9/5vGDcOwfV9UVKQzZ87YfZZU6jRXbm6uJCkvL69C65Kkzz77TL///rskqXfv3qpdu7bq1KmjrKws27atX7++7rzzToWHh1d6jgCAK5vbXTCSlZUlSQoIsH9WRmBgoDIzM0v137hxo0JCQhQfH6+rr75aGRkZuuWWW9S3b1/9+OOP5a5n0qRJtjuCrmTffvutli9friNHjmjGjBnKzs6WdPbVD7GxsTpy5IhWr16twsJCff3116pTp47mzp0r6ext4wMGDFDz5s317rvvatu2bZKkZ555Rk899ZTatGljt65zpyWzsrL03nvvqV+/fjp16pRuv/12Pfnkk7aL0xs2bKhffvlFCQkJys7OVsOGDVVcXKyhQ4de3n8cAIDHsBjn/195NzBkyBDNmjVLJSUldg+n69Spk06cOKHt27fb9b/66qvVqlUrff7557a2d955RwMHDlRycrLatm1b5noKCwvtjlBYrVY1atRIOTk5tvdAne/UqVNKTU1V06ZNVaNGDbPTtMkvOm17jo+jz9CBvUu1jVDFFeVJE/93dNCF7/EBcGlYrVaFhISU+/t9jtud0qpTp46k0qdF8vLyyjylUbNmzVLXiLRu3VrS2RdclsfX11fBwcF2fwAAwDO53eGEc6dB0tPT1aJFC1t7enq6unTpUqp/8+bNS73qICQkRJIu+Nwed+HvU137X+nm6jIAAPBobneEp2vXrvL397c9YVeS0tLSlJGRobi4uFL977nnHm3ZssXubd+HDh2St7e37UgPAAC4srld4PHz81N8fLzmz59va5s3b55iY2MVExOjlStXKioqSjt37pQk9ejRQ40bN9Z//vMfW/+PP/5YAwYMUIMGDS57/QAAwP243SktSRo/frwSEhI0dOhQhYaGKjU1VYmJibJYLLJarcrMzFR+fr6ks08BXrFiheLj420hqEaNGnrllVdcOQUAAOBG3O4uLVe52FXe3AHk/thGKBN3aQEercrepQUAAOBsBB4AAODxCDyuVpQnjQk5+1dU/isZAABA5RF4AACAxyPwAAAAj0fgucLNnTtXt99+u2bMmHHBfqmpqXr00UdLvZDVYrEoLCxMN998s2JjY2WxWBQeHq5bb71V1157rSwWi6ZPn34ppwAAwEUReK5w/fr108aNG1VUVFRun2XLlmnIkCGaP39+qX7R0dFKS0vTDz/8oAULFkg6+7Ts1atXa9euXZo1a5ZD9Zz/xGwAAJyFwHOFCwwMtL17rDzdu3fX008/XeZ3Dz74oAICyn+uyWOPPSZvb+8K1XLs2DGNHTu2Qn0BAHAEgQcV4uXlVWZ7fHz8BZfz9/fX448/ftHxCwsL1bdvXx0+fLhS9QEAcCFu+WqJKsUwpOL8yi9flF/2f64sb3/JYnF4sdzcXPXt21dffPGFGjRooNdff109evS46HK+vr4X7ePj4yNJ2rNnj1577TWFh4crJSVFvr6+mjZtmho2bKikpCTt2bNHhw8fVnx8vAYMGKA//elPDs8DAICyEHjMKs7//8fWmzW1ufkxKvno/M8++0yzZs3SqFGjNHjwYMXFxWn37t1q1qyZ+ZokHTlyRLfccotWrlyp6OhoGYahPn36qHPnztq6dat69eql6dOnKzIykoucAQBOxyktSJJ69uypzp07q02bNnrvvfdUUlKiOXPmOG38WbNmqXbt2oqOjpZ09u6ul156Sfv27dPChQudth4AAMrCER6zvP3PHlWprKL8/z+y8+w+ycfffD2VWey8C4ubN2+uq666Sv/973/N1XKeLVu2lLq4OTo6Wj4+PkpJSXHaegAAKAuBxyyLxXlvX/bxd5s3OdeuXbtC1+dUlJeXl37//Xe7tnPP8KnoXVwAAFQWp7RQpkOHDqlLly5OGy8mJkaHDx/Wr7/+amsrLi7WsWPHdNNNN0k6G4AMw3DaOgEAOIfAA1WrVs3ugX8rVqxQcHCwBgwYYGsrLCyUJJ05c6bccU6ePClJys8vfbfZoEGD1KBBA02ePNnW9vHHH6t169a69957JUlhYWHau3evzpw5o+TkZHOTAgDgPAQeaMqUKVq3bp369eunp59+WsuWLdOaNWvk5+cnSVq5cqUtqMyaNUurV68uNcaaNWtsDw385ptvNGPGDGVlZdm+r1WrltauXatDhw7pwQcfVEJCgtavX69vvvnGdkrr8ccf1+7du3XLLbcoNDT0Uk8bAHAFsRicQ5AkWa1WhYSEKCcnR8HBwaW+P3XqlFJTU9W0aVPVqFHDeSsuyvv/29oreUs5zrpk2whVG/sY4NEu9vt9Dkd4AACAx+MuLVfzCZDG5Li6CgAAPBpHeAAAgMcj8AAAAI9H4AEAAB6PwAMAADwegcdB3MXvvtg2AIDyEHgq6NzD8cp6ijDcw7ltw7u5AAB/xG3pFeTl5aWaNWsqIyNDkuTv7y+LxeLiqiCdPbKTn5+vjIwM1axZU15eXq4uCQDgZgg8Dqhfv74k2UIP3EvNmjVt2wgAgPMReBxgsVjUoEED1a1bV8XFxa4uB+fx9vbmyA4AoFwEnkrw8vLixxUAgCqEi5YBAIDHI/AAAACPR+ABAAAej8ADAAA8HoEHAAB4PAIPAADweAQeAADg8Qg8AADA4xF4AACAxyPwAAAAj+exgeeXX35xdQkAAMBNuGXgMQxDU6dO1YgRIzR69GgNHDhQubm5F1wmNjZWFovF9vfhhx9epmoBAIC7c8uXh06cOFGrV6/WqlWrJEkJCQnq16+fli5dWmb/lJQUNW7cWAMHDpR09uWevXr1umz1AgAA9+Z2gScrK0sTJkzQ3LlzbW39+/dX06ZNtW7dOnXq1KnUMrNmzdIrr7yixo0bX85SAQBAFeF2p7SSkpJUUFCgdu3a2doiIyNVq1YtLVq0qFT/jIwMLVy4UNdee626d++uFStWXM5yAQBAFeB2gWfHjh2SpIiICLv2iIgIbd26tVT/3NxcjRo1Sn/961/11Vdf6c4779TEiRMvup7CwkJZrVa7PwAA4JncLvBkZWVJkgICAuzaAwMDlZmZWap/s2bNlJCQoCVLlmjv3r2KiYnR6NGjlZycfMH1TJo0SSEhIba/Ro0aOW8SAADArbhd4PHx8ZEkWSwWu3aLxSJvb+8LLhsZGakVK1aodu3a+vzzzy/Yd+TIkcrJybH9paWlmSscAAC4Lbe7aLlOnTqSpLy8PAUFBdna8/LyFB4eftHlQ0JC1KtXL2VkZFywn6+vr3x9fc0VCwAAqgS3O8LTpk0bSVJ6erpde3p6uqKjoys0Rs2aNW3BCQAAwO0CT9euXeXv7293DU5aWpoyMjIUFxdXoTE2b96sO++881KVCAAAqhi3Czx+fn6Kj4/X/PnzbW3z5s1TbGysYmJitHLlSkVFRWnnzp2SpKFDh+qFF15Qfn6+JOmTTz5RVFSUbr75ZpfUDwAA3I/bXcMjSePHj1dCQoKGDh2q0NBQpaamKjExURaLRVarVZmZmbaAExgYqDlz5ujzzz9Xt27dFB0drTlz5rh4BgAAwJ1YDMMwXF2EO7BarQoJCVFOTo6Cg4NdXQ4AZynKkyb+74aHUYckn4AL9wdQpVT099vtTmkBAAA4G4EHAAB4PAIPAADweAQeAADg8Qg8AADA4xF4AACAxyPwAAAAj0fgAQAAHo/AAwAAPJ7Dr5Y4ePBgpVbk5+fHG8wBAIBLOBx4IiMjZbFYKtzfMAxZLBbdfvvt+vLLLx1dHQAAgGkOB56ePXtqypQp8vHxqfAyeXl5evvttx1dFQAAgFM4HHg6d+6sqKgoh1fUpEkTh5cBAABwBocvWu7atWulVlTZ5QAAAMxyOPC0bNmyUiuq7HIAAABmcVs6AADweE4JPAcOHHDGMAAAAJdEhS9a3r17t957770yv9uyZYtWrVrltKIAAACcqcJHeJo2baodO3YoICCg1F+NGjUuZY0AAACmVPgIT40aNTR79mxFRkaW+q6yT18GAAC4HBy6hqessCNJjRs3dkYtAAAAl4Spi5ZTUlKcVQcAAMAlYyrwPPnkk86qAwAA4JIxFXgMw3BWHQAAAJeMqcDjyFvTAQAAXIUnLQMAAI9H4AEAAB6Pa3gAAIDHMxV45s6d66w6AAAALhlTgef666+/4PfLli0zMzwAAIBTVPjVEuU5evSo3nzzTW3fvl1Wq9V2msswDO3atUtHjx41XSQAAIAZpgNP9+7ddezYMXXs2FE1a9a0tZeUlGj//v1mhwcAADDNdOBJTU3V/v37FRAQUOq7tWvXmh0eAADANNO3pXfr1q3cu7V4qSgAAHAHpo/wTJ06Va+++qr+8pe/2LWfPn1a7777rhYsWGB2FQAAAKaYDjzvvfeeJk2apPHjx5f6zmKxEHgAAIDLmQ4848eP14wZM3TrrbfK19fX1l5SUqL333/f7PAAAACmmQ48TZo00ZNPPlnmi0SHDRtmdngAAADTTF+0/OKLL+rrr78u87uffvrJ7PAAAACmmT7Cs2TJEv34449l3pG1Z88eHjwIAABcznTgqVatmq666io1adLErr2kpES///672eEBAABMMx14Hn/8cXXo0EF+fn6lvvv222/NDg8AAGCa6Wt4OnbsqDfffFMHDhywtS1btkz79+9X586dKzWmYRiaOnWqRowYodGjR2vgwIHKzc2t0LIrVqxQly5dKrVeAADgmUwHniFDhuiFF17Qtm3bbG3du3fX2LFjtWnTpkqNOXHiRCUlJWnKlCl6+eWXFR4ern79+l10OavVqr///e/lPvkZAABcmUwHnuzsbKWnp6t79+527XFxcZW6LT0rK0sTJkzQo48+amvr37+/li1bpnXr1l1w2XHjxunWW291eJ0AAMCzmQ48bdq0Ue3atUu1Hzx4UD///LPD4yUlJamgoEDt2rWztUVGRqpWrVpatGhRucutXr1aUVFRvL8LAACUYjrwlJSUaOvWrXZtP//8s8aMGaNWrVo5PN6OHTskSREREXbtERERpdZzTl5enhYsWKAnnniiwuspLCyU1Wq1+wMAAJ7J9F1azz77rO6++25JUnh4uA4ePKj169erdu3amjNnjsPjZWVlSZICAgLs2gMDA5WZmVnmMuPHj9cLL7xQ5tOeyzNp0iSNHTvW4foAAEDVY/oIT2BgoNasWaNhw4apfv36atu2rWbOnKl9+/bZnZaqKB8fH0kqFV4sFou8vb1L9V+3bp3Cw8PVrFkzh9YzcuRI5eTk2P7S0tIcrhUAAFQNpo/wSGfDSO/evdW7d2/TY9WpU0fS2dNUQUFBtva8vDyFh4fb9S0oKNC7776rd955x+H1+Pr62r3sFAAAeC6Hj/DMmDGjUiuq6HJt2rSRJKWnp9u1p6enKzo62q5t48aN+uCDDxQcHKzAwEAFBgZq4sSJWrdunQIDA7Vw4cJK1QoAADyLw0d4cnJyKrWic9fmXEzXrl3l7++v5ORktWjRQpKUlpamjIwMxcXF2fXt0KGDdu7cadc2Y8YMbdiwQQsXLlS9evUqVSsAAPAsDgeeV199VatXr3boAuHs7OxSp6PK4+fnp/j4eM2fP18PPPCAJGnevHmKjY1VTEyMVq5cqUGDBmnJkiVq1aqVmjdvbrd8WFiY/Pz8SrUDAIArl8OBZ/jw4ZVakSMBZPz48UpISNDQoUMVGhqq1NRUJSYmymKxyGq1KjMzU/n5+ZWqAwAAXHksBu9hkHT2tRQhISHKyclRcHCwq8sB4CxFedLE/x1hHnVI8gm4cH8AVUpFf79N35YOAADg7gg8AADA4xF4AACAx3NK4OnWrZuOHj3qjKEAAACczimBJykpScePH5fVatWaNWsq/aweAACAS8Fpp7RSU1PVunVr/eUvf1GTJk2UmJjorKEBAABMccq7tHx8fLRgwQItXrxYYWFhWrt2rf75z3+qSZMmuu6665yxCgAAgEpzyhGepk2basCAAbr++usVGRmphx9+WBs2bNCSJUucMTwAAIApTgk8ffr00ahRo1RQUGBrCw4OLvWyTwAAAFdwSuAZPny4jh8/rk6dOmnDhg229r179zpjeAAAAFOcEnhCQkK0YsUKnTp1SjfddJPq1q2rxo0b67///a8zhgcAADDFKRctS1JUVJR+/vlnffHFF0pJSVHDhg316KOPOmt4AACASnNa4JEkLy8v9ezZUz179nTmsAAAAKY49dUSubm5dhcuAwAAuAOHA49hGJo7d66GDh2qpKQkSVJycrKuv/561axZU4GBgYqJidGPP/7o9GIBAAAqw+FTWk8//bRmzpyp6667TitWrNCuXbs0bdo0FRQU6L333lOHDh106NAhTZ48WRMmTODWdAAA4HIOH+FZuHCh3nvvPW3ZskV79+5VzZo1dejQIc2ePVsPP/ywWrRooVtvvVWfffYZr5cAAABuweEjPNWqVdNdd91l+zxgwAB98803uu222+wHrl5dR44cMV8hAACASQ4f4bn33nu1ceNGu7aXXnpJoaGhdm2HDh3SBx98YK46AAAAJ3A48Lz66qtasWKFNm3aZGtr2bKlLBaLXb8ZM2aUCkEAAACu4HDgCQgI0IwZM1S3bt0L9nvyySe1dOnSShcGAADgLJV+Dk+TJk3sPj/++OM6fPiw7XPTpk117bXXlmoHAAC43Jz24MH58+crOzu7wu0AAACXi9MCj2EYDrUDAABcLk59tQQAAIA7qvTLQ48fP66dO3faPhuGoc2bN+vYsWOSJIvFok6dOpmvEAAAwKRKB55NmzZp0KBBts9nzpzRqFGj5O3tLels4Nm3b5/5CgEAAEyqdOC54447lJqaavvs7e2tr7/+Wtdee61TCgMAAHAWruEBAAAej8ADAAA8HoEHAAB4PKcFnlWrVqlp06YVbgcAALhcKn3R8h/9+c9/dqgdAADgcuGUFgAA8HgEHgAA4PEIPAAAwOMReAAAgMdz2kXLKINhSMX5rq4CuLIVsQ8CIPBcWsX50sRwV1cBAMAVj1NaAK4MjWIkb39XVwHARS7pEZ5Tp06pRo0al3IV7s3bXxp1yNVVAJDO7o8Wi6urAOAiTgs8R48eVWFhoe3zmTNnNGfOHE2ePNlZq6h6LBbJJ8DVVQAAcMUzHXg+/PBDDR06VFlZWXbthmHIYrFUKvAYhqHXXntNGRkZ8vHx0ZEjRzRt2jQFBQWV2X/lypUaMWKE9uzZoxYtWujNN99UTExMpeYDAAA8j+nAM2zYMN1///3q0aOHfHx8bO2FhYV66623KjXmxIkTtXr1aq1atUqSlJCQoH79+mnp0qWl+qakpGjx4sX67LPPVFxcrAEDBqh37946dOiQLBy+BgAAkiyGYRhmBrj66qu1a9cuVa9eOjsdPXpU9erVc2i8rKwsRUREaO7cuXrooYckSfv371fTpk21du1aderUya7/xx9/rL59+9o+L126VD179lRmZqZq165d4fVarVaFhIQoJydHwcHBDtUMAABco6K/36bv0po4caISExPL/G7z5s0Oj5eUlKSCggK1a9fO1hYZGalatWpp0aJFpfqfH3YkKScnR+3bt3co7AAAAM9m+pTW559/rvXr1+vNN9+0azcMQ9u3b9exY8ccGm/Hjh2SpIiICLv2iIgIbd269YLLnjhxQomJiVqyZMlF11NYWGh3kbXVanWoTgAAUHWYDjzVq1fXNddco/r169u1nz59Wr/99pvD4527+DkgwP7upsDAQGVmZpa73BtvvKFXX31V6enpCgsLu+j1Q5MmTdLYsWMdrg8AAFQ9pgPPoEGDdMMNN8jLy6vUdxs2bHB4vHMXPv/xgmOLxSJvb+9yl3viiSf017/+VePGjdO///1v3XXXXerVq1e5/UeOHKlnnnnG9tlqtapRo0YO1wsAANyf6Wt4YmJitHv3bj344INq1aqVrrvuOv3jH//QwYMH1bFjR4fHq1OnjiQpLy/Prj0vL0/h4eW/psHPz0+tWrXShx9+qGbNmum777674Hp8fX0VHBxs9wcAADyT6cCzfv16dejQQatXr1bDhg117bXXaufOnWrfvr3tehxHtGnTRpKUnp5u156enq7o6OiLLl+tWjW1a9fugkeDAADAlcV04Hn++ec1efJkHTx4UF9//bU++OADffvtt9q4caNmzJjh8Hhdu3aVv7+/kpOTbW1paWnKyMhQXFxchcY4fPiwOnfu7PC6AQCAZzIdeFq0aKEhQ4aUeg5PZGSkGjRo4PB4fn5+io+P1/z5821t8+bNU2xsrGJiYrRy5UpFRUVp586dkqRZs2bpgw8+sPVds2aNatasqbvuuquSMwIAAJ7G9EXL5V1XU1RUpE2bNlVqzPHjxyshIUFDhw5VaGioUlNTlZiYKIvFIqvVqszMTOXn50uSfvnlF7399tt688031bVrV9WtW1effvpppecDAAA8j+knLcfHx6tFixa67777FBAQoN9//13ff/+9Xn/9dXXq1EmzZs1yVq2XFE9aBgCg6qno77fpwHPy5El169ZN33//va3NMAzdfvvtWrx4sfz8/MwMf9kQeAAAqHoq+vtt+pRWYGCgvvvuO61cuVLJycny8vJSTEyMbr75ZrNDAwAAOIXpIzwXkpubq6CgoEs1vFNxhAcAgARuj/UAACAASURBVKrnsr089ELOv9MKAADAVRw+pdWhQwfdeOONeuONN2QYhmJiYsp8x1VRUZGOHDmiwYMHO6VQAACAynI48HTu3Nn2xGOLxaKbbrpJR48e1TXXXGPXr7i4WMuXL3dOlQAAACY4HHimTJli97l3795q2bKl7R1Y52zfvl3t2rUzVx0AAIATmL6GZ8mSJaXCjiS1bNlS8+bNMzs8AACAaZW6Lb2wsFAzZ85Ufn6+fvrpJ40bN87ue8MwtGfPHn377bfOqBEAAMCUSgUeX19f9ejRQ3FxcTpw4IAOHz5s973FYlFYWJimTZvmlCIBAADMqPSDB6+++mqtXbtWn3/+uR577DFn1gQAAOBUpq7hqVmzJmEHAAC4PdMXLRcWFmrq1Kk6cOCArW3p0qXav3+/2aEBAACcwnTgGTx4sF544QVt27bN1tajRw+NHTtWmzZtMjs8AACAaaYDT3Z2ttLT09W9e3e79ri4OA0bNszs8AAAAKaZDjxt2rRR7dq1S7UfPHhQP//8s9nhAQAATDMdeEpKSrR161a7tp9//lljxoxRq1atzA4PAABgWqVvSz/n2Wef1d133y1JCg8P18GDB7V+/XrVrl1bc+bMMV0gAACAWRbDMAyzgxiGoSVLlmjdunUqLi5Wy5Yt9dBDDykoKMgZNV4WVqtVISEhysnJUXBwsKvLAQAAFVDR32/Tp7Qkae7cudqxY4def/11vf766zpx4oR++OEHZwwNAABgmunA8/zzz+upp57SihUrJEne3t4aNWqUPvzwQ33++eemCwQAADDLdOBJSkpScnKyOnToYNfev39/vfTSS2aHBwAAMM104Gnfvr2uu+66Uu1Hjx7Vvn37zA4PAABgmunAU7NmTRUUFMhisdjatm/frhEjRqhFixZmhwcAADDN9G3pTz/9tPr06aPffvtNGRkZSk1N1caNGxUQEKAFCxY4o0YAAABTnHJb+pkzZ/Tpp58qJSVFeXl5ioqK0oMPPqjQ0FBn1HhZcFs6AABVT0V/v50SeM534sQJBQcHq1o1p9zxftkQeAAAqHou2XN4Xn31VQ0fPlwDBgzQZ599Zmv/5Zdf1LFjR9WqVUtBQUF65plndPr06cpVDwAA4EQOH+GpVq2abrzxRi1atEgNGzaUdPaOrLZt2+rIkSPq0qWL2rVrp6SkJPXp00cJCQmXpHBn4wgPAABVzyU7whMYGKilS5fawo4kDRgwQEeOHNGQIUO0atUqTZkyRRs3btR3331XueoBAACcyOHAc8MNN6hWrVq2z4sWLdKXX36ptm3batq0abZ2Pz8/1a1b1zlVAgAAmOBw4Dl58qQKCwslSfv27dNTTz2latWqac6cOaUuVN65c6dzqgQAADDB4efwdO7cWa1bt9af/vQnffPNN8rNzdXw4cNLvVpi5syZBB4AAOAWHA48EyZMUM2aNbVkyRI1b95c/fr10zPPPGP7/rffftPLL7+sefPm2Z36AgAAcBWnP4dn8+bN8vb21lVXXaWgoCBnDn1JcZcWAABVT0V/v02/WuKP2rdv7+whAQAATKlaj0MGAACoBAIPAADweAQeAADg8Qg8AADA45kOPNu2bdO2bdt04sQJSdL69et1zz33aPDgwcrOzjZdIAAAgFmmA89tt92mffv2KTAwUAcOHNBdd92lzMxMRUVFaeTIkZUa0zAMTZ06VSNGjNDo0aM1cOBA5ebmltt/+fLlatu2rQIDA3XddddpxYoVlZ0OAADwQKYDz/Dhw3XPPfeoevXqGjRokIKCgrRixQoNGzZMbdu2rdSYEydOVFJSkqZMmaKXX35Z4eHh6tevX5l9N2zYoBkzZmjkyJGaMmWKjh8/rh49emjHjh1mpgUAADyI057DM2fOHK1YsUKfffaZAgICJEm7du1yeJysrCxNmDBBc+fOtbX1799fTZs21bp169SpUye7/p988omWLFkiPz8/SdJNN92ktm3b6uOPP1Z0dLSJGQEAAE9h+ghPgwYNFB4ermHDhmnChAnq3bu3tm/frsGDB2v27NkOj5eUlKSCggK1a9fO1hYZGalatWpp0aJFpfr37NnTFnYk6brrrlOtWrWUk5NTuQkBAACPY/oIz0MPPaT77rtPxcXFCgwMlCTVq1dPzz33nJ577jmHxzt3KioiIsKuPSIiQlu3bi3V/49HfCSpsLCw1MtMy+pz7q3v0tlHUwMAAM/klFNavr6+8vX1tX2uW7dupcfKysqSJNtpsXMCAwOVmZl50eVTUlIUGhqqe++994L9Jk2apLFjx1a6TgAAUHW43W3pPj4+kiSLxWLXbrFY5O3tfdHlX3/9dc2ePdvuNFdZRo4cqZycHNtfWlqaw7UCAICqwe1uS69Tp44kKS8vz649Ly9P4eHhF1x22bJlioqK0t13333R9fj6+io4ONjuDwAAeCbTp7TO3ZYuye629ICAALs7rSqqTZs2kqT09HS1aNHC1p6enq4uXbqUu9yuXbu0Zs0avf766w6vEwAAeDanvVri3G3pb7zxhqnb0rt27Sp/f38lJyfb2tLS0pSRkaG4uLgylzl8+LBmzJihKVOm2NoMw9Du3bsdXj8AAPA8bndbup+fn+Lj4zV//nxb27x58xQbG6uYmBitXLlSUVFR2rlzpyQpNzdX999/v2688UYtWbJEn376qT766CM98sgjFbrmBwAAeD6LYRiG2UEKCwvtbkvPzMxUfn6+JKlJkyYOj3fmzBklJCTIarUqNDRUqampmj59usLCwrR48WL1799f33zzjW644Qbdcccd+uqrr0qNERsbq3Xr1lV4nVarVSEhIcrJyeF6HgAAqoiK/n47JfDs2LFDr7zyilJSUuTt7a2bbrpJ//znP9W4cWOzQ182BB4AAKqeiv5+mz6ltX79enXo0EGrV69Ww4YNde2112rXrl1q374977MCAABuwfRdWs8//7wmT56sQYMGqXr1/x9u//79mjhxot566y2zqwAAADDFdOBp0aKFhgwZUqo9MjJSDRo0MDs8AACAaaZPaZX3MMCioiJt2rTJ7PAAAACmmQ48J06c0L/+9S9lZWWpsLBQv/76q+bPn68bbrhBV111lTNqBAAAMMX0XVonT55Ut27d9P3339vaDMPQ7bffrsWLF1/0nVbugru0AACoeir6+236Gp6kpCSNHz9excXF2rJli7y8vBQTE6Obb77Z7NAAAABOYfoIT1hYmAYPHqxx48aV+s4wjFJvPXdXHOEBAKDquWzP4Rk7dmy5L/VctGiR2eEBAABMM31K69ixY3ruued09dVXq0aNGrb206dPa82aNerbt6/ZVQAAAJhiOvDk5OQoJydHhw8ftms/c+aMTp48aXZ4AAAA00wHnocffliDBw9W8+bNS333/vvvmx0eAADANIcDz9KlS23/2cfHR3fccUepPps2bVLjxo318MMPm6sOAADACRy+aLlXr1665557tHbtWrVs2bLMPq1atdLgwYOVl5dnukAAAACzKnWX1uTJkzV16lQ1adKkzO/9/f31/PPP69VXXzVVHAAAgDM4HHgiIiI0fPjwi/Zr3769UlJSKlUUAACAMzkceKKjoyvcl1NaAADAHTgcePLz8yvc98CBA44ODwAA4HQOBx7DMLRly5aL9lu6dKnCwsIqVRQAAIAzORx4Hn/8cfXq1UubNm0qt8+aNWvUv39/PfTQQ6aKAwAAcAaHn8Pz4IMP6ssvv9SNN96oLl266JZbblGDBg10+vRppaWlac2aNfrpp5/05z//WYMGDboUNQMAADikUk9aXrBggaKjozV58mStWrXK9kZ0wzBUvXp1DRw4UNOnT5eXl5dTiwUAAKgMi2EYRmUXzs3N1Zo1a7R3716VlJSoUaNG6tKlixo0aODMGi+Lir5eHgAAuI+K/n6bepdWUFCQevToYWYIAACAS65ST1oGAACoSgg8AADA4xF4AACAxyPwAAAAj0fgAQAAHo/AAwAAPB6BBwAAeDwCDwAA8HgEHgAA4PEIPAAAwOMReAAAgMcj8AAAAI9H4AEAAB6PwAMAADwegQcAAHg8Ag8AAPB4BB4AAODxCDwAAMDjVXd1AWUxDEOvvfaaMjIy5OPjoyNHjmjatGkKCgoqdxmr1app06apZs2aGjZs2GWsFgAAuDu3PMIzceJEJSUlacqUKXr55ZcVHh6ufv36ldt/06ZNGjdunMaMGaPs7OzLWCkAAKgK3C7wZGVlacKECXr00Udtbf3799eyZcu0bt26Mpe54YYbNHny5MtUIQAAqGrcLvAkJSWpoKBA7dq1s7VFRkaqVq1aWrRoUbnLeXl5XY7yAABAFeR21/Ds2LFDkhQREWHXHhERoa1btzptPYWFhSosLLR9tlqtThsbAAC4F7c7wpOVlSVJCggIsGsPDAxUZmam09YzadIkhYSE2P4aNWrktLEBAIB7cbvA4+PjI0myWCx27RaLRd7e3k5bz8iRI5WTk2P7S0tLc9rYAADAvbjdKa06depIkvLy8uxuQ8/Ly1N4eLjT1uPr6ytfX1+njQcAANyX2x3hadOmjSQpPT3drj09PV3R0dGuKAkAAFRxbhd4unbtKn9/fyUnJ9va0tLSlJGRobi4OBdWBgAAqiq3Czx+fn6Kj4/X/PnzbW3z5s1TbGysYmJitHLlSkVFRWnnzp12y5274+rMmTOXtV4AAOD+3O4aHkkaP368EhISNHToUIWGhio1NVWJiYmyWCyyWq3KzMxUfn6+rf/27dv1r3/9S5K0ePFiRUdHq3fv3k69yBkAAFRdFsMwDFcX4Q6sVqtCQkKUk5Oj4OBgV5cDAAAqoKK/3253SgsAAMDZCDwAAMDjEXgAAIDHI/AAAACPR+ABAAAej8ADAAA8HoEHAAB4PAIPAADweAQeAADg8Qg8AADA4xF4AACAxyPwAAAAj+eWb0sHAGcyDEMFxSWuLgO44vl5e8lisbhk3QQeAB7NMAzF/Wu9thzIdnUpwBVv17jb5e/jmujBKS0AHq2guISwA4AjPACuHJtH/1X+Pl6uLgO4Yvl5u27/I/AAuGL4+3i57HA6ANfilBYAAPB4BB4AAODxCDwAAMDjEXgAAIDHI/AAAACPR+ABAAAej8ADAAA8HoEHAAB4PAIPAADweAQeAADg8Qg8AADA4xF4AACAxyPwAAAAj0fgAQAAHo/AAwAAPB6BBwAAeDwCDwAA8HgEHgAA4PEIPAAAwOMReAAAgMcj8AAAAI9H4AEAAB6PwAMAADwegQcAAHi86q4uoCyGYei1115TRkaGfHx8dOTIEU2bNk1BQUFl9t+7d68mTpyo6OhoJScn629/+5u6d+9+masGAADuyi0Dz8SJE7V69WqtWrVKkpSQkKB+/fpp6dKlpfpmZGSoS5cu+uijj9SpUydlZWXpmmuu0RdffKGOHTte7tIBAIAbcrvAk5WVpQkTJmju3Lm2tv79+6tp06Zat26dOnXqZNf/tddeU40aNWztYWFh6tatm0aNGmULTK5iGIYKiktcWgNwpcsvYh8E4IaBJykpSQUFBWrXrp2tLTIyUrVq1dKiRYtKBZ7Fixfb9ZWk9u3b6/3331dmZqbq1KlzWeouS0Fxia5N+Mpl6wcAAGe53UXLO3bskCRFRETYtUdERGjr1q12badOndKvv/5aZl/DMLRt27Zy11NYWCir1Wr3B8BztW8SKj9vL1eXAcBF3O4IT1ZWliQpICDArj0wMFCZmZl2bdnZ2TIMo8y+kkr1P9+kSZM0duxYZ5RcLj9vL+0ad/slXQeAivHz9pLFYnF1GQBcxO0Cj4+PjySV+h8mi8Uib2/vCveVVKr/+UaOHKlnnnnG9tlqtapRo0aVL7wMFotF/j5u908MAMAVx+1+jc9dc5OXl2d3G3peXp7Cw8Pt+oaFhal69erKy8uzaz/3+Y/9z+fr6ytfX19nlQ0AANyY213D06ZNG0lSenq6XXt6erqio6Pt2iwWi6Kjo8vsW716dV1zzTWXtlgAAFAluF3g6dq1q/z9/ZWcnGxrS0tLU0ZGhuLi4kr17927t11fSdq8ebNuvfVWhYWFXfJ6AQCA+3O7wOPn56f4+HjNnz/f1jZv3jzFxsYqJiZGK1euVFRUlHbu3ClJevLJJ3Xs2DGtX79ekpSTk6PExEQ9++yzLqkfAAC4H7e7hkeSxo8fr4SEBA0dOlShoaFKTU1VYmKiLBaLrFarMjMzlZ+fL0mqV6+eVq1apUmTJmnt2rXavn27Zs+erdtuu83FswAAAO7CYhiG4eoi3IHValVISIhycnIUHBzs6nIAAEAFVPT32+1OaQEAADgbgQcAAHg8Ag8AAPB4BB4AAODxCDwAAMDjEXgAAIDHI/AAAACP55YPHnSFc48jslqtLq4EAABU1Lnf7Ys9VpDA8z+5ubmSpEaNGrm4EgAA4Kjc3FyFhISU+z1PWv6fM2fO6NChQwoKCpLFYnHauFarVY0aNVJaWppHPsHZ0+cnef4cPX1+kufPkflVfZ4+x0s5P8MwlJubq/DwcFWrVv6VOhzh+Z9q1aopIiLiko0fHBzskf8lPsfT5yd5/hw9fX6S58+R+VV9nj7HSzW/Cx3ZOYeLlgEAgMcj8AAAAI/nNWbMmDGuLsLTeXl5qXPnzqpe3TPPIHr6/CTPn6Onz0/y/Dkyv6rP0+fo6vlx0TIAAPB4nNICAAAej8ADAAA8HoHHBX755RdXl+BSGRkZPNG6ivOEbch+WPW34ZWuqm/Dy70PEngcZBiGpk6dqhEjRmj06NEaOHCg7SnN5YmNjZXFYrH9ffjhh7bvioqKNHLkSI0dO1bDhw/XM888o+Li4ks9jXI5Mr9FixbZzevcX506dez6vf3223bf33jjjQoKCroc07mgtWvXqkuXLhftt3fvXj366KOaOnWqHnjgAS1btszue3fbhudUdH7Lly9X27ZtFRgYqOuuu04rVqwo1aeqb0Opau2H51RkflVxPzxx4oQGDBig+vXrq169enriiScu+MNdFfdBR+dY1fZDR+cnuX4f5KJlB02YMEGrV6/WqlWrJEkJCQnaunWrli5dWmb/lJQUvfrqq+ratauks1ep9+rVy/Zf0scff1xnzpzRO++8I0l6+OGHVbNmTc2YMeMyzKY0R+bXr18/3XLLLQoPD7e1LV++XPn5+Zo/f76trXv37rr33nttn6+//nq1bt36Es7iwnJzc7V06VKNHz9ee/bsueD7VzIyMtS2bVt99NFH6tSpk7KysnTNNdfoiy++UMeOHSW53zZ0ZH4bNmxQQkKCBgwYoGPHjmnSpEk6evSokpOTFR0dbetXlbehVPX2Q0fmVxX3w/vvv19t27ZVs2bN9MUXX2j+/Pn629/+pg8++KBU36q4D0qOzbEq7oeOzE9yk33QQIUdP37c8PPzM95//31bW2pqqiHJWLt2bZnL9O/f3zhw4ECZ3+3atavUsmvWrDG8vLyM3377zbnFV4Aj8zt16pTx5ZdflhqjV69exieffGL7vGbNGuPll1++dEWbMHr0aONiu8CIESOMq666yq7tkUceMW699VbDMNxvG56vIvMbPny4kZ+fb/uckpJiSDJGjx5ta6vq29AwqtZ+eL6Lza8q7ocpKSnGW2+9ZdfWs2dPw8vLyzh16lSp/lVxH3R0jlVtP3R0fobhHvsggccBCxYsMCQZO3futGuvVauWMXjw4FL9jx49avj6+hoBAQHG3XffbSQlJdl9//LLLxuSjJMnT9racnNzDUnG1KlTL80kLsDR+f1RQUGBERoaalitVltbr169DIvFYrRp08aYNGmSUVBQ4PS6K+ull1666I9l8+bNjT59+ti1zZw507BYLEZGRobbbcPzVWR+ZQX1WrVqGUOGDLF9rurbsKrth+eryPz+yN33w/Xr1xtFRUV2bTNnzjQkGcePHy/Vvyrug47Osarth47Oz132Qa7hccCOHTskqdQ7tyIiIrR169ZS/XNzczVq1Cj99a9/1VdffaU777xTEydOtBsvNDRUAQEBtrbAwECFhISUOd6l5uj8/uibb75R+/bt7c4pd+7cWU8++aSOHTumkSNHKjY2VidPnnRu4ZfIqVOn9Ouvv5b572EYhrZt2+Z229BRnTp1KtVWWFioDh062D5X5W0oVb390Cx33w9jYmLk7e1t13bq1Ck1a9ZMYWFhpdqr4j7oyBylqrcfOjo/d9kHCTwOyMrKkiS7jSKd3TCZmZml+jdr1kwJCQlasmSJ9u7dq5iYGI0ePVrJycm28f441oXGu9Qcnd8fJSYmqkePHnZtw4YN05w5c5SamqoXX3xRW7Zs0QsvvOC8oi+h7OxsGYZR5r+HJGVmZrrdNjQrJSVFoaGhdtcJVOVtKFW9/dCsqrgfrlu3TvHx8aXaPWkfLG+OZamK++GF5ucu+yCBxwE+Pj6SJIvFYtdusVhKpd0/ioyM1IoVK1S7dm19/vnntvH+OFZFx7sUzMzvzJkz+uKLL3T33XeX+b23t7fGjRunxx9/XIsXL3ZOwZfYhf49pLNzcrdtaNbrr7+u2bNny8/Pr9R3VXEb/lFV2A/NqIr74e7du5Wdna1BgwaV+s5T9sELzbEsVW0/dGR+rtwHCTwOOHebZ15enl17Xl6e3R0S5QkJCVGvXr2UkZFhG++PYzkynrOZmd+GDRtUt25dRUZGXrDfo48+apu/uwsLC1P16tXL/PeQpPDwcLfbhmYsW7ZMUVFR5f5YnlOVtmFZ3H0/NKOq7YdFRUVKSEjQRx99JC8vr1Lfe8I+eLE5/lFV2w8dnZ/kun2QwOOANm3aSJLS09Pt2tPT0+1uHbyQmjVr2oJFmzZtlJ2drYKCAtv3+fn5ys7OrvB4zmRmfomJierevftF13H+/N2dxWJRdHR0mf8e1atX1zXXXON227Cydu3apTVr1ighIeGifavSNiyPO++HZlS1/fCFF15QQkJCuT9qnrAPXmyO56uK+6Ej8zufK/ZBAo8DunbtKn9/f9t5R0lKS0tTRkaG4uLiKjTG5s2bdeedd0qSevfuLcMwlJKSYvt+y5Ytslgsuueee5xbfAWYmV9F/4d28+bNuuuuu0zXern07t3b7t9DOjuHW2+9VWFhYW63DSvj8OHDmjFjhqZMmWJrMwxDu3fvLrN/VduGZXHn/dCMqrQfTp06VXfddZf+9Kc/2dp27dpVql9V3gcrOkepau6Hjszvj1yxDxJ4HODn56f4+Hi7h3nNmzdPsbGxiomJ0cqVKxUVFaWdO3dKkoYOHaoXXnhB+fn5kqRPPvlEUVFRuvnmmyVJjRs31gMPPFBqvAceeEANGza8jDM7y9H5nbN3715lZWXZ3VEgSV988YX69u1ru/vr6NGjmjdvnsaNG3fpJ1MBhYWFks5e93DOH+d47q6I9evXS5JycnKUmJioZ599VpL7bcPzVWR+ubm5uv/++3XjjTdqyZIl+vTTT/XRRx/pkUcekbe3t0dsw6q2H56vIvM7pyrthwsWLFBycrKOHz+uTz/9VJ9++qlmzZql999/32P2QUfmWBX3Q0fm5y77YHWnjXSFGD9+vBISEjR06FCFhoYqNTVViYmJslgsslqtyszMtG3UwMBAzZkzR59//rm6deum6OhozZkzx268t99+W88884xGjhypM2fOqEaNGnrzzTddMTVJjs3vnMTERHXr1k3Vqtnn55CQEKWkpOimm27Sgw8+qPr16+vDDz9UvXr1LueUSikuLtbHH39seyJoQkKC7r//fkVHR5eaY7169bRq1SpNmjRJa9eu1fbt2zV79mzddttttvHcbRs6Mr8+ffpo7dq1Wrt2rd0YsbGxat68uQ4fPlzlt2FV3A8dmd85VWU/XLt2rfr376/i4mK7VwtIZ8NcTk5Old8HHZ1jVdsPHZ2fu+yDvFoCAAB4PE5pAQAAj0fgAQAAHo/AAwAAPB6BBwAAeDwCDwAA8HgEHgAA4PEIPAAAwOMReAAAgMcj8AAAAI9H4AFQIR999JFatWoli8WiFi1aKC4uTnFxcbr77rvVrFkzWSwWnThxwtVlVsrGjRvVt29fdejQQd26dVOrVq3k5eUli8Wi+++/39XlAXAC3qUFoELuv/9+HTt2TEOGDNE///lPPfroo7bvDMOo0Fu63dHMmTP17LPPatq0afroo49ksVgkST/88IPuu+8+F1cHwFk4wgOgwgIDA8tst1gseuCBB0q9uNLdffPNNxo2bJhefPFFPfXUU7awI0k333yzFi5caNcGoOriCA8Ap3jggQdcXYLDXnzxRdWoUUPDhg0r8/vOnTsrOzv7MlcF4FKoWv93DIBbeuWVV7R//35J0s6dOzVo0CB16dJF3377rdq0aaPQ0FBNmTLFbpm33npLQ4YM0Z133qmOHTtqy5YtkqTvvvtO/fv315w5c/T8888rLCxM33//vSQpOTlZQ4cO1T/+8Q95eXkpKChIcXFxSklJ0XPPPSeLxaJ77rlHaWlpkqStW7eqQYMGWr58eamaMzMztXHjRrVr105BQUHlzq13796SpLS0NE2aNEm9evXS2rVr1bBhQ1tQ2rNnj5544gmNGTNGPXv21H333af09HRJ0qpVqxQWFmY7Bbht2zb17NnTduTo6NGjeuWVV9SyZUslJyerQ4cO8vPzU9euXXXkyJHKbA4AZeAIDwCHzZgxQ0uWLJEk7d+/Xz///LPt4t4WLVrozJkz2rZtm/bt26eNGzdqxowZGjVqlB577DHVqVNHH3/8sYqKijRz5kxJUs+ePdWjRw/t379foaGh+vTTT5WamqqJEyfq1KlTCg0NVW5urrp166YNGzaocePGKikp0bvvvqsFCxaoRo0aatOmjRYvXixvb281atRIkhQVFaWYmBh169at1Bz2798vwzDUsGHDUt8dP35cixcvVklJiSTJ29tbd9xxh37++Wf99NNP+vXXXzVhwgTl5eXpyJEj8Q8NPAAABk5JREFUuuWWW7Ry5UpFR0fLMAz16dNHnTt31tatW/WXv/xF0dHRtrFbt26tXr16aenSpZKk6tWr6/Dhw/rvf/+r1atXKzExUWvXrtUjjzyiJ598UomJiU7ccsCVi8ADwGFDhw61HbEwDEMPP/yw7TsvLy81aNBAQUFBGjhwoKSzgWbEiBHat2+f6tSpozFjxqhjx46Kj4+XJPn4+KhRo0bKyMhQ69atFRYWpo4dO+rGG2/UjTfeKEn68ssvdeTIEdWvX1+S1KdPH82dO1c5OTmqUaOGqlWrpn/84x8aOXKkjh49qnr16mn58uXq0aNHmXM4F2bKuu6oVq1aiouLU3R0tLKzs3Xw4EHVrl1bLVq00LfffqvHHnvM1nf06NGqXbu2LdRYLBa99NJLat26tRYuXKgnnnii1DrOvy6oVq1aatu2rSRp+PDhslgs6tu3r9auXavZs2crIyNDdevWreCWAVAeTmkBMMVisZQbKs7x8fGRJBUWFqqgoEB79uzRqFGjNH36dE2fPl2ffPKJfvrpJ7ujLTVq1LAbo6ioSJJ04MABSVJERIQCAgLswsD/tXd/IU21cRzAv8e5Lmaom8OyIBSFWW2ld5KEN0ZYdKHTK1GUXcQGIwwGoiiJQghFwxtDktlN0R8XLEgUb1S6CcIxvNBQimGNaAkWjsW0Xxey8zbdXi15ce/4fm4Gz3nO2W8b7Hx3nuc5s9ls0Gq1GB0dBQC8fPlSHZLa6dSpUwCgDj3tpNfrUVpaisLCQhiNxpR1vX37Fjk5OQltZrMZR44cwfz8fIp3JLnfg1BNTQ0A4P379390DCJKjoGHiA6svr5eDRB7iUQiEJGkJ/J4qEmmtrYWJSUlGBkZAQAsLCyoV0Ti8vLy0NraipGREWxsbGBrawv5+flJj3fixAmYzWa8efMm5f2D9rPqTKPRYHV1NaFNURQYDAZotdo9908lNzc34ZGIDoaBh4gOLDs7G1lZWejq6tqzb0FBAQwGgxpc4vx+P6amplLud/ToUTx9+hSBQAADAwOIRqO4devWrn5OpxPBYBBOpzPp3J3f9fX1IRqNYmBgYM+6U6mqqkIoFMLKyoraFovFEA6HceHCBQDbAejnz5/q9n8LdnEfPnzAyZMnYTKZ/ro2IvoHAw8R7VskEgGwPTS10/379/Ht2zcAwObmJkRE3RY/wcdP+g6HA16vF3a7HXNzcxgbG0N/fz+uXLmi9tvc3Ew4/vLyMjo6OtDS0oKysjJoNBpMT0/v6nf69GnU1tbi8ePHew61NTQ04O7du3C73ejt7U14Xevr6wgGg9DpdGpbsrrsdjuKioowODiotj158gTnzp2D1WoFABQXF2N2dhYfP37E4uIiXr16BQDqyra4YDAIYDswjY6O4vbt2/+7exsRpS0hItqHZ8+eSUVFhQCQwsJCaWxslObmZqmvr5fy8nIBIF6vVxYWFqSiokKys7PF4/HI+vq6XL9+XQBIa2urhMNh+fHjhzgcDsnPzxeDwSAtLS3y5csXicVi4na7RaPRyNmzZ8Xn86nPHwwGpbKyUsrKykSn04miKAJALl++vKvWR48eSUNDw75fWyAQkLa2NrFYLHLp0iW5du2aVFdXi8vlkk+fPomIyMzMjFgsFlEURYaGhuTz58/q/svLy3L16lVpbm6Wnp4ecTgc8vXrV3X7u3fv5Pz586LT6aS9vV3Gx8elrq5OPB6PbG1ticfjEQBy8+ZN6ejoEKvVKg8ePPibj4mIUlBEfvsZRkSUpsbHx/H9+/eE1WFra2twuVy4c+cODAaD2nd4eBhGoxFNTU2HVO2fGRsbQ3t7O/h1TPTf4bJ0Ikp70WgUNpstYQhIURQUFBTAYrFAr9er7SICn8+HFy9eHEKlRJSuGHiIKO3F5850d3ejs7MTx44dQygUwvPnz3HmzBkoioJ79+7h9evXyMrKwsWLF3ctH09n8XsCxWKxA63sIqLUOBuOiNKeTqfDxMQE/H4/TCYTjh8/jhs3bqCmpgZ1dXUAgLW1NUxOTiI3Nxcul+uQK94/v9+Phw8fAtj+b6+lpaVDrogoM3EODxEREWU8XuEhIiKijMfAQ0RERBmPgYeIiIgyHgMPERERZTwGHiIiIsp4DDxERESU8Rh4iIiIKOMx8BAREVHG+wWknMKkMgPTGQAAAABJRU5ErkJggg==\n",
       "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
+       "<Figure size 640x480 with 1 Axes>"
       ]
      },
      "metadata": {},
@@ -513,7 +501,7 @@
     }
    ],
    "source": [
-    "univ0.plot(['infFiss', 'b1Tot'], loglog=False, xlabel=\"Energy Group\");"
+    "univ0.plot(['infFiss', 'b1Tot'], loglog=False);"
    ]
   },
   {
@@ -533,22 +521,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "('nom', 'nom') <BranchContainer for nom, nom from /home/drew/.local/lib/python3.7/site-packages/serpentTools-0.7.0+30.g3066be7.dirty-py3.7.egg/serpentTools/data/demo.coe>\n",
-      "('B750', 'nom') <BranchContainer for B750, nom from /home/drew/.local/lib/python3.7/site-packages/serpentTools-0.7.0+30.g3066be7.dirty-py3.7.egg/serpentTools/data/demo.coe>\n",
-      "('B1000', 'nom') <BranchContainer for B1000, nom from /home/drew/.local/lib/python3.7/site-packages/serpentTools-0.7.0+30.g3066be7.dirty-py3.7.egg/serpentTools/data/demo.coe>\n",
-      "('nom', 'FT1200') <BranchContainer for nom, FT1200 from /home/drew/.local/lib/python3.7/site-packages/serpentTools-0.7.0+30.g3066be7.dirty-py3.7.egg/serpentTools/data/demo.coe>\n",
-      "('B750', 'FT1200') <BranchContainer for B750, FT1200 from /home/drew/.local/lib/python3.7/site-packages/serpentTools-0.7.0+30.g3066be7.dirty-py3.7.egg/serpentTools/data/demo.coe>\n",
-      "('B1000', 'FT1200') <BranchContainer for B1000, FT1200 from /home/drew/.local/lib/python3.7/site-packages/serpentTools-0.7.0+30.g3066be7.dirty-py3.7.egg/serpentTools/data/demo.coe>\n",
-      "('nom', 'FT600') <BranchContainer for nom, FT600 from /home/drew/.local/lib/python3.7/site-packages/serpentTools-0.7.0+30.g3066be7.dirty-py3.7.egg/serpentTools/data/demo.coe>\n",
-      "('B750', 'FT600') <BranchContainer for B750, FT600 from /home/drew/.local/lib/python3.7/site-packages/serpentTools-0.7.0+30.g3066be7.dirty-py3.7.egg/serpentTools/data/demo.coe>\n",
-      "('B1000', 'FT600') <BranchContainer for B1000, FT600 from /home/drew/.local/lib/python3.7/site-packages/serpentTools-0.7.0+30.g3066be7.dirty-py3.7.egg/serpentTools/data/demo.coe>\n"
+      "('nom', 'nom') <BranchContainer for nom, nom from /home/ajohnson400/github/my-serpent-tools/serpentTools/data/demo.coe>\n",
+      "('B750', 'nom') <BranchContainer for B750, nom from /home/ajohnson400/github/my-serpent-tools/serpentTools/data/demo.coe>\n",
+      "('B1000', 'nom') <BranchContainer for B1000, nom from /home/ajohnson400/github/my-serpent-tools/serpentTools/data/demo.coe>\n",
+      "('nom', 'FT1200') <BranchContainer for nom, FT1200 from /home/ajohnson400/github/my-serpent-tools/serpentTools/data/demo.coe>\n",
+      "('B750', 'FT1200') <BranchContainer for B750, FT1200 from /home/ajohnson400/github/my-serpent-tools/serpentTools/data/demo.coe>\n",
+      "('B1000', 'FT1200') <BranchContainer for B1000, FT1200 from /home/ajohnson400/github/my-serpent-tools/serpentTools/data/demo.coe>\n",
+      "('nom', 'FT600') <BranchContainer for nom, FT600 from /home/ajohnson400/github/my-serpent-tools/serpentTools/data/demo.coe>\n",
+      "('B750', 'FT600') <BranchContainer for B750, FT600 from /home/ajohnson400/github/my-serpent-tools/serpentTools/data/demo.coe>\n",
+      "('B1000', 'FT600') <BranchContainer for B1000, FT600 from /home/ajohnson400/github/my-serpent-tools/serpentTools/data/demo.coe>\n"
      ]
     }
    ],
@@ -588,7 +576,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -604,7 +592,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -618,7 +606,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -627,7 +615,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
@@ -640,7 +628,7 @@
        " 'TFU': 600}"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -651,7 +639,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -668,7 +656,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [
     {
@@ -677,7 +665,7 @@
        "{'infTot': array([0.313338, 0.54515 ])}"
       ]
      },
-     "execution_count": 24,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -689,7 +677,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [
     {
@@ -698,7 +686,7 @@
        "{}"
       ]
      },
-     "execution_count": 25,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -732,7 +720,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,

--- a/serpentTools/xs.py
+++ b/serpentTools/xs.py
@@ -503,12 +503,12 @@ class BranchCollector(object):
         branch = self._branches[branchKey]
         univs = set()
         _burnups = set()
-        for unID, bu, ix in branch.universes:
+        for (unID, bu, ix, day), universe in iteritems(branch):
             univs.add(unID)
-            _burnups.add(bu)
+            _burnups.add(bu if day is None else day)
         self._burnups = tuple(sorted(_burnups))
         self.univIndex = tuple(sorted(univs))
-        return branch.universes[unID, bu, ix]
+        return universe
 
     @staticmethod
     def _getXsSizes(sampleUniv):
@@ -558,7 +558,7 @@ class BranchCollector(object):
 
         univAxis = self._axis[1:]
         # Create all the univIndex
-        for univIndex, univID in enumerate(self.univIndex):
+        for univID in self.univIndex:
             self.universes[univID] = BranchedUniv(univID, self, univAxis)
         for xsKey, xsMat in iteritems(self.xsTables):
             for univIndex, univID in enumerate(self.univIndex):


### PR DESCRIPTION
This PR extends work from #343 by using `UnivTuple`s as keys for the branch container. This will cause some breaking changes, as the keys in `BranchContainer.universes` are now tuples of four values, not three any more. This provides a consistent way to collect keys storing homogenized universe data between the results reader and branching reader.

Another change introduced is that now the BranchContainers is a subclass of dictionary with the __setitem__ and __getitem__ setting and fetching homogenized universes. This was already handled by the `universes` attribute, but now we have more control over setting keys and ensuring the values are universes.