### PR TITLE
BUG Properly set burnup, days for universes without burnup

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,6 +13,12 @@ Next
 * |HomogUniv| objects no longer automatically convert data to arrays
 * Serpent 2.1.31 is the default version for :ref:`serpentVersion` setting
 
+Bug Fixes
+---------
+
+* Burnup and days are properly set on homogenized universes when reading a
+  result file with multiple universes but no burnup
+
 Incompatible API Changes
 ------------------------
 

--- a/serpentTools/parsers/results.py
+++ b/serpentTools/parsers/results.py
@@ -311,14 +311,14 @@ class ResultsReader(XSReader):
             else:
                 days = self.resdata[varPyDays][-1]
         else:
-            days = self._counter['meta'] - 1
+            days = 0
         if varPyBU in self.resdata.keys():
             if burnIdx > 0:
                 burnup = self.resdata[varPyBU][-1, 0]
             else:
                 burnup = self.resdata[varPyBU][-1]
         else:
-            burnup = self._counter['meta'] - 1
+            burnup = 0
         return UnivTuple(self._univlist[-1], burnup, burnIdx, days)
 
     def _getVarName(self, tline):

--- a/serpentTools/parsers/results.py
+++ b/serpentTools/parsers/results.py
@@ -204,14 +204,22 @@ class ResultsReader(XSReader):
 
     def __init__(self, filePath):
         XSReader.__init__(self, filePath, 'results')
-        self._counter = {'meta': 0, 'rslt': 0}
-        self._numUniverses = 0
-        self._univlist = []
-        self.metadata, self.resdata, self.universes = {}, {}, {}
-        self._varTypeLookup = {}
+
+        self.metadata = {}
+        self.resdata = {}
+        self.universes = {}
 
     def _read(self):
         """Read through the results file and store requested data."""
+
+        self._counter = {'meta': 0, 'rslt': 0}
+        self._univlist = []
+        self._varTypeLookup = {}
+
+        self.metadata.clear()
+        self.resdata.clear()
+        self.universes.clear()
+
         with open(self.filePath, 'r') as fObject:
             for tline in fObject:
                 self._processResults(tline)
@@ -459,8 +467,8 @@ class ResultsReader(XSReader):
     def _postcheck(self):
         self._inspectData()
         self._cleanMetadata()
-        del self._varTypeLookup
-        self._univList = []
+        del (self._varTypeLookup, self._burnupKeys, self._keysVersion,
+             self._counter, self._univlist)
 
     def _compare(self, other, lower, upper, sigma):
         similar = self.compareMetadata(other)

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -1,0 +1,40 @@
+import re
+import os
+
+import pytest
+import serpentTools
+
+
+@pytest.fixture
+def multipleGcuNoBu():
+    origFile = serpentTools.data.getFile("InnerAssembly_res.m")
+    newFile = "MultipleGcuNoBu_res.m"
+    nGcu = 3
+    counter = re.compile("Increase counter")
+    burnKey = re.compile("BURN")
+    counts = 0
+
+    with open(origFile, "r") as orig, open(newFile, "w") as new:
+        for line in orig:
+            if burnKey.match(line):
+                continue
+            if counter.search(line):
+                counts += 1
+            if counts > nGcu:
+                break
+            new.write(line)
+
+    with serpentTools.settings.rc as temprc:
+        temprc["serpentVersion"] = "2.1.30"
+        yield newFile
+
+    os.remove(newFile)
+
+
+def test_multipleGcuNoBu(multipleGcuNoBu):
+    r = serpentTools.read(multipleGcuNoBu)
+    assert len(r.universes) == 3
+    for key in r.universes:
+        assert key.step == 0
+        assert key.burnup == 0
+        assert key.days == 0


### PR DESCRIPTION
This PR closes #345 by setting the value of burnup and days to be zero if no burnup / burn_day data has been found so far. In the current versions we support, the BURNUP and BURN_DAY vectors are created/appended before we hit the GC_UNIVERSE block. Previously, the burnup/days was taken to be the number of "metadata" blocks, so the first universe would be at day 0, second at day 1, third at day 2, etc [as seen from the referenced issue]. 

Commit f90035b introduces a test that, as a standalone commit, verifies the issue exists. Once the fix in added in 7dd8840 , the test ensures the fix works.

Subsequent commits do some cleanup on the temporary variables the results reader needs to determine file location. These temporary variables are all discarded as a part of the postcheck process.