### PR TITLE
BUG Fix detector slicing, material zai plot

### DIFF
--- a/serpentTools/detectors.py
+++ b/serpentTools/detectors.py
@@ -447,6 +447,9 @@ class Detector(NamedObject):
         fixed: dict or None
             Dictionary where keys are strings pointing to dimensions in
         """
+        if fixed is None:
+            return (slice(None), ) * len(self.indexes)
+
         keys = set(fixed)
         slices = tuple()
         for key in self.indexes:

--- a/serpentTools/objects/materials.py
+++ b/serpentTools/objects/materials.py
@@ -382,7 +382,7 @@ class DepletedMaterial(DepletedMaterialBase):
         else:
             if isinstance(names, str):
                 names = [names, ]
-            if isinstance(zai, str):
+            if isinstance(zai, (int, str)):
                 zai = [zai, ]
         yVals = self.getValues(xUnits, yUnits, xVals, names, zai)
         ax = ax or pyplot.gca()


### PR DESCRIPTION
This PR introduces two small bug fixes, one introduced in this release with the new detectors and the other that has laid dormant for a while.

First, the detector slicing (#352) is updated to better handle no constraints. 

Second, a bug was discovered at the user's group meeting wherein DepletedMaterial.plot(time, value, zai=z) for single integer z (e.g. 922350) would not work. Now that is allowed