### PR TITLE
BUG Fix setting of SampledDetector.allTally

### DIFF
--- a/serpentTools/samplers/detector.py
+++ b/serpentTools/samplers/detector.py
@@ -183,7 +183,7 @@ class SampledDetector(Detector):
             self._allTallies = tallies
             return
 
-        if tallies.shape != self._tallies.shape:
+        if tallies.shape != self._allTallies.shape:
             raise ValueError("Expected shape to be {}, is {}".format(
                 self._allTallies.shape, tallies.shape))
 
@@ -205,7 +205,7 @@ class SampledDetector(Detector):
             self._allErrors = errors
             return
 
-        if errors.shape != self._errors.shape:
+        if errors.shape != self._allErrors.shape:
             raise ValueError("Expected shape to be {}, is {}".format(
                 self._allErrors.shape, errors.shape))
 


### PR DESCRIPTION
allTallies and allErrors setter methods previously compared the array shapes to tallies and errors, respectively. By definition this will not work, as the all* quantites have an additional dimension for file / detector index. This PR enables scaling allTallies and allErrors by a constant now, e.g.
```
p = DetectorSampler("assem_*_det0.m")["power"]
p.allTallies /= 1E6
```

Also converted the deviation attribute to be a property. This has two benefits:
1. If we have allTallies, we can compute the deviation at call time with `allTallies.std(axis=0)`
2. Size checking against existing deviation, tallies, or allTallies attributes