### PR TITLE
BUG/API Improve usability of sampled spread plots

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -27,6 +27,11 @@ Changelog
   :class:`~serpentTools.objects.UnivTuple`
 * Keys for microscopic cross sections in ``MicroXSReader.xsVal`` and
   ``MicroXSReader.xsUnc`` are :class:`~serpentTools.MicroXSTuple`
+* Spread plots for sampled detector and depletion containers allow
+  changing how the mean data and sampled data are plotted by passing
+  dictionary of matplotlib commands, e.g.
+  ``meanKwargs={"c": "r", "marker": x"}`` would plot the mean data in
+  red with crosses as markers.
 
 .. _v0.8.0-bug:
 

--- a/serpentTools/samplers/base.py
+++ b/serpentTools/samplers/base.py
@@ -14,11 +14,6 @@ from serpentTools.parsers.base import BaseReader
 
 MISSING_KEY_FLAG = "<missing>"
 
-SPREAD_PLOT_KWARGS = {
-    'c': 'k',
-    'alpha': 0.5
-}
-
 
 def extendFiles(files):
     """Return a set of files where some may contain * globs"""
@@ -47,7 +42,7 @@ class Sampler(object):
         Single file or iterable (list) of files from which to read.
         Supports file globs, ``*det0.m`` expands to all files that
         end with ``det0.m``
-parser: subclass of BaseReader
+    parser: subclass of BaseReader
         Class that will be used to read all files
 
     Attributes

--- a/serpentTools/samplers/depletion.py
+++ b/serpentTools/samplers/depletion.py
@@ -385,9 +385,7 @@ class SampledDepletedMaterial(SampledContainer, DepletedMaterialBase):
             plotData = self._slice(data, rows, cols)[0]
             ax.plot(xVals, plotData, **sampleKwargs)
 
-        ax.plot(
-            xVals, primaryData, label='Mean value - N={}'.format(self._index),
-            **meanKwargs)
+        ax.plot(xVals, primaryData, label='Mean value', **meanKwargs)
 
         ax = sigmaLabel(ax, xlabel or DEPLETION_PLOT_LABELS[xUnits],
                         ylabel or DEPLETION_PLOT_LABELS[yUnits])

--- a/serpentTools/samplers/depletion.py
+++ b/serpentTools/samplers/depletion.py
@@ -344,16 +344,6 @@ class SampledDepletedMaterial(SampledContainer, DepletedMaterialBase):
         -------
         {rax}
 
-        Raises
-        ------
-        :class:`~serpentTools.SamplerError`
-            If ``self.allData`` is empty. Sampler was instructed to
-            free all materials and does not retain data from all containers
-
-        See Also
-        --------
-        :meth:`~serpentTools.samplers.depletion.SampledDepletedMaterial.plot`
-
         """
         if not self.allData:
             raise SamplerError("Data from all sampled files has been freed "

--- a/serpentTools/samplers/detector.py
+++ b/serpentTools/samplers/detector.py
@@ -12,7 +12,7 @@ from serpentTools.messages import SerpentToolsException
 from serpentTools.utils import magicPlotDocDecorator, formatPlot
 from serpentTools.parsers.detector import DetectorReader
 from serpentTools.detectors import Detector
-from serpentTools.samplers.base import Sampler, SPREAD_PLOT_KWARGS
+from serpentTools.samplers.base import Sampler
 
 
 class DetectorSampler(Sampler):
@@ -212,7 +212,8 @@ class SampledDetector(Detector):
         self._allErrors = errors
 
     @magicPlotDocDecorator
-    def spreadPlot(self, xdim=None, fixed=None, ax=None, xlabel=None,
+    def spreadPlot(self, xdim=None, fixed=None, sampleKwargs=None,
+                   meanKwargs=None, ax=None, xlabel=None,
                    ylabel=None, logx=False, logy=False, loglog=False,
                    legend=True):
         """
@@ -224,6 +225,13 @@ class SampledDetector(Detector):
             Bin index to place on the x-axis
         fixed: None or dict
             Dictionary controlling the reduction in data down to one dimension
+        sampleKwargs : dict, optional
+            Additional matplotlib-acceptable arguments to be passed into the
+            plot when plotting data from unique runs, e.g.
+            ``{"c": k, "alpha": 0.5}``.
+        meanKwargs : dict, optional
+            Additional matplotlib-acceptable argumentst to be used when
+            plotting the mean value, e.g. ``{"c": "b", "marker": "o"}``
         {ax}
         {xlabel}
         {ylabel}
@@ -258,12 +266,18 @@ class SampledDetector(Detector):
                     samplerData.shape))
         xdata, autoX = self._getPlotXData(xdim, samplerData)
         xlabel = xlabel or autoX
+
+        if sampleKwargs is None:
+            sampleKwargs = {"c": "k", "alpha": 0.5, "marker": ""}
+        if meanKwargs is None:
+            meanKwargs = {"c": "#0173b2", "marker": "o"}
+
         ax = ax or pyplot.gca()
         for data in self.allTallies:
-            ax.plot(xdata, data[slices], **SPREAD_PLOT_KWARGS)
+            ax.plot(xdata, data[slices], **sampleKwargs)
 
         ax.plot(xdata, samplerData, label='Mean value - N={}'.format(
-            self.allTallies.shape[0]))
+            self.allTallies.shape[0]), **meanKwargs)
         formatPlot(ax, logx=logx, logy=logy, loglog=loglog, xlabel=xlabel,
                    ylabel=ylabel, legend=legend)
         return ax

--- a/serpentTools/samplers/detector.py
+++ b/serpentTools/samplers/detector.py
@@ -276,8 +276,7 @@ class SampledDetector(Detector):
         for data in self.allTallies:
             ax.plot(xdata, data[slices], **sampleKwargs)
 
-        ax.plot(xdata, samplerData, label='Mean value - N={}'.format(
-            self.allTallies.shape[0]), **meanKwargs)
+        ax.plot(xdata, samplerData, label='Mean value', **meanKwargs)
         formatPlot(ax, logx=logx, logy=logy, loglog=loglog, xlabel=xlabel,
                    ylabel=ylabel, legend=legend)
         return ax

--- a/serpentTools/samplers/detector.py
+++ b/serpentTools/samplers/detector.py
@@ -244,15 +244,6 @@ class SampledDetector(Detector):
         -------
         {rax}
 
-        Raises
-        ------
-        AttributeError
-            If ``allTallies`` is None, indicating this object has been
-            instructed to free up data from all sampled files
-        :class:`~serpentTools.SerpentToolsException`
-            If data to be plotted, after applying ``fixed``, is not
-            one dimensional
-
         """
         if self.allTallies is None:
             raise AttributeError(


### PR DESCRIPTION
Two main changes here, but both related to the spread plots from sampled detector and depleted material objects.

1. `SampledDepletedMaterial.spreadPlot` now accepts either isotope name (U235) or zai (922350)
2. Users can alter how `spreadPlot` for `SampledDepletedMaterial` and `SampledDetector` plot both the mean data and data from individual runs with `sampleKwargs` and `meanKwargs`