### PR TITLE
BUG Fix detector.names setting

### DIFF
--- a/serpentTools/parsers/detector.py
+++ b/serpentTools/parsers/detector.py
@@ -76,7 +76,7 @@ class DetectorReader(BaseReader):
 
     def _processDet(self, name, bins, grids):
         """Add this detector with it's grid data to the reader."""
-        if self.settings['names'] and name in self.settings['names']:
+        if self.settings['names'] and name not in self.settings['names']:
             return
         if name in self.detectors:
             raise KeyError("Detector {} already stored on reader"


### PR DESCRIPTION
The detector.names setting is supposed to contain a list of detectors to be stored on the reader. Instead, it previously read in detectors that were not in the list, meaning it worked more like anti-pattern. This has been remedied.

This might merit releasing 0.8.1 for maintenance