### PR TITLE
REL Release 0.9.0

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,10 +6,10 @@
 Changelog
 =========
 
-.. _vnext:
+.. _v0.9.0:
 
-Next
-====
+:release-tag:`0.9.0`
+====================
 
 * Python 2 support has been dropped.
 * Add support for installing and testing against Python 3.7

--- a/serpentTools/__init__.py
+++ b/serpentTools/__init__.py
@@ -7,4 +7,4 @@ from serpentTools.samplers import *
 from serpentTools.seed import *
 from serpentTools.xs import *
 
-__version__ = "0.9.0a"
+__version__ = "0.9.0"

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ with open('./requirements.txt') as req:
 
 pythonRequires = ">=3.5,<3.8"
 
-version = "0.9.0a"
+version = "0.9.0"
 
 setupArgs = {
     'name': 'serpentTools',


### PR DESCRIPTION
Identical API as version 0.8.0, but with no python 2 support.

This commit bumps version numbers in setup.py, docs/conf.py, and serpentTools/__init__.py