### PR TITLE
REL Release version 0.9.1

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,22 @@
 Changelog
 =========
 
+
+.. _v0.9.1:
+
+:release-tag:`0.9.1`
+====================
+
+.. _v0.9.1-bugs:
+
+Bug Fixes
+---------
+
+* Sensitivity arrays generated with ``sens opt history 1`` will no longer
+  overwrite the primary result arrays - :pull:`366`. These arrays are not 
+  currently stored - :issue:`367`
+
+
 .. _v0.9.0:
 
 :release-tag:`0.9.0`

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -52,7 +52,7 @@ master_doc = 'index'
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 
-version = "0.9.0a"
+version = "0.9.1"
 
 # General information about the project.
 project = 'serpentTools'

--- a/serpentTools/__init__.py
+++ b/serpentTools/__init__.py
@@ -7,4 +7,4 @@ from serpentTools.samplers import *
 from serpentTools.seed import *
 from serpentTools.xs import *
 
-__version__ = "0.9.0"
+__version__ = "0.9.1"

--- a/serpentTools/parsers/sensitivity.py
+++ b/serpentTools/parsers/sensitivity.py
@@ -54,6 +54,13 @@ class SensitivityReader(BaseReader):
     The matrices in :attr:`energyIntegratedSens` will have the same
     structure, but with the :attr:`energies` dimension removed.
 
+
+    .. note::
+
+        Arrays generated using the history option ``sens opt history 1``
+        are not currently stored on the reader. See feature request
+        :issue:`367`
+
     Parameters
     ----------
     filePath : str

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ with open('./requirements.txt') as req:
 
 pythonRequires = ">=3.5,<3.8"
 
-version = "0.9.0"
+version = "0.9.1"
 
 setupArgs = {
     'name': 'serpentTools',


### PR DESCRIPTION
Bump version to 0.9.1 in `setup.py`, `serpentTools/__init__.py`, and `docs/conf.py`. Updated changelog to reflect handling of sensitivity history arrays. Will issue a release shortly after