### PR TITLE
DEV Use list of arrays to improve results parsing

### DIFF
--- a/serpentTools/parsers/results.py
+++ b/serpentTools/parsers/results.py
@@ -3,7 +3,7 @@ from collections import OrderedDict
 from numbers import Real
 import re
 
-from numpy import array, vstack, empty
+from numpy import array, empty, asarray
 from cycler import cycler
 from matplotlib import rcParams
 from matplotlib.pyplot import gca
@@ -140,6 +140,58 @@ def varTypeFactory(key):
 __all__ = ['ResultsReader', ]
 
 
+class ListOfArrays(list):
+    """Helper class for creating arrays by appending rows
+
+    Parameters
+    ----------
+    values : numpy.ndarray, optional
+        Initial row to insert into array
+
+    Attributes
+    ----------
+    A : numpy.ndarray
+        Array where each row ``A[i]`` is the ``i``-th row or
+        sub-array that was appended
+    """
+
+    def __init__(self, values=None):
+        super().__init__()
+        self._shape = None
+        self._dtype = None
+        if values is not None:
+            self.append(values)
+
+    @property
+    def A(self):
+        return array(self)
+
+    def append(self, value):
+        """Append a row into the final array
+
+        Parameters
+        ----------
+        value : numpy.ndarray or array-like
+            Some object that can be coerced to a numpy.ndarray.
+            Must have same shape and data type (e.g. float) as
+            previously appended rows
+
+        """
+        value = asarray(value)
+        if not self:
+            self._shape = value.shape
+            self._dtype = value.dtype
+        elif self._shape != value.shape:
+            raise ValueError(
+                "Shapes do not agree: Current {} vs. incoming {}".format(
+                    self._shape, value.shape))
+        elif self._dtype != value.dtype:
+            raise TypeError(
+                "Types do not agree: Current {} vs. incoming {}".format(
+                    self._dtype, value.dtype))
+        super().append(value)
+
+
 class ResultsReader(XSReader):
     """
     Parser responsible for reading and working with result files.
@@ -214,6 +266,7 @@ class ResultsReader(XSReader):
         self._counter = {'meta': 0, 'rslt': 0}
         self._univlist = []
         self._varTypeLookup = {}
+        self._tempArrays = {}
 
         self.metadata.clear()
         self.resdata.clear()
@@ -222,6 +275,17 @@ class ResultsReader(XSReader):
         with open(self.filePath, 'r') as fObject:
             for tline in fObject:
                 self._processResults(tline)
+
+        while self._tempArrays:
+            # Consume temporary arrays
+            key, temp = self._tempArrays.popitem()
+            value = temp.A
+
+            # Only insert first row if no burnup present
+            if value.shape[0] == 1:
+                self.resdata[key] = value.reshape(value.size)
+            else:
+                self.resdata[key] = value
 
     def _processResults(self, tline):
         """Performs the main processing of the results."""
@@ -280,23 +344,18 @@ class ResultsReader(XSReader):
     def _storeResData(self, varNamePy, varVals):
         """Process time-dependent results data"""
         vals = str2vec(varVals)  # convert the string to float numbers
-        if varNamePy in self.resdata.keys():  # extend existing matrix
-            currVar = self.resdata[varNamePy]
-            if len(currVar.shape) == 2:
-                ndim = currVar.shape[0]
-            else:
-                ndim = 1
-            if ndim < self._counter['rslt']:
-                # append this data only once!
-                try:
-                    stacked = vstack([self.resdata[varNamePy], vals])
-                    self.resdata[varNamePy] = stacked
-                except Exception as ee:
-                    raise SerpentToolsException(
-                        "Error in appending {}  into {} of resdata:\n{}"
-                        .format(varNamePy, vals, str(ee)))
-        else:
-            self.resdata[varNamePy] = array(vals)  # define a new matrix
+
+        stored = self._tempArrays.get(varNamePy)
+        if stored is None:
+            self._tempArrays[varNamePy] = ListOfArrays(vals)
+        elif len(stored) < self._counter['rslt']:
+            # append this data only once!
+            try:
+                stored.append(vals)
+            except Exception as ee:
+                raise SerpentToolsException(
+                    "Error in appending {}  into {} of resdata:\n{}"
+                    .format(varNamePy, vals, str(ee)))
 
     def _storeMetaData(self, varNamePy, varType, varVals):
         """Store general descriptive data"""
@@ -309,23 +368,23 @@ class ResultsReader(XSReader):
     def _getBUstate(self):
         """Define unique branch state"""
         burnIdx = self._counter['rslt'] - 1
-        dayVec = self.resdata.get(self._burnupKeys["days"])
+        dayVec = self._tempArrays.get(self._burnupKeys["days"])
 
         if dayVec is None:
             days = 0
         elif burnIdx:
-            days = dayVec[-1, 0]
+            days = dayVec[-1][0]
         else:
-            days = dayVec[0]
+            days = dayVec[0][0]
 
-        burnupVec = self.resdata.get(self._burnupKeys["burnup"])
+        burnupVec = self._tempArrays.get(self._burnupKeys["burnup"])
 
         if burnupVec is None:
             burnup = 0
         elif burnIdx:
-            burnup = burnupVec[-1, 0]
+            burnup = burnupVec[-1][0]
         else:
-            burnup = burnupVec[-1]
+            burnup = burnupVec[0][0]
 
         return UnivTuple(self._univlist[-1], burnup, burnIdx, days)
 
@@ -467,7 +526,7 @@ class ResultsReader(XSReader):
         self._inspectData()
         self._cleanMetadata()
         del (self._varTypeLookup, self._burnupKeys, self._keysVersion,
-             self._counter, self._univlist)
+             self._counter, self._univlist, self._tempArrays)
 
     def _compare(self, other, lower, upper, sigma):
         similar = self.compareMetadata(other)


### PR DESCRIPTION
Introduced a helper class, ListOfArrays, to improve performance of the ResultsReader.  Instead of using ``numpy.vstack`` each time a new row is appended into the ``ResultsReader.resdata``, the row is simply appended into a list. Some checking is done to ensure that the rows have consistent shape and data type.

After reading, the final arrays are constructed and placed back in the ``resdata`` dictionary. This approach improves performance and scalability, especially for longer rows, e.g. more burnup steps.