### PR TITLE
[WIP] API Separate file objects from readers

### DIFF
--- a/serpentTools/__init__.py
+++ b/serpentTools/__init__.py
@@ -1,5 +1,6 @@
 # flake8: noqa
 from serpentTools.detectors import *
+from serpentTools.detfile import DetectorFile
 from serpentTools.parsers import *
 from serpentTools.messages import *
 from serpentTools.data import *

--- a/serpentTools/__init__.py
+++ b/serpentTools/__init__.py
@@ -2,6 +2,7 @@
 from serpentTools.detectors import *
 from serpentTools.detfile import DetectorFile
 from serpentTools.parsers import *
+from serpentTools.resultFile import ResultFile
 from serpentTools.messages import *
 from serpentTools.data import *
 from serpentTools.samplers import *

--- a/serpentTools/base.py
+++ b/serpentTools/base.py
@@ -1,0 +1,73 @@
+from abc import ABC, abstractmethod
+from contextlib import contextmanager
+from pathlib import Path
+import io
+
+
+class SerpentFile(ABC):
+    """Abstract base class for all Serpent files
+
+    A specific subclass should be responsible for storing data from
+    a specific type of file.
+
+    """
+
+    @classmethod
+    @abstractmethod
+    def fromSerpent(cls, fileOrStream, **kwargs):
+        """Return a new instance based on a file or stream
+
+        Parameters
+        ----------
+        fileOrStream : str or pathlib.Path or readable
+            If a string or :class:`pathlb.Path`, open the file for
+            reading. Otherwise check that the object can be read by
+            looking for a ``read`` and ``readline`` method.
+        kwargs :
+            Additional key word arguments to be passed to the
+            actual processing.
+
+        Returns
+        -------
+        SerpentFile
+            A serpent file corresponding to the data contained in
+            the file or readable stream.
+
+        """
+
+
+@contextmanager
+def getStream(fileOrStream):
+    """Context manager for coercing an argument to a readable type
+
+    Parameters
+    ----------
+    fileOrStream : str or pathlib.Path or io.TextIOBase
+        If a string or :class:`pathlib.Path`, open the file
+        for reading and process. Otherwise, check that the
+        object can be read by looking for a ``read`` and
+        ``readline`` method.
+
+    Yields
+    ------
+    io.TextIOBase
+        Some readable stream that will produce either the file
+        contents, in the case of string or :class:`pathlib.Path`
+        arguments, or the original input stream
+    """
+    close = True
+    if isinstance(fileOrStream, Path):
+        stream = fileOrStream.open("r")
+    elif isinstance(fileOrStream, str):
+        stream = open(fileOrStream, "r")
+    elif not isinstance(fileOrStream, io.TextIOBase):
+        raise TypeError("{} does not appear to be a readable object "
+                        "or file path".format(type(fileOrStream)))
+    else:
+        stream = fileOrStream
+        close = False
+    try:
+        yield stream
+    finally:
+        if close:
+            stream.close()

--- a/serpentTools/detfile.py
+++ b/serpentTools/detfile.py
@@ -1,0 +1,136 @@
+"""Detector file implementation
+
+Responsible for storing data from detector files
+"""
+
+from collections.abc import Mapping
+import warnings
+
+from .messages import deprecated
+from .detectors import Detector
+from .base import SerpentFile, getStream
+
+
+__all__ = ["DetectorFile"]
+
+
+class DetectorFile(SerpentFile, Mapping):
+    """Class for storing detector data
+
+    Can be treated as a :class:`dict`, mapping detector
+    names to their corresponding :class:`serpentTools.Detector`
+    instances. Fulfills a :class:`collections.abc.Mapping`
+    interface by providing :meth:`__iter__`, :meth:`__getitem__`,
+    :meth:`__setitem__`, and :meth:`__len__` methods.
+
+    .. note::
+
+        Only :class:`serpentTools.Detector` instances can be
+        assigned as values.
+
+    Parameters
+    ----------
+    detectors : Mapping[str, Detector], optional
+        Initial map of detector names and
+        :class:`~serpentTools.Detector` instances.
+
+    Attributes
+    ----------
+    detectors : dict
+        Deprecated attribute for backwards compatibility. It
+        is preferable to treat instances of this class as
+        a dictionary
+
+    See Also
+    --------
+    :meth:`fromSerpent` - Convenience method for loading data
+    directly from a detector file
+
+    """
+
+    def __init__(self, detectors=None):
+        if detectors is None:
+            self._detectors = {}
+        elif not isinstance(detectors, Mapping):
+            raise TypeError("Expected detectors to be Mapping, not {}".format(
+                type(detectors)))
+        else:
+            for k, v in detectors.items():
+                if not isinstance(k, str):
+                    raise TypeError("Keys must be strings, not {}".format(k))
+                if not isinstance(v, Detector):
+                    raise TypeError("Values must be {}, not {}".format(Detector, type(v)))
+            self._detectors = detectors
+
+    def __iter__(self):
+        return iter(self._detectors)
+
+    def __getitem__(self, key):
+        return self._detectors[key]
+
+    def __setitem__(self, key, value):
+        if not isinstance(value, Detector):
+            raise TypeError(
+                "Cannot assign {} to {} as it is not a {}".format(
+                    key, type(value), Detector))
+        self._detectors[key] = value
+
+    def __len__(self):
+        return len(self._detectors)
+
+    def __repr__(self):
+        return "<{} with detectors {}>".format(
+            self.__class__.__name__, ", ".join(sorted(self)))
+
+    @property
+    def detectors(self):
+        warnings.warn(
+            "{o}.detectors is deprecated in favor of operating directly "
+            "on {o} like a dictionary.".format(o=self.__class__.__name__))
+        return self
+
+    @deprecated("det.items()")
+    def iterDets(self):
+        return self.items()
+
+    @classmethod
+    def fromSerpent(cls, fileOrStream, names=None):
+        """Process detector data and create a new DetectorFile
+
+        If no names are given, then the current value of
+        ``detector.names`` will be retrived from the
+        :class:`~serpentTools.settings.rc` settings manager.
+        Any value given in ``names`` will take precedence over
+        existing settings.
+
+        Parameters
+        ----------
+        fileOrStream : str or pathlib.Path or readable
+            If a string or :class:`pathlib.Path`, open the file
+            for reading and process. Otherwise, check that the
+            object can be read by looking for a ``read`` and
+            ``readline`` method.
+        names : iterable of str, optional
+            Specific names of detectors, as they appear in the output
+            file, to be processed. Any detector that is found that
+            does appear in ``names`` will not be stored on the
+            resulting :class:`DetectorFile` object
+
+        Returns
+        -------
+        DetectorFile
+            Instance containing all detector data found in the stream
+
+        """
+        from serpentTools.settings import rc
+        from serpentTools.parsers import DetectorReader
+
+        detFile = cls()
+        names = names or rc["detector.names"]
+        reader = DetectorReader(names)
+
+        with getStream(fileOrStream) as stream:
+            for det in reader.processStream(stream):
+                detFile[det.name] = det
+
+        return detFile

--- a/serpentTools/parsers/detector.py
+++ b/serpentTools/parsers/detector.py
@@ -1,101 +1,117 @@
 """Parser responsible for reading the ``*det<n>.m`` files"""
 
-from warnings import warn
 from numpy import empty
 
 from serpentTools.utils import str2vec
 from serpentTools.utils.compare import getKeyMatchingShapes
 from serpentTools.engines import KeywordParser
 from serpentTools.detectors import detectorFactory
-from serpentTools.parsers.base import BaseReader
-from serpentTools.messages import SerpentToolsException
 
 
-# After py2 removal, subclass this from collections.abc.Mapping
-# Gain full dictionary-like behavior by defining a few methods
-class DetectorReader(BaseReader):
+class DetectorReader:
     """
     Parser responsible for reading and working with detector files.
 
     Parameters
     ----------
-    filePath: str
-        path to the depletion file
+    names : iterable of str, optional
+        Names of detectors to be saved, exactly as they appear in the
+        output file. If not given, all detectors will be stored
 
     Attributes
     ----------
-    detectors : dict
-        Dictionary where key, value pairs correspond to detector names
-        and their respective :class:`~serpentTools.objects.detector.Detector`
-        instances
+    names : set of str
+        Names of detectors to be processed. If empty, all detectors
+        will be processed
+
     """
 
-    def __init__(self, filePath):
-        BaseReader.__init__(self, filePath, 'detector')
-        self.detectors = {}
+    def __init__(self, names=None):
+        self.names = set(names) if names else set()
 
-    def __getitem__(self, name):
-        """Retrieve a detector from :attr:`detectors`"""
-        return self.detectors[name]
+    def processStream(self, stream):
+        """Process the contents of an output file
 
-    def __len__(self):
-        return len(self.detectors)
+        :attr:`names` is used to filter out detectors. If
+        not-empty and the name of a detector does not appear
+        in the list, the data is not processed.
 
-    def __contains__(self, key):
-        return key in self.detectors
+        Parameters
+        ----------
+        stream : io.TextIOBase
+            Readable buffer such as an opened file to be read.
 
-    def __iter__(self):
-        return iter(self.detectors)
+        Yields
+        ------
+        Detector
+            Each detector found in the file
 
-    def iterDets(self):
-        """Yield name, detector pairs by iterating over :attr:`detectors`."""
-        for key, det in self.detectors.items():
-            yield key, det
-
-    def _read(self):
-        """Read the file and store the detectors."""
+        """
         currentName = ""
         grids = {}
         bins = None
-        with KeywordParser(self.filePath, ["DET"], ["\n", "];"]) as parser:
-            for chunk in parser.yieldChunks():
-                name, data = cleanDetChunk(chunk)
-                if currentName and name[:len(currentName)] != currentName:
-                    self._processDet(currentName, bins, grids)
-                    bins = data
-                    grids = {}
-                    currentName = name
-                elif bins is None:
-                    currentName = name
-                    bins = data
-                else:
-                    gridName = name[len(currentName):]
-                    grids[gridName] = data
-            self._processDet(currentName, bins, grids)
+        parser = KeywordParser(stream, ["DET"], ["\n", "];"])
+        for chunk in parser:
+            name, data = self._cleanDetChunk(chunk)
+            if currentName and name[:len(currentName)] != currentName:
+                det = self._processDet(currentName, bins, grids)
+                if det is not None:
+                    yield det
+                bins = data
+                grids = {}
+                currentName = name
+            elif bins is None:
+                currentName = name
+                bins = data
+            else:
+                gridName = name[len(currentName):]
+                grids[gridName] = data
+            det = self._processDet(currentName, bins, grids)
+            if det is not None:
+                yield det
+
+    @staticmethod
+    def _cleanDetChunk(chunk):
+        """
+        Return the name of the detector [grid] and the array of data.
+
+        Parameters
+        ----------
+        chunk : list
+            Chunk of text from the output file pertaining to this section.
+            Should begin with ``DET<name>[<grid>] = [`` with
+            array data on the subsequent lines
+
+        Returns
+        -------
+        str
+            Name of the detector including grid characters
+        numpy.ndarray
+            Array containing numeric data from the chunk
+
+        Raises
+        ------
+        ValueError
+            If the name of the detector could not be determined
+        """
+        if chunk[0][:3] != 'DET':
+            raise ValueError(
+                "Could not determine name of detector from chunk: {}"
+                .format(chunk[0]))
+        name = chunk[0].split()[0][3:]
+        if chunk[-1][:2] == '];':
+            chunk.pop()
+        nCols = len(chunk[1].split())
+        data = empty((len(chunk[1:]), nCols), order='F')
+        for indx, row in enumerate(chunk[1:]):
+            data[indx] = str2vec(row)
+        return name, data
 
     def _processDet(self, name, bins, grids):
         """Add this detector with it's grid data to the reader."""
-        if self.settings['names'] and name not in self.settings['names']:
+        if self.names and name not in self.names:
             return
-        if name in self.detectors:
-            raise KeyError("Detector {} already stored on reader"
-                           .format(name))
-        self.detectors[name] = detectorFactory(name, bins, grids)
-
-    def _precheck(self):
-        """ Count how many detectors are in the file."""
-        with open(self.filePath) as fh:
-            for line in fh:
-                sline = line.split()
-                if not sline:
-                    continue
-                if 'DET' in sline[0]:
-                    return
-        warn("No detectors in pre-checking {}".format(self.filePath))
-
-    def _postcheck(self):
-        if not self.detectors:
-            warn("No detectors stored from file {}".format(self.filePath))
+        return detectorFactory(name, bins, grids)
 
     def _compare(self, other, lower, upper, sigma):
         """Compare two detector readers."""
@@ -120,40 +136,3 @@ class DetectorReader(BaseReader):
 
         return data
 
-
-def cleanDetChunk(chunk):
-    """
-    Return the name of the detector [grid] and the array of data.
-
-    Parameters
-    ----------
-    chunk: list
-        Chunk of text from the output file pertaining to this section.
-        Should begin with ``DET<name>[<grid>] = [`` with
-        array data on the subsequent lines
-
-    Returns
-    -------
-    str:
-        Name of the detector including grid characters
-    numpy.ndarray:
-        Array containing numeric data from the chunk
-
-    Raises
-    ------
-    SerpentToolsException:
-        If the name of the detector could not be determined
-    """
-    if chunk[0][:3] != 'DET':
-        raise SerpentToolsException(
-            "Could not determine name of detector from chunk: {}"
-            .format(chunk[0]))
-    leader = chunk.pop(0)
-    name = leader.split()[0][3:]
-    if chunk[-1][:2] == '];':
-        chunk.pop(-1)
-    nCols = len(chunk[0].split())
-    data = empty((len(chunk), nCols), order='F')
-    for indx, row in enumerate(chunk):
-        data[indx] = str2vec(row)
-    return name, data

--- a/serpentTools/resultFile.py
+++ b/serpentTools/resultFile.py
@@ -1,0 +1,445 @@
+from collections import OrderedDict
+from collections.abc import Mapping
+
+from cycler import cycler
+from matplotlib.pyplot import gca
+from matplotlib import rcParams
+
+from .base import getStream, SerpentFile
+from serpentTools.objects.containers import UnivTuple
+from serpentTools.utils import (
+    magicPlotDocDecorator, RESULTS_PLOT_XLABELS, formatPlot, placeLegend,
+)
+from serpentTools.messages import SerpentToolsException
+
+__all__ = ["ResultFile"]
+
+
+class ResultFile(SerpentFile):
+    """File containing the primary simulation results
+
+    When inspecting keys of :attr:`universes`, it is preferable to use
+    an attribute based approach rather than positional. For example::
+
+        >>> for key in res.universes:
+        ...     break
+        >>> key.universe
+        # rather than
+        >>> key[0]
+
+    Parameters
+    ----------
+    resdata : Mapping, optional
+        Dictionary with time-dependent variables as keys and the
+        corresponding values. The data is unique for each burnup step.
+    universes: Mapping, optional
+        Dictionary of universe identifiers
+        :class:`~serpentTools.objects.UnivTuple` and their corresponding
+        :class:`~serpentTools.objects.HomogUniv` objects.
+    metadata: Mapping, optional
+        Dictionary with descriptive variables as keys and the
+        corresponding description.
+
+    Attributes
+    ------------
+    metadata: Mapping
+        Dictionary with descriptive variables as keys and the
+        corresponding description. Within the _res.m file this data is
+        printed multiple times, but contains the same description
+        and thus is stored only once. e.g., 'version': 'Serpent 2.1.29'
+    resdata: Mapping
+        Dictionary with time-dependent variables as keys and the
+        corresponding values. The data is unique for each burnup step.
+        Some variables also contain uncertainties.
+        e.g., 'absKeff': [[9.91938E-01, 0.00145],[1.81729E-01, 0.00240]]
+    universes: Mapping
+        Dictionary of universe identifiers
+        :class:`~serpentTools.objects.UnivTuple` and their corresponding
+        :class:`~serpentTools.objects.HomogUniv` objects. The keys
+        describe a unique state: 'universe', burnup (MWd/kg), burnup
+        index, time (days) ('0', 0.0, 0, 0.0).  Burnup indexes are
+        zero-indexed, meaning the first step is index 0.
+
+    See Also
+    --------
+    :meth:`fromSerpent` - A convenience method for loading data
+    directly from a result file
+
+    """
+
+    def __init__(self, resdata=None, universes=None, metadata=None):
+        if resdata is None:
+            self.resdata = {}
+        elif not isinstance(resdata, Mapping):
+            raise TypeError(
+                "Expect resdata to be Mapping, not {}".format(type(resdata)))
+        else:
+            self.resdata = resdata
+
+        if universes is None:
+            self.universes = {}
+        elif not isinstance(universes, Mapping):
+            raise TypeError(
+                "Expect universes to be Mapping, not {}".format(type(resdata)))
+        else:
+            self.universes = universes
+
+        if metadata is None:
+            self.metadata = {}
+        elif not isinstance(metadata, Mapping):
+            raise TypeError(
+                "Expect metadata to be Mapping, not {}".format(type(resdata)))
+        else:
+            self.metadata = metadata
+
+    def getUniv(self, univ, burnup=None, index=None, timeDays=None):
+        """
+        Return a specific universe given the ID and time of interest
+
+        Parameters
+        ----------
+        univ: str
+            Unique str for the desired universe
+        burnup: float or int, optional
+            Burnup [MWd/kgU] of the desired universe
+        timeDays: float or int, optional
+            Time [days] of the desired universe
+        index: int, optinal
+            Point of interest in the burnup/days index
+
+        Returns
+        -------
+        :class:`~serpentTools.objects.HomogUniv`
+            Requested universe
+
+        Raises
+        ------
+        KeyError:
+            If the requested universe could not be found
+        :class:`~serpentTools.SerpentToolsException`
+            If burnup, days and index are not given
+        """
+        if index is None and burnup is None and timeDays is None:
+            raise SerpentToolsException(
+                'Burnup, time or index are required inputs')
+
+        searchKey = UnivTuple(univ, burnup, index, timeDays)
+
+        # check if key is exactly present
+
+        universe = self.universes.get(searchKey)
+        if universe is not None:
+            return universe
+
+        for key, universe in self.universes.items():
+            for uItem, sItem in zip(key, searchKey):
+                if sItem is None:
+                    continue
+                elif uItem != sItem:
+                    break
+            else:
+                return universe
+        raise KeyError(
+            "Could not find a universe that matches {}".format(searchKey))
+
+    @magicPlotDocDecorator
+    def plot(self, x, y=None, right=None, sigma=3, ax=None, legend=None,
+             ncol=None, xlabel=True, ylabel=None, logx=False, logy=False,
+             loglog=False, rightlabel=None):
+        """
+        Plot quantities over time
+
+        Parameters
+        ----------
+        x: str or iterable of strings
+            ``y`` is not given, then plot these quantites against
+            burnup in days. Otherwise, plot this quantity as the x
+            axis with same rules as if called by ``plot('burndays', x)``.
+            Burnup options are ``{'burnup', 'days', 'burnDays', 'burnStep'}``
+        y: str or iterable of strings
+            Quantity or quantities to plot. For all entries, only
+            the first column, with respect to time, will be plotted.
+            If the second column exists, and sigma is > 0, that column
+            will be treated as the relative uncertainty for an
+            errorbar plot. If a dictionary is passed, then plots will
+            be labeled by the values of that dictionary, e.g.
+            ``{'anaKeff': $k_{eff}$}`` would plot the first column of
+            ``anaKeff`` with a ``LaTeX``-ready :math:`k_{eff}`
+        right: str or iterable of strings
+            Quantites to plot on the same plot, but with a different
+            y axis and common x axis. Same rules apply as for arguments
+            to ``y``. Each label will modified to have a unique identifier
+            indicating the plot uses the right y-axis
+        {ax}
+        {sigma}
+        {legend}
+        {ncol}
+        {xlabel}
+        {ylabel}
+        {logx}
+        logy: bool or list or tuple
+            Apply a log scale to the y-axis. If passing values to
+            ``right``, this can be a two item list or tuple,
+            corresponding to log-scaling the left and right axis,
+            respectively.
+        {loglog}
+        rlabel: str or None
+            If given and passing values to ``right``, use this to label
+            the y-axis.
+
+        Returns
+        -------
+        :class:`matplotlib.axes.Axes` or tuple of axes
+            If right is not given, then only the primary axes object
+            is returned. Otherwise, the primary and the "right"
+            axes object are returned
+
+        """
+
+        # cleanup some inputs
+        if y is None:
+            y = x
+            x = "burnDays"
+
+        sigma = max(int(sigma), 0)
+
+        y = self._expandPlotIterables(y)
+
+        if right is not None:
+            right = self._expandPlotIterables(right, ' [right]')
+
+        if xlabel is True:
+            xlabel = RESULTS_PLOT_XLABELS[x]
+
+        if len(y) == 1 and ylabel is None:
+            for ylabel in y.values():
+                break  # just need the first one
+            if sigma:
+                ylabel += r'$ \pm {}\sigma$'.format(sigma)
+
+        ax = ax or gca()
+
+        self._plot(x, y, ax, sigma)
+
+        if right is None:
+            formatPlot(ax, logx=logx, logy=logy, loglog=loglog,
+                       xlabel=xlabel, ylabel=ylabel, legend=legend,
+                       ncol=ncol)
+            return ax
+
+        # plot some other quantity on the same x axis
+        other = ax.twinx()
+
+        # update color cycle to not repeat
+        colors = rcParams['axes.prop_cycle'].by_key()['color']
+        colors = colors[len(y):] + colors[:len(y)]
+        other.set_prop_cycle(cycler('color', colors))
+
+        self._plot(x, right, other, sigma)
+
+        # formatting
+        if logy is None or isinstance(logy, bool):
+            logy = [logy, ] * 2
+
+        if loglog is None or isinstance(loglog, bool):
+            loglog = [loglog, None]
+
+        if legend or legend is None:
+            leftHandles, leftLabels = ax.get_legend_handles_labels()
+            rightHandles, rightLabels = other.get_legend_handles_labels()
+
+            placeLegend(ax, legend, ncol,
+                        (leftHandles + rightHandles,
+                         leftLabels + rightLabels))
+
+        if len(right) == 1 and rightlabel is None:
+            for rightlabel in right.values():
+                break  # just need the first one
+            if sigma:
+                rightlabel += r'$ \pm {}\sigma$'.format(sigma)
+
+        formatPlot(ax, logx=logx, logy=logy[0], loglog=loglog[0],
+                   legend=False, xlabel=xlabel, ylabel=ylabel)
+        formatPlot(other, logx=False, loglog=False, logy=logy[1],
+                   legend=False, ylabel=rightlabel.replace(' [right]', ''))
+
+        return ax, other
+
+    def _plot(self, x, y, ax, sigma):
+        """Simple, unformatted plot with dictionary of keys"""
+        # get plot data
+        xvals = self.resdata[x][:, 0]
+        for resKey, label in y.items():
+            ydata = self.resdata[resKey]
+            if ydata.shape[0] != xvals.size and ydata.size != xvals.size:
+                raise ValueError(
+                    "Quantity for {} has {} time points, not {} like {}"
+                    .format(resKey, ydata.shape[0], xvals.size, x))
+
+            # grab second column for uncertainty
+            if sigma and ydata.shape[1] > 1:
+                ax.errorbar(xvals, ydata[:, 0], label=label,
+                            yerr=ydata[:, 0] * sigma * ydata[:, 1])
+            else:
+                ax.errorbar(xvals, ydata[:, 0], label=label)
+
+    @staticmethod
+    def _expandPlotIterables(y, tail=''):
+        if isinstance(y, str):
+            return {y: "{}{}".format(y, tail)}
+        elif not isinstance(y, (dict, OrderedDict)):
+            return OrderedDict([[item, '{}{}'.format(item, tail)]
+                                for item in y])
+        return y
+
+    def toMatlab(self, fileP, reconvert=True, append=True, format='5',
+                 longNames=True, compress=True, oned='row'):
+        """
+        Write a binary MATLAB file from the contents of this reader
+
+        The group constant data will be presented as a multi-dimensional
+        array, rather than a stacked 2D matrix. The axis are ordered
+        ``burnup, universeIndex, group, value/uncertainty``
+
+        The ordering of the universes can be found in the ``'UNIVERSES'``
+        vector if ``reconvert==True``, otherwise ``'universes'``. Each
+        universe ID is present in this vector, ordered to their
+        position along the second axis in the matrix.
+
+        Parameters
+        ----------
+        fileP: str or file-like object
+            Name of the file to write
+        reconvert: bool
+            If this evaluates to true, convert values back into their
+            original form as they appear in the output file.
+        append: bool
+            If true and a file exists under ``output``, append to that file.
+            Otherwise the file will be overwritten
+        format: {'5', '4'}
+            Format of file to write. ``'5'`` for MATLAB 5 to 7.2, ``'4'`` for
+            MATLAB 4
+        longNames: bool
+            If true, allow variable names to reach 63 characters,
+            which works with MATLAB 7.6+. Otherwise, maximum length is
+            31 characters
+        compress: bool
+            If true, compress matrices on write
+        oned: {'row', 'col'}:
+            Write one-dimensional arrays as row vectors if
+            ``oned=='row'`` (default), or column vectors
+
+        Examples
+        --------
+
+        >>> import serpentTools
+        >>> from scipy.io import loadmat
+        >>> r = serpentTools.readDataFile('pwr_res.m')
+        # convert to original variable names
+        >>> r.toMatlab('pwr_res.mat', True)
+        >>> loaded = loadmat('pwr_res.mat')
+        >>> loaded['ABS_KEFF']
+        array([[0.991938, 0.00145 ],
+               [0.181729, 0.0024  ]])
+        >>> kinf = loaded['INF_KINF']
+        >>> kinf.shape
+        (2, 1, 1, 2)
+        >>> kinf[:, 0, 0, 0]
+        array([0.993385, 0.181451])
+        >>> tot = loaded['INF_TOT']
+        >>> tot.shape
+        (2, 1, 2, 2)
+        >>> tot[:, 0, :, 0]
+        array([[0.496553, 1.21388 ],
+               [0.481875, 1.30993 ]])
+        # use the universes key to identify ordering of universes
+        >>> loaded['UNIVERSES']
+        array([0])
+
+        Raises
+        ------
+        ImportError
+            If :term:`scipy` is not installed
+
+        """
+        converter = MatlabConverter(self, fileP)
+        return converter.convert(reconvert, append, format, longNames,
+                                 compress, oned)
+
+    def _gather_matlab(self, reconvert):
+        if reconvert:
+            varFunc = getSerpentCaseName
+            out = {
+                varFunc(key): value for key, value in self.metadata.items()
+            }
+            out.update({
+                varFunc(key): value for key, value in self.resdata.items()
+            })
+        else:
+            out = {}
+            varFunc = getMixedCaseName
+            out.update(self.metadata)
+            out.update(self.resdata)
+        out.update(self._gather_univdata(varFunc))
+        return out
+
+    def _gather_univdata(self, func):
+        numAppearances = {}
+
+        for key in self.universes:
+            if key.universe not in numAppearances:
+                numAppearances[key.universe] = 1
+                continue
+            numAppearances[key.universe] += 1
+        # check to make sure all universes appear an identical
+        # number of times
+        burnupVals = set(numAppearances.values())
+        if len(burnupVals) != 1:
+            raise SerpentToolsException(
+                "Universes appear a different number of times:\n{}"
+                .format(numAppearances))
+
+        shapeStart = burnupVals.pop(), len(numAppearances)
+        univOrder = tuple(sorted(numAppearances))
+
+        univData = {func('universes'): univOrder}
+
+        for univKey, univ in self.universes.items():
+
+            # position in matrix
+            uIndex = univOrder.index(univKey.universe)
+            bIndex = univKey.step
+
+            for expName, uncName in zip(
+                    ('infExp', 'b1Exp', 'gc'), ('infUnc', 'b1Unc', 'gcUnc')):
+                expD = getattr(univ, expName)
+                uncD = getattr(univ, uncName)
+                gatherPairedUnivData(univ, uIndex, bIndex, shapeStart, func,
+                                     expD, uncD, univData)
+
+        return univData
+
+    @classmethod
+    def fromSerpent(
+            cls, fileOrStream, version=None, variableGroups=None,
+            variables=None, getInfXS=None, getB1XS=None):
+
+        from serpentTools.settings import rc
+        from serpentTools.parsers import ResultsReader
+        if version is None:
+            version = rc["serpentVersion"]
+        if variableGroups is None:
+            variableGroups = rc["xs.variableGroups"]
+        if variables is None:
+            variables = rc["xs.variableExtras"]
+        if getInfXS is None:
+            getInfXS = rc["xs.getInfXS"]
+        if getB1XS is None:
+            getB1XS = rc["xs.getB1XS"]
+
+        parser = ResultsReader(version, variableGroups, variables,
+                               getInfXS, getB1XS)
+        with getStream(fileOrStream) as stream:
+            resdata, universes, metadata = parser.processStream(stream)
+
+        return cls(resdata, universes, metadata)

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -32,7 +32,7 @@ def multipleGcuNoBu():
 
 
 def test_multipleGcuNoBu(multipleGcuNoBu):
-    r = serpentTools.read(multipleGcuNoBu)
+    r = serpentTools.ResultFile.fromSerpent(multipleGcuNoBu)
     assert len(r.universes) == 3
     for key in r.universes:
         assert key.step == 0


### PR DESCRIPTION
Wanted to put this up here to provide a space for discussion, but this is my plan for resolving #335 - the separation of classes for storing data and for reading data. The basic plan is this, for each file type we support, there will be a corresponding ``File`` object that inherits from the new ``serpentTools.base.SerpentFile``. This ``File``, e.g. a ``DetectorFile``, is responsible for simply storing data from the file, while the ``serpentTools.parsers.DetectorReader`` knows how the plain text file is structured and can parse accordingly. 

The ``SerpentFile`` is an abstract base class that provides the interface that concrete classes, like ``DetectorFile`` are expected to implement. Currently this is a single class method that is responsible for reading a plain text Serpent file:
```python
@classmethod
def fromSerpent(cls, fileOrStream, **kwargs):
    # do some stuff
```
The ``fileOrStream`` should be file name to be read, or additionally a readable stream (like an opened file) to be read. This opens us up to work on more interesting representations of the output files, including [in-memory buffers](https://docs.python.org/3/library/io.html?#io.StringIO) or, as I found this weekend, [files inside a compressed zip archive](https://docs.python.org/3/library/zipfile.html?#zipfile.ZipFile.open). The additional key word arguments will interface with the settings module, and provide a consistent way to remove it - #339 

The goal for this PR is to have ``serpentTools.read`` fetch the correct ``SerpentFile`` subclass, and call this ``fromSerpent`` class method with optional filtering arguments. Most of these are pretty straightforward, as the parsing methods all work on opened files anyway. Those who use ``serpentTools.read(filepath)`` should experience no breaks in compatibility, but those who use the readers directly will.

I'm almost positive all tests will fail at this point, mainly due to [changes in the parsing engines](https://github.com/CORE-GATECH-GROUP/serpent-tools/commit/61f577d9536ac13d7a36e9b5b9b6d777863864a3)

## TODO
- [x] Detector reader
- [ ] Results reader - partially done
- [ ] Depletion reader
- [ ] MicroXS reader
- [ ] Branching reader
- [ ] Depletion matrix reader
- [ ] Sensitivity reader
- [ ] XSPlot reader
- [ ] History reader
- [ ] Update example notebooks
- [ ] Update API documentation
- [ ] Update changelog
- [ ] Pass tests