### PR TITLE
ENH Support for installing, testing with py 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ python:
   - "3.6"
   - "3.5"
   - "3.7"
+  - "3.8"
 env:
   - ST_INSTALL=setup
   - ST_INSTALL=sdist

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,6 +11,8 @@ Changelog
 0.9.2
 =====
 
+* Officially support installing under Python 3.8
+
 .. _v0.9.2-bugs:
 
 Bug Fixes

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,6 +3,6 @@ flake8==3.5.0
 pandas==0.24.0
 jupyter==1.0.0
 coverage==4.5.1
-scipy==1.1.0
+scipy==1.3.2
 pytest
 pytest-cov==2.7.1

--- a/setup.py
+++ b/setup.py
@@ -35,12 +35,13 @@ classifiers = [
     'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',
+    'Programming Language :: Python :: 3.8',
 ]
 
 with open('./requirements.txt') as req:
     installRequires = req.read()
 
-pythonRequires = ">=3.5,<3.8"
+pythonRequires = ">=3.5,<3.9"
 
 version = "0.9.1"
 


### PR DESCRIPTION
Nothing that would adversely impact this package found in the changelog - https://docs.python.org/3/whatsnew/3.8.html

setup.py now allows python 3.8, and the travis build also tests against this.

I've also been using 3.8 for a while now and haven't had any issues with serpentTools.
