### PR TITLE
BUG Properly handle similarly named detectors

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,18 @@
 Changelog
 =========
 
+.. _v0.9.2:
+
+0.9.2
+=====
+
+.. _v0.9.2-bugs:
+
+Bug Fixes
+---------
+
+* Detector reader can handle sequential detectors with very similar
+  names - :issue:`374`.
 
 .. _v0.9.1:
 
@@ -20,7 +32,6 @@ Bug Fixes
 * Sensitivity arrays generated with ``sens opt history 1`` will no longer
   overwrite the primary result arrays - :pull:`366`. These arrays are not 
   currently stored - :issue:`367`
-
 
 .. _v0.9.0:
 


### PR DESCRIPTION
Improved the logic for how the detector reader creates new detectors by examining a list of known detector grids ``("E", "X", "Y", "Z", "T", "COORD", "R", "PHI", "THETA")`` and checking
1) does the new detector start with the currently processed detector and
2) does the new detector name equal the current detector + a grid name.

A test is added that includes some very similarly named detectors with some grids attached to them as well. The file is created before the test using a pytest fixture and removed after the test.

Closes #374