### PR TITLE
DEV Better logging by not breaking downstream logging

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -18,6 +18,8 @@ Bug Fixes
 
 * Detector reader can handle sequential detectors with very similar
   names - :issue:`374`.
+* ``serpentTools`` doesn't make any modifications to the logging state,
+  other than introducing package-wide logger.
 
 .. _v0.9.1:
 

--- a/docs/develop/logging.rst
+++ b/docs/develop/logging.rst
@@ -1,9 +1,43 @@
-.. _dev-logging:
+.. _logging:
 
 .. currentmodule:: serpentTools.messages
 
 Logging and Reporting
 =====================
+
+The primary internal logging is performed with a logger named
+``serpentTools``, that can be obtained using::
+
+    >>> import logging
+    >>> logging.getLogger("serpentTools")
+
+If you want to see the messages produced by this logger, you have a 
+few options. First, the Python logging system must be configured. This
+can be done simply with::
+
+    >>> import logging
+    >>> logging.basicConfig(format="%(levelname)-s: %(message)-s")
+    # Display a basic warning
+    >>> logging.warning("This is a warning")
+    WARNING: This is a warning
+
+To show the internal messages, one can modify the verbosity through the
+:ref:`settings` interface with::
+
+    >>> serpentTools.settings.rc["verbosity"] = "debug"
+
+where ``"debug"`` can be one of ``"debug"``, ``"info"``, ``"warning"``,
+``"error"`` or ``"critical"``.
+
+Alternatively, the level can be adjusting using the python 
+:module:`logging` module::
+
+    >>> logging.getLogger("serpentTools").setLevel(logging.DEBUG)
+
+.. _dev-logging:
+
+Developer Reference
+-------------------
 
 .. note::
 

--- a/serpentTools/messages.py
+++ b/serpentTools/messages.py
@@ -11,7 +11,6 @@ import functools
 import warnings
 import logging
 from logging import Handler
-from logging.config import dictConfig
 from collections.abc import Callable
 
 from numpy import ndarray
@@ -43,33 +42,6 @@ class MismatchedContainersError(SamplerError):
 
 
 LOG_OPTS = ['critical', 'error', 'warning', 'info', 'debug']
-
-loggingConfig = {
-    'version': 1,
-    'formatters': {
-        'brief': {'format': '%(levelname)-8s: %(name)-12s: %(message)s'},
-        'precise': {
-            'format': '%(asctime)s %(name)-12s %(levelname)-8s %(message)s'
-        }
-    },
-    'handlers': {
-        'console': {
-            'class': 'logging.StreamHandler',
-            'formatter': 'brief',
-            'level': logging.DEBUG,
-            'stream': 'ext://sys.stdout'
-        }
-    },
-    'loggers': {
-        'serpentTools': {
-            'handlers': ['console'],
-            'level': logging.WARNING,
-            'propagate': False,
-        },
-    }
-}
-
-dictConfig(loggingConfig)
 
 __logger__ = logging.getLogger('serpentTools')
 
@@ -377,7 +349,7 @@ class DictHandler(Handler):
 
     Attributes
     ----------
-    logMessages: dict
+    logMessages : dict
         Dictionary of lists where each key is a log level such
         as ``'DEBUG'`` or ``'WARNING'``. The list associated
         with each key contains all messages called under that


### PR DESCRIPTION
Summary: The configuration in serpentTools.messages has been removed, leaving only a logger that can be easily found with ``logging.getLogger("serpentTools")``

Our previous approach was to automatically configure the logger when we created it. This had the benefit of people automatically seeing the info, warning messages as they arrive. However, this tends to have really bad down-stream effects if someone is developing with serpentTools. Ideally, the logging level, handles, and general configuration should be up to the end user or the developer. 

As an example, consider this proxy app that creates it's own logger, and then import serpentTools (on master)
```python
import logging
import hydep
logging.basicConfig(format="%(levelname)s:%(name)s:%(message)s", level=logging.INFO)
logger = logging.getLogger("myapp")
logger.info("Before import")
import serpentTools
logger.info("After import")
```
would output
```
INFO:myapp:Before import
```

After this change
```
INFO:myapp:Before import
INFO:myapp:After import
```
Furthermore, with this change, `serpentTools` is way more receptive to other formatting options provided by the end user / developer. I've also added some additional documentation on our logging capabilities. Some reading that inspired this change:
https://docs.python.org/3/howto/logging.html#configuring-logging-for-a-library