### PR TITLE
DEV/API Plot fixes: colorbars, auto-labels, legends, etc.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -24,6 +24,8 @@ Bug Fixes
   names - :issue:`374`.
 * ``serpentTools`` doesn't make any modifications to the logging state,
   other than introducing package-wide logger.
+* Colorbars for mesh plots are placed next to their corresponding
+  plot, rather than near the last drawn plot - :issue:`372`
 
 .. _v0.9.1:
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -278,7 +278,7 @@ Pending Deprecations
 * :pull:`174` - Added parent object ``BaseObject`` with basic comparison
   method from which all objects inherit. Comparison method contains
   upper and lower bounds for values w/o uncertainties, :pull:`191`
-* :pull:`196` - Add comparison methods for |resultReader| and
+* :pull:`196` - Add comparison methods for |ResultsReader| and
   |HomogUniv| objects
 * :pull:`228` - Add comparison methods for |DetectorReader| and
   |Detector| objects
@@ -320,7 +320,7 @@ Deprecations
   files with unique random seeds - :mod:`serpentTools.seed`
 * :pull:`229` - :meth:`serpentTools.SensitivityReader.plot`
   now respects the option to not set x nor y labels.
-* :pull:`231` - |resultReader| objects
+* :pull:`231` - |ResultsReader| objects
   can now read files that do not contain group constant data. The setting
   :ref:`results-expectGcu` should be used to inform the reader that no
   group constant data is anticipated

--- a/serpentTools/detectors.py
+++ b/serpentTools/detectors.py
@@ -576,7 +576,7 @@ class Detector(NamedObject):
 
         if legend is None and labels:
             legend = True
-        ax = formatPlot(ax, loglog=loglog, logx=logx, ncol=ncol,
+        ax = formatPlot(ax, loglog=loglog, logx=logx, legendcols=ncol,
                         xlabel=xlabel or "Energy [MeV]", ylabel=ylabel,
                         legend=legend, title=title)
         return ax
@@ -669,9 +669,9 @@ class Detector(NamedObject):
         if legend is None and labels:
             legend = True
 
-        ax = formatPlot(ax, loglog=loglog, logx=logx, logy=logy, ncol=ncol,
-                        xlabel=xlabel, ylabel=ylabel, legend=legend,
-                        title=title)
+        ax = formatPlot(
+            ax, loglog=loglog, logx=logx, logy=logy, legendcols=ncol,
+            xlabel=xlabel, ylabel=ylabel, legend=legend, title=title)
         return ax
 
     @magicPlotDocDecorator

--- a/serpentTools/detectors.py
+++ b/serpentTools/detectors.py
@@ -1347,7 +1347,7 @@ class HexagonalDetector(Detector):
         pc.set_norm(normalizer)
         ax.add_collection(pc)
 
-        addColorbar(ax, pc, None, cbarLabel)
+        addColorbar(ax, pc, cbarLabel=cbarLabel)
 
         formatPlot(ax, loglog=loglog, logx=logx, logy=logy,
                    xlabel=xlabel or "X [cm]",

--- a/serpentTools/objects/containers.py
+++ b/serpentTools/objects/containers.py
@@ -94,47 +94,47 @@ class HomogUniv(NamedObject):
 
     Parameters
     ----------
-    name: str
+    name : str
         name of the universe
-    bu: float
+    bu : float
         burnup value
-    step: float
+    step : float
         temporal step
-    day: float
+    day : float
         depletion day
 
     Attributes
     ----------
-    name: str
+    name : str
         name of the universe
-    bu: float or int
+    bu : float or int
         non-negative burnup value
-    step: int
+    step : int
         temporal step
-    day: float or int
+    day : float or int
         non-negative depletion day
-    infExp: dict
+    infExp : dict
         Expected values for infinite medium group constants
-    infUnc: dict
+    infUnc : dict
         Relative uncertainties for infinite medium group constants
-    b1Exp: dict
+    b1Exp : dict
         Expected values for leakage corrected group constants
-    b1Unc: dict
+    b1Unc : dict
         Relative uncertainties for leakage-corrected group constants
-    gc: dict
+    gc : dict
         Expected values for group constants that do not fit
         the ``INF_`` nor ``B1_`` pattern
-    gcUnc: dict
+    gcUnc : dict
         Relative uncertainties for group constants that do not fit
         the ``INF_`` nor ``B1_`` pattern
-    reshaped: bool
+    reshaped : bool
         ``True`` if scattering matrices have been reshaped to square
         matrices. Otherwise, these matrices are stored as vectors.
-    groups: None or :class:`numpy.array`
+    groups : None or :class:`numpy.array`
         Group boundaries from highest to lowest
-    numGroups: None or int
+    numGroups : None or int
         Number of energy groups bounded by ``groups``
-    microGroups: None or :class:`numpy.array`
+    microGroups : None or :class:`numpy.array`
         Micro group structure used to produce group constants.
         Listed from lowest to highest
 
@@ -471,7 +471,7 @@ class HomogUniv(NamedObject):
             if logy is None:
                 logy = inferAxScale(ax, 'y')
 
-        formatPlot(ax, logx=logx, logy=logy, ncol=ncol,
+        formatPlot(ax, logx=logx, logy=logy, legendcols=ncol,
                    legend=legend, xlabel=xlabel or "Energy [MeV]",
                    ylabel=ylabel)
         return ax

--- a/serpentTools/objects/materials.py
+++ b/serpentTools/objects/materials.py
@@ -342,7 +342,6 @@ class DepletedMaterial(DepletedMaterialBase):
         {matLabelFmt}
         {ncol}
         {title}
-
         {kwargs} :py:func:`matplotlib.pyplot.plot`
 
         Returns
@@ -351,9 +350,9 @@ class DepletedMaterial(DepletedMaterialBase):
 
         See Also
         --------
-        * :py:func:`~serpentTools.objects.materials.DepletedMaterial.getValues`
-        * :py:func:`matplotlib.pyplot.plot`
-        * :py:meth:`str.format` - used for formatting labels
+        * :func:`~serpentTools.objects.materials.DepletedMaterial.getValues`
+        * :func:`matplotlib.pyplot.plot`
+        * :meth:`str.format` - used for formatting labels
 
         Raises
         ------
@@ -361,6 +360,7 @@ class DepletedMaterial(DepletedMaterialBase):
             If x axis units are not ``'days'`` nor ``'burnup'``
         TypeError
             If both ``names`` and ``zai`` are given
+
         """
         if yUnits is None:
             yUnits = xUnits
@@ -390,8 +390,12 @@ class DepletedMaterial(DepletedMaterialBase):
         for row in range(yVals.shape[0]):
             ax.plot(xVals, yVals[row], label=labels[row], **kwargs)
 
-        ax = formatPlot(ax, loglog=loglog, logx=logx, logy=logy, ncol=ncol,
-                        xlabel=xlabel or DEPLETION_PLOT_LABELS[xUnits],
-                        ylabel=ylabel or DEPLETION_PLOT_LABELS[yUnits],
+        if xlabel is None:
+            xlabel = DEPLETION_PLOT_LABELS[xUnits]
+        if ylabel is None:
+            ylabel = DEPLETION_PLOT_LABELS[yUnits]
+
+        ax = formatPlot(ax, loglog=loglog, logx=logx, logy=logy, legendcols=ncol,
+                        xlabel=xlabel, ylabel=ylabel,
                         title=title, legend=legend)
         return ax

--- a/serpentTools/objects/xsdata.py
+++ b/serpentTools/objects/xsdata.py
@@ -264,9 +264,9 @@ class XSData(NamedObject):
 
         ylabel = ylabel or ('Cross Section ({})'.format('b' if self.isIso
                             else 'cm$^{-1}$'))
-        ax = formatPlot(ax, loglog=loglog, logx=logx, logy=logy, ncol=ncol,
-                        legend=legend, title=title, xlabel=xlabel,
-                        ylabel=ylabel)
+        ax = formatPlot(
+            ax, loglog=loglog, logx=logx, logy=logy, legendcols=ncol,
+            legend=legend, title=title, xlabel=xlabel, ylabel=ylabel)
 
         return ax
 

--- a/serpentTools/parsers/depletion.py
+++ b/serpentTools/parsers/depletion.py
@@ -122,7 +122,7 @@ class DepPlotMixin(object):
         if missing:
             warning("The following materials were not found in materials "
                     "dictionary: {}".format(', '.join(missing)))
-        formatPlot(ax, legend=legend, ncol=ncol, logx=logx, logy=logy,
+        formatPlot(ax, legend=legend, legendcols=ncol, logx=logx, logy=logy,
                    loglog=loglog,
                    xlabel=xlabel or DEPLETION_PLOT_LABELS[xUnits],
                    ylabel=ylabel or DEPLETION_PLOT_LABELS[yUnits],

--- a/serpentTools/parsers/results.py
+++ b/serpentTools/parsers/results.py
@@ -690,7 +690,7 @@ class ResultsReader(XSReader):
         if right is None:
             formatPlot(ax, logx=logx, logy=logy, loglog=loglog,
                        xlabel=xlabel, ylabel=ylabel, legend=legend,
-                       ncol=ncol)
+                       legendcols=ncol)
             return ax
 
         # plot some other quantity on the same x axis
@@ -714,9 +714,10 @@ class ResultsReader(XSReader):
             leftHandles, leftLabels = ax.get_legend_handles_labels()
             rightHandles, rightLabels = other.get_legend_handles_labels()
 
-            placeLegend(ax, legend, ncol,
-                        (leftHandles + rightHandles,
-                         leftLabels + rightLabels))
+            placeLegend(
+                ax, legend,
+                (leftHandles + rightHandles, leftLabels + rightLabels),
+                ncol=ncol)
 
         if len(right) == 1 and rightlabel is None:
             for rightlabel in right.values():

--- a/serpentTools/parsers/sensitivity.py
+++ b/serpentTools/parsers/sensitivity.py
@@ -408,7 +408,7 @@ class SensitivityReader(BaseReader):
             'Sensitivity {} {}'.format(
                 'per unit lethargy' if normalize else '',
                 r'$\pm{}\sigma$'.format(sigma) if sigma else ''))
-        ax = formatPlot(ax, loglog=loglog, logx=logx, logy=logy, ncol=ncol,
+        ax = formatPlot(ax, loglog=loglog, logx=logx, logy=logy, legendcols=ncol,
                         legend=legend, xlabel=xlabel, ylabel=ylabel.strip())
         return ax
 

--- a/serpentTools/utils/docstrings.py
+++ b/serpentTools/utils/docstrings.py
@@ -9,29 +9,38 @@ __all__ = [
     'compareDocReplacer',
 ]
 
-_MPL_AX = ':py:class:`matplotlib.axes.Axes`'
-_LOG_BASE = """log{}: bool\n    Apply a log scale to {}."""
+_MPL_AX = ':class:`matplotlib.axes.Axes`'
+
+_LOG_BASE = """log{} : bool\n    Apply a log scale to {}."""
 LOG_LOG = _LOG_BASE.format('log', 'both axes')
 LOGX = _LOG_BASE.format('x', 'x axis')
 LOGY = _LOG_BASE.format('y', 'y axis')
-TITLE = """title: str\n    Title to apply to the figure."""
-LABELS = """labels: None or iterable
+
+TITLE = """title : str\n    Title to apply to the figure."""
+LABELS = """labels : None or iterable
     Labels to apply to each line drawn. This can be used to identify
     which bin is plotted as what line."""
 
-XLABEL = """xlabel: str or None\n    Label for x-axis."""
-YLABEL = """yabel: str or None\n    Label for y-axis."""
-SIGMA = """sigma: int
+_LABEL_BASE = """{q}label : str or bool, optional
+    Label to apply to the {q}-axis. If given as ``None``,
+    a label will be determined from other arguments.
+    If not ``None`` but evaluates to ``False, do not label."""
+XLABEL = _LABEL_BASE.format(q="x")
+YLABEL = _LABEL_BASE.format(q="y")
+
+SIGMA = """sigma : int
     Confidence interval to apply to errors. If not given or ``0``,
     no errors will be drawn."""
-AX = """ax: {} or None
-    Ax on which to plot the data.""".format(_MPL_AX)
+AX = """ax : {}, optional
+    Ax on which to plot the data. If not provided, create a new
+    plot""".format(_MPL_AX)
 RETURNS_AX = """{}
     Ax on which the data was plotted.""".format(_MPL_AX)
-CMAP = """cmap: str or None
+CMAP = """cmap : str, optional
     Valid Matplotlib colormap to apply to the plot."""
-KWARGS = """kwargs:\n    Addition keyword arguments to pass to"""
-MAT_FMT_DOC = """labelFmt: str or None
+KWARGS = """kwargs : dict, optional
+    Addition keyword arguments to pass to"""
+MAT_FMT_DOC = """labelFmt : str, optional
     Formattable string for labeling the individual plots. If not
     given, just label as isotope name, e.g. ``'U235'``.
     Will make the following substitutions on the ``labelFmt`` string,
@@ -48,8 +57,8 @@ MAT_FMT_DOC = """labelFmt: str or None
     +---------------+-------------------------+
 """
 
-UNIV_FMT_DOC = """labelFmt: str or None
-    formattable string for labeling the individual plots.
+UNIV_FMT_DOC = """labelFmt : str, optional
+    Formattable string for labeling the individual plots.
 
     +---------+----------------------------+
     | String  | Replaced value             |
@@ -66,15 +75,15 @@ UNIV_FMT_DOC = """labelFmt: str or None
     +---------+----------------------------+
 """
 
-LEGEND = """legend: bool or str or None
+LEGEND = """legend : bool or str or None
     Automatically label the plot. No legend will be made if a
     single item is plotted. Pass one of the following values
     to place the legend outside the plot: {}""".format(
     "above, right")
 
-NCOL = """ncol: int\n    Integer number of columns to apply to the legend."""
+NCOL = """ncol : int\n    Integer number of columns to apply to the legend."""
 
-MESH_THRESH = """thresh: float
+MESH_THRESH = """thresh : float
     Do not plot data less than or equal to this value."""
 
 PLOT_MAGIC_STRINGS = {
@@ -86,6 +95,8 @@ PLOT_MAGIC_STRINGS = {
     'univLabelFmt': UNIV_FMT_DOC, 'mthresh': MESH_THRESH,
 }
 """Magic strings that, if found as {x}, will be replaced by the key of x"""
+
+del _LABEL_BASE, _LOG_BASE, _MPL_AX
 
 
 def magicPlotDocDecorator(f):
@@ -107,11 +118,11 @@ def magicPlotDocDecorator(f):
 
 
 COMPARE_DOC_DESC = """
-    desc0: dict or None
-    desc1: dict or None
+    desc0 : dict or None
+    desc1 : dict or None
         Description of the origin of each value set. Only needed
         if ``quiet`` evalues to ``True``."""
-COMPARE_DOC_HERALD = """herald: callable
+COMPARE_DOC_HERALD = """herald : callable
         Function that accepts a single string argument used to
         notify that differences were found. If
         the function is not a callable object, a
@@ -119,21 +130,21 @@ COMPARE_DOC_HERALD = """herald: callable
         will be printed and :func:`serpentTools.messages.error`
         will be used."""
 COMPARE_DOC_LIMITS = """
-    lower: float or int
+    lower : float or int
         Lower limit for relative tolerances in percent
         Differences below this will be considered allowable
-    upper: float or int
+    upper : float or int
         Upper limit for relative tolerances in percent. Differences
         above this will be considered failure and errors
         messages will be raised"""
-COMPARE_DOC_SIGMA = """sigma: int
+COMPARE_DOC_SIGMA = """sigma : int
         Size of confidence interval to apply to
         quantities with uncertainties. Quantities that do not
         have overlapping confidence intervals will fail"""
 COMPARE_DOC_TYPE_ERR = """TypeError
         If ``other`` is not of the same class as this class
         nor a subclass of this class"""
-COMPARE_DOC_HEADER = """header: bool
+COMPARE_DOC_HEADER = """header : bool
         Print/log an ``info`` message about this comparison."""
 COMPARE_DOC_MAPPING = {
     'herald': COMPARE_DOC_HERALD,

--- a/serpentTools/utils/plot.py
+++ b/serpentTools/utils/plot.py
@@ -43,7 +43,7 @@ DEPLETION_PLOT_LABELS = {
     'gsrc': r'Photon emission rate $[\#/s]$',
     'ingTox': 'Ingestion toxicity $[Sv]$',
     'inhTox': 'Inhalation toxicity $[Sv]$',
-    'days': 'Burnup $[d]$',
+    'days': 'Time $[d]$',
     'burnup': 'Burnup $[MWd/kgU]$',
 }
 

--- a/serpentTools/utils/plot.py
+++ b/serpentTools/utils/plot.py
@@ -1,6 +1,7 @@
 """
 Utilties for assisting with plots
 """
+from matplotlib import pyplot
 from matplotlib.axes import Axes
 from matplotlib.colors import Normalize, LogNorm
 
@@ -272,26 +273,31 @@ def _set_ax_lims(ax, vmin, vmax, xory, pad):
     return func(vmin - offset, vmax + offset)
 
 
-def addColorbar(ax, mappable, norm, cbarLabel=None):
+def addColorbar(ax, mappable, norm=None, cbarLabel=None):
     """
     Quick utility to add a colorbar to an axes object
 
+    The color bar is placed adjacent to the provided
+    axes argument, rather than in the provided space.
+
     Parameters
     ----------
-    mappable: iterable
-        Collection of meshes, patches, or values that are used to construct
-        the colorbar.
-    norm: None or :class:`matplotlib.colors.Normalize` subclass
-        Normalizer for this plot
-    cbarLabel: None or str
+    mappable : iterable
+        Collection of meshes, patches, or values that are used to
+        construct the colorbar.
+    norm : :class:`matplotlib.colors.Normalize`, optional
+        Normalizer for this plot. Can be a subclass like
+        :class:`matplotlib.colors.LogNorm`
+    cbarLabel : str, optional
         If given, place this as the y-label for the colorbar
 
     Returns
     -------
     :class:`matplotlib.colorbar.Colorbar`
         The colorbar that was added
+
     """
-    cbar = ax.figure.colorbar(mappable, norm=norm)
-    if cbarLabel is not None:
+    cbar = pyplot.colorbar(mappable, ax=ax, norm=norm)
+    if cbarLabel:
         cbar.ax.set_ylabel(cbarLabel)
     return cbar

--- a/serpentTools/utils/plot.py
+++ b/serpentTools/utils/plot.py
@@ -204,10 +204,11 @@ def normalizerFactory(data, norm, logScale, xticks, yticks):
     if norm is not None:
         if isinstance(norm, Normalize):
             return norm
-        if issubclass(norm.__class__, Normalize):
-            return norm
-        if callable(norm):
+        elif callable(norm):
             return norm(data, xticks, yticks)
+        else:
+            raise TypeError("Normalizer {} not understood".format(norm))
+
     if logScale:
         if (data < 0).any():
             warning("Negative values will be excluded from logarithmic "

--- a/serpentTools/utils/plot.py
+++ b/serpentTools/utils/plot.py
@@ -73,6 +73,7 @@ RESULTS_PLOT_XLABELS = {
     'burnStep': "Burnup step",
 }
 
+
 @magicPlotDocDecorator
 def formatPlot(
     ax,
@@ -178,19 +179,19 @@ def normalizerFactory(data, norm, logScale, xticks, yticks):
 
     Parameters
     ----------
-    data: :class:`numpy.ndarray`
+    data : :class:`numpy.ndarray`
         Data to be plotted and normalized
-    norm: None or callable or :class:`matplotlib.colors.Normalize`
+    norm : None or callable or :class:`matplotlib.colors.Normalize`
         If a ``Normalize`` object, then use this as the normalizer.
         If callable, set the normalizer with
         ``norm(data, xticks, yticks)``. If not None, set the
         normalizer to be based on the min and max of the data
-    logScale: bool
+    logScale : bool
         If this evaluates to true, construct a
         :class:`matplotlib.colors.LogNorm` with the minimum
         set to be the minimum of the positive values.
-    xticks: :class:`numpy.ndarray`
-    yticks: :class:`numpy.ndarray`
+    xticks : :class:`numpy.ndarray`
+    yticks : :class:`numpy.ndarray`
         Arrays ideally corresponding to the data. Used with callable
         `norm` function.
 
@@ -287,13 +288,13 @@ Set the {v} limits on an Axes object
 
 Parameters
 ----------
-ax: :class:`matplotlib.axes.Axes`
+ax : :class:`matplotlib.axes.Axes`
     Ax to be updated
-{v}min: float
+{v}min : float
     Current minimum extent of {v} axis
-{v}max: float
+{v}max : float
     Current maximum extent of {v} axis
-pad: float
+pad : float, optional
     Padding, in percent, to apply to each side of
     the current min and max
 """


### PR DESCRIPTION
A collection of updates here. In order of decreasing impact:

1. When plotting against days, the x axis will be labeled ``"Time [d]"``, changed from ``"Burnup [d]"``. This is a bit easier to understand, as burnup doesn't usually come in days.
2. Colorbars are now attached adjacent to their parent `Axes` object - closes #372 
3. In (hopefully all) cases, passing `xlabel=False` and/or `ylabel=False` will result in the corresponding axis not being labeled.
4. Internal `formatPlot` method now uses `Axes.set` - closes #379 
5. Improved flexibility of both `formatPlot` and `placeLegend` helper functions. Support forwarding keyword arguments directly to `Axes.set` and `Axes.legend`, respectively
6. Docstring improvements in a lot of the automated docstrings