### PR TITLE
REL Release 0.9.2

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -52,7 +52,7 @@ master_doc = 'index'
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 
-version = "0.9.1"
+version = "0.9.2"
 
 # General information about the project.
 project = 'serpentTools'

--- a/serpentTools/__init__.py
+++ b/serpentTools/__init__.py
@@ -7,4 +7,4 @@ from serpentTools.samplers import *
 from serpentTools.seed import *
 from serpentTools.xs import *
 
-__version__ = "0.9.1"
+__version__ = "0.9.2"

--- a/serpentTools/__main__.py
+++ b/serpentTools/__main__.py
@@ -10,8 +10,6 @@ import re
 import argparse
 from os.path import splitext
 
-import six
-
 import serpentTools
 from serpentTools import settings
 from serpentTools.messages import info, error
@@ -21,10 +19,10 @@ from serpentTools.io import MatlabConverter
 _VERB_MAP = {'v': {1: 'info', 2: 'debug'},
              'q': {1: 'error', 2: 'critical'}}
 _VERB_MSG = {}
-for key, items in six.iteritems(_VERB_MAP):
+for key, items in _VERB_MAP.items():
     _VERB_MSG[key] = ', '.join(
         ['{}: {}'.format(key * num, value)
-         for num, value in six.iteritems(items)])
+         for num, value in items.items()])
 
 
 def __buildParser():

--- a/serpentTools/parsers/__init__.py
+++ b/serpentTools/parsers/__init__.py
@@ -3,8 +3,6 @@ Package dedicated for reading ``SERPENT`` output files
 """
 import re
 
-import six
-
 from serpentTools.messages import SerpentToolsException, debug, deprecated
 from serpentTools.parsers.depletion import DepletionReader
 from serpentTools.parsers.branching import BranchingReader
@@ -75,7 +73,7 @@ def inferReader(filePath):
     SerpentToolsException
         If a reader cannot be inferred
     """
-    for reg, reader in six.iteritems(REGEXES):
+    for reg, reader in REGEXES.items():
         match = re.match(reg, filePath)
         if match and match.group() == filePath:
             debug('Inferred reader for {}: {}'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,10 +1,3 @@
-[versioneer]
-VCS = git
-style = pep440
-versionfile_source = serpentTools/_version.py
-versionfile_build = serpentTools/_version.py
-tag_prefix =
-
 [flake8]
 exclude = 
     .tox,

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ with open('./requirements.txt') as req:
 
 pythonRequires = ">=3.5,<3.9"
 
-version = "0.9.1"
+version = "0.9.2"
 
 setupArgs = {
     'name': 'serpentTools',

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -1,13 +1,6 @@
 """
 Test the abstract base class approach upon
 which our objects are built.
-
-Most of this is trivial for a set python build,
-but since we support flavors of 2 and 3,
-we take advantage of :func:`six.add_metaclass`
-to properly create the abstract
-base classes.
-
 """
 
 from unittest import TestCase

--- a/tests/test_parserLevelRead.py
+++ b/tests/test_parserLevelRead.py
@@ -1,8 +1,6 @@
 """Class to test the read commands from serpentTools.parsers"""
 import unittest
 
-import six
-
 from serpentTools.messages import SerpentToolsException
 from serpentTools.parsers import inferReader, read
 
@@ -34,7 +32,7 @@ class TestReaderInfer(unittest.TestCase):
             'test_res.m': ResultsReader, 'test_fmtx99.m': FissionMatrixReader,
             'test_res': None, 'test.coe_dep.m': DepletionReader
         }
-        for fileP, expectedReader in six.iteritems(expectedClasses):
+        for fileP, expectedReader in expectedClasses.items():
             if expectedReader is None:
                 with self.assertRaises(SerpentToolsException):
                     inferReader(fileP)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -3,7 +3,6 @@ from os import remove
 from unittest import TestCase
 
 import yaml
-import six
 from serpentTools import settings
 
 from tests import TestCaseWithLogCapture
@@ -139,7 +138,7 @@ class ConfigLoaderTester(TestCaseWithLogCapture):
             yaml.dump(settings, out)
         with self.rc:
             self.rc.loadYaml(filePath, strict)
-            for key, value in six.iteritems(expected):
+            for key, value in expected.items():
                 if isinstance(value, list):
                     self.assertListEqual(value, self.rc[key])
                 else:


### PR DESCRIPTION
Did a little clean up on the last remnants of `six` and `versioneer`, but I think this is ready for release. Some good bug fixes, enhancements, and documentation fixes. Plus (official) python 3.8 support :tada: 

After this (sometime in the near future) we will need to backport / merge in the changes on to the develop branch. There will likely be some merge issues, but then all those issues will _finally_ be closed for good.