### PR TITLE
API Expose DepletedMaterial data arrays as attributes

### DIFF
--- a/serpentTools/objects/materials.py
+++ b/serpentTools/objects/materials.py
@@ -65,54 +65,115 @@ class DepletedMaterialBase(NamedObject):
     __doc__ = """
     Base class for storing material data from a depleted material file
 
-    {equiv:s}
+    Many of the instance attributes are shortcuts for accessing data
+    in the underlying dictionary. For example, the following command
+    fetch the same data::
+
+        >>> m.data["adens"]
+        >>> m["adens"]
+        >>> m.adens
+
+    With one exception: the attribute-based accessing is guaranteed to
+    not raise an error if the data has not been loaded into the dictionary.
+    This may be the case if a file was read using filtering settings and
+    ``adens`` was not read.
 
     Parameters
     ----------
-    {params:s}
+    name : str
+        Name of this material
+    metadata : dict
+        Dictionary with file metadata
 
     Attributes
     ----------
-    {attrs:s}
+    data : dict
+        Main dictionary of arrays from the output file
+    zai : list of int
+        Isotopic ZZAAAI identifiers like ``922350``. Ordered like
+        the rows of the data arrays
+    names : list of str
+        Isotope names like ``"U235"``. Ordered like the rows of the
+        data arrays
+    days : numpy.ndarray
+        Time in days for each column in the data arrays
+    burnup : numpy.ndarray or None
+        Burnup vector for this specific material
+    volume : numpy.ndarray or None
+        Volume of this material over time
+    adens : numpy.ndarray or None
+        2D array of atom densities in atoms/b-cm
+    mdens : numpy.ndarray or None
+        2D array of mass densites in g/cm3
+    activity : numpy.ndarray or None
+        2D array of activities in Bq
+    decayHeat : numpy.ndarray or None
+        2D array of decay heats in W
+    spontaneousFissionRate : numpy.ndarray or None
+        2D array of spontaneous fission rate in fission per second
+    photonProdRate : numpy.ndarray or None
+        2D array of photon emission rate in photons per second
+    ingTox : numpy.ndarray or None
+        2D array of ingestion toxicity in sieverts
+    inhTox : numpy.ndarray or None
+        2D array of inhalation toxicity in sieverts
 
-    """.format(equiv=docEquiv, params=docParams, attrs=docAttrs)
+    """
 
     def __init__(self, name, metadata):
         NamedObject.__init__(self, name)
         self.data = {}
-        self.__burnup = None
-        self.__mdens = None
-        self.__adens = None
         self.zai = metadata.get('zai', None)
         self.names = metadata.get('names', None)
         self.days = metadata.get('days', None)
 
     def __getitem__(self, item):
-        if item not in self.data:
-            raise KeyError('Key {} not found on material {}'
-                           .format(item, self.name))
+        """Retrieve a value from the data dictionary"""
         return self.data[item]
+
+    def get(self, key, default=None):
+        """Retrive a value from the dictionary, or default if not found"""
+        return self.data.get(key, default)
 
     @property
     def burnup(self):
-        if 'burnup' not in self.data:
-            raise AttributeError('Burnup for material {} has not been loaded'
-                                 .format(self.name))
-        return self.data['burnup']
+        return self.data.get("burnup")
 
     @property
     def adens(self):
-        if 'adens' not in self.data:
-            raise AttributeError('Atomic densities for material {} have not '
-                                 'been loaded'.format(self.name))
-        return self.data['adens']
+        return self.data.get("adens")
 
     @property
     def mdens(self):
-        if 'mdens' not in self.data:
-            raise AttributeError('Mass densities for material {} has not been '
-                                 'loaded'.format(self.name))
-        return self.data['mdens']
+        return self.data.get("mdens")
+
+    @property
+    def volume(self):
+        return self.data.get("volume")
+
+    @property
+    def activity(self):
+        return self.data.get("a")
+
+    @property
+    def ingTox(self):
+        return self.data.get("ingTox")
+
+    @property
+    def inhTox(self):
+        return self.data.get("inhTox")
+
+    @property
+    def decayHeat(self):
+        return self.data.get("h")
+
+    @property
+    def spontaneousFissionRate(self):
+        return self.data.get("sf")
+
+    @property
+    def photonProdRate(self):
+        return self.data.get("gsrc")
 
     def _getIsoID(self, isotopes):
         """Return the row indices that correspond to specfic isotopes."""
@@ -270,7 +331,62 @@ class DepletedMaterialBase(NamedObject):
 
 
 class DepletedMaterial(DepletedMaterialBase):
-    __doc__ = DepletedMaterialBase.__doc__
+    """Base class for storing material data from a depleted material file
+
+    Many of the instance attributes are shortcuts for accessing data
+    in the underlying dictionary. For example, the following command
+    fetch the same data::
+
+        >>> m.data["adens"]
+        >>> m["adens"]
+        >>> m.adens
+
+    With one exception: the attribute-based accessing is guaranteed to
+    not raise an error if the data has not been loaded into the dictionary.
+    This may be the case if a file was read using filtering settings and
+    ``adens`` was not read.
+
+    Parameters
+    ----------
+    name : str
+        Name of this material
+    metadata : dict
+        Dictionary with file metadata
+
+    Attributes
+    ----------
+    data : dict
+        Main dictionary of arrays from the output file
+    zai : list of int
+        Isotopic ZZAAAI identifiers like ``922350``. Ordered like
+        the rows of the data arrays
+    names : list of str
+        Isotope names like ``"U235"``. Ordered like the rows of the
+        data arrays
+    days : numpy.ndarray
+        Time in days for each column in the data arrays
+    burnup : numpy.ndarray or None
+        Burnup vector for this specific material
+    volume : numpy.ndarray or None
+        Volume of this material over time
+    adens : numpy.ndarray or None
+        2D array of atom densities in atoms/b-cm
+    mdens : numpy.ndarray or None
+        2D array of mass densites in g/cm3
+    activity : numpy.ndarray or None
+        2D array of activities in Bq
+    decayHeat : numpy.ndarray or None
+        2D array of decay heats in W
+    spontaneousFissionRate : numpy.ndarray or None
+        2D array of spontaneous fission rate in fission per second
+    photonProdRate : numpy.ndarray or None
+        2D array of photon emission rate in photons per second
+    ingTox : numpy.ndarray or None
+        2D array of ingestion toxicity in sieverts
+    inhTox : numpy.ndarray or None
+        2D array of inhalation toxicity in sieverts
+
+    """
 
     def addData(self, variable, rawData):
         """

--- a/tests/test_depletion.py
+++ b/tests/test_depletion.py
@@ -208,6 +208,35 @@ class DepletedMaterialTester(_DepletionTestHelper):
         assert_equal(self.material.adens, expectedAdens)
         assert_equal(self.material['ingTox'], expectedIngTox)
 
+    def test_attributes(self):
+        """Verify the attribute and dictionary based fetching"""
+        # Populate data that is not contained in reference file
+        # to test the attribute-based fetching
+        material = self.material
+        for key in ["mdens", "inhTox", "a", "sf", "gsrc", "h"]:
+            material.data[key] = material.data["adens"]
+        material.data["volume"] = material.data["burnup"]
+
+        for attr in ["burnup", "adens", "mdens", "volume", "ingTox", "inhTox"]:
+            self.assertIs(self.material.data[attr], self.material[attr])
+            self.assertIs(self.material[attr], getattr(self.material, attr))
+            previous = self.material.data.pop(attr)
+            self.assertIs(getattr(self.material, attr), None)
+            self.material.data[attr] = previous
+
+        for key, attr in [
+                ["a", "activity"],
+                ["h", "decayHeat"],
+                ["sf", "spontaneousFissionRate"],
+                ["sf", "spontaneousFissionRate"],
+        ]:
+            self.assertIs(self.material[key], self.material.data[key])
+            self.assertIs(getattr(self.material, attr), self.material.data[key])
+            previous = self.material.data.pop(key)
+            self.assertIs(getattr(self.material, attr), None)
+            self.material.data[key] = previous
+
+
     def test_getValues_burnup_full(self):
         """ Verify that getValues can produce the full burnup vector."""
         actual = self.material.getValues('days', 'burnup', )


### PR DESCRIPTION
The following attributes map directly to contents of the data dictionary, returning None if not present:
```
activity -> a
adens -> adens
burnup -> burnup
decayHeat -> h
ingTox -> ingTox
inhTox -> inhTox
mdens -> mdens
photonProdRate -> gsrc
spontaneousFissionRate -> sf
volume -> volume
```
This allows the user to perform `m.adens` or `m.photonProdRate` to directly fetch data from the data dictionary. In the future, these might be the preferred way to store / fetch data, but that's to be seen. 

The docstrings have also been improved with these new quantities.