### PR TITLE
API Export depletion data to pandas DataFrame

### DIFF
--- a/serpentTools/objects/materials.py
+++ b/serpentTools/objects/materials.py
@@ -399,3 +399,79 @@ class DepletedMaterial(DepletedMaterialBase):
                         xlabel=xlabel, ylabel=ylabel,
                         title=title, legend=legend)
         return ax
+
+    def toDataFrame(self, quantity, names=None, zai=None, index="days"):
+        """Create a pandas DataFrame for a property of interest
+
+        If ``names`` and ``zai`` are not provided, then the isotope
+        names will be used as the columns.
+
+        Parameters
+        ----------
+        quantity : str
+            Either a key in :attr:`data` or the string name of an attribute
+            like ``photonProdRate`` for :attr:`photonProdRate`
+        names : sequence of str, optional
+            Specific isotope names to obtain. Not compatible with ``zai``
+        zai : sequence of int, optional
+            Specific isotope zai to obtain. Not compatible with ``names``
+        index : {"days", "burnup", "step"}, optional
+            What array to use for the index or rows of the DataFrame.
+            Defaults to using :attr:`days`, but ``"burnup"`` can be passed
+            to use :attr:`burnup`, if it is present. The value of ``"step"``
+            will simply create a basic index that starts at 0 and increments
+            by one per row
+
+        Returns
+        -------
+        pandas.DataFrame
+            2D tabulated representation of the requested array. Columns
+            reflect isotopes, rows represent points in time
+
+        """
+        import pandas
+
+        if quantity in {"burnup", "volume"}:
+            raise ValueError("{} does not reflect 2D isotopic data".format(
+                quantity))
+
+        if names is not None and zai is not None:
+            raise ValueError("Cannot pass both isotope names and zai")
+
+        if index == "days":
+            dfIndex = pandas.Index(self.days, name="Time [d]")
+        elif index == "burnup":
+            bu = self.burnup
+            if bu is None:
+                raise AttributeError(
+                    "Burnup not set on material {}".format(self.name))
+            dfIndex = pandas.Index(bu, name="Burnup [MWd/kgU]")
+        elif index == "step":
+            dfIndex = pandas.Index(range(len(self.days)), name="Step")
+        else:
+            raise ValueError(
+                "Index must be days, burnup, or step, not {}".format(index))
+
+        data = self.data.get(quantity)
+
+        if data is None:
+            data = getattr(self, quantity, None)
+        if data is None:
+            raise AttributeError("Quantity {} not present as key in data "
+                                 "or as attribute".format(quantity))
+
+        if names is None:
+            if zai is None:
+                columns = pandas.Index(self.names, name="Isotope")
+                isoslice = slice(None)
+            else:
+                isoslice = self._getRowIndices("zai", zai)
+                columns = pandas.Index(
+                    [self.zai[x] for x in isoslice], name="Isotope ZAI")
+        else:
+            isoslice = self._getRowIndices("names", names)
+            columns = pandas.Index(
+                [self.names[x] for x in isoslice], name="Isotopes")
+
+        return pandas.DataFrame(
+            data[isoslice].T.copy(), index=dfIndex, columns=columns)

--- a/tests/test_pt_depletion.py
+++ b/tests/test_pt_depletion.py
@@ -1,0 +1,58 @@
+import sys
+import numpy
+import pytest
+import serpentTools
+
+
+@pytest.fixture(scope="module")
+def referenceDepReader():
+    return serpentTools.readDataFile("ref_dep.m")
+
+
+@pytest.fixture(scope="module")
+def referenceMaterial(referenceDepReader):
+    return referenceDepReader.materials["fuel"]
+
+
+@pytest.mark.skipif(sys.version_info < (3, 6), reason="pandas requires 3.6+")
+@pytest.mark.parametrize("quantity", ["adens", "ingTox", "inhTox"])
+def test_toDataFrame(referenceMaterial, quantity):
+    adensFrame = referenceMaterial.toDataFrame(quantity)
+    assert numpy.array_equal(
+        adensFrame.columns.values, referenceMaterial.names
+    )
+    assert numpy.array_equal(adensFrame.index.values, referenceMaterial.days)
+    assert numpy.array_equal(
+        adensFrame.values, referenceMaterial.data[quantity].T
+    )
+
+    reference = referenceMaterial.getValues(
+        "days", quantity, names=["U235", "Xe135", "Pu239"]
+    )
+    frame0 = referenceMaterial.toDataFrame(
+        quantity, names=["U235", "Xe135", "Pu239"], index="burnup"
+    )
+    frame1 = referenceMaterial.toDataFrame(
+        quantity, zai=[922350, 541350, 942390], index="step"
+    )
+
+    assert numpy.array_equal(frame0.values, reference.T)
+    assert numpy.array_equal(frame0.values, frame1.values)
+    assert numpy.array_equal(frame0.index.values, referenceMaterial.burnup)
+    assert numpy.array_equal(frame0.columns.values, ["U235", "Xe135", "Pu239"])
+    assert numpy.array_equal(frame1.columns.values, [922350, 541350, 942390])
+    assert numpy.array_equal(
+        frame1.index.values, range(len(referenceMaterial.days))
+    )
+
+
+@pytest.mark.skipif(sys.version_info < (3, 6), reason="pandas requires 3.6+")
+def test_toDataFrameErrors(referenceMaterial):
+    with pytest.raises(ValueError, match=".*2D"):
+        referenceMaterial.toDataFrame("burnup")
+
+    with pytest.raises(ValueError, match="Cannot pass both"):
+        referenceMaterial.toDataFrame("adens", names=["U235"], zai=[922350])
+
+    with pytest.raises(AttributeError, match=".*bad"):
+        referenceMaterial.toDataFrame("bad")


### PR DESCRIPTION
This PR introduces `DepletedMaterial.toDataFrame` that can produce a nice data frame of quantities stored on the instance. The columns are isotope names or ZAI identifiers, while the rows are index by time. Users can request specific isotopes by name or by ZAI, not both. Additionally, the index of the data frame can be set to points in time, burnup, or burnup step.

I've added a pytest-exclusive test file for this method as well. 