### PR TITLE
API Add better acess methods for results, detector, depletion

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -183,6 +183,8 @@ autosummary_generate = True
 
 autodoc_default_options = {
     'members': True,
+    'special-members': True,
+    'exclude-members': '__init__',
 }
 
 # -- Links to external documentation

--- a/serpentTools/parsers/depletion.py
+++ b/serpentTools/parsers/depletion.py
@@ -107,14 +107,14 @@ class DepPlotMixin(object):
                            "<burnup>, not {}".format(xUnits))
         missing = set()
         ax = ax or pyplot.gca()
-        materials = materials or self.materials.keys()
+        materials = materials or sorted(self)
         labelFmt = labelFmt or '{mat} {iso}'
         for mat in materials:
-            if mat not in self.materials:
+            if mat not in self:
                 missing.add(mat)
                 continue
 
-            ax = self.materials[mat].plot(
+            ax = self[mat].plot(
                 xUnits, yUnits, timePoints, names,
                 zai, ax, legend=False, xlabel=xlabel, ylabel=ylabel,
                 logx=False, logy=False, loglog=False, labelFmt=labelFmt,
@@ -167,6 +167,49 @@ class DepletionReader(DepPlotMixin, MaterialReader):
         """Retrieve a material from :attr:`materials`."""
         return self.materials[name]
 
+    def __len__(self):
+        return len(self.materials)
+
+    def __contains__(self, name):
+        """Check if a material is stored"""
+        return name in self.materials
+
+    def __iter__(self):
+        """Iterate over material names"""
+        return iter(self.materials)
+
+    def keys(self):
+        """Key-view into material dictionary"""
+        return self.materials.keys()
+
+    def values(self):
+        """Values-view into material dictionary"""
+        return self.materials.values()
+
+    def items(self):
+        """Iterate over name, material pairs"""
+        return self.materials.items()
+
+    def get(self, key, default=None):
+        """Retrieve a material from the dictionary if it exists
+
+        Parameters
+        ----------
+        key : str
+            Name of a material that may or may not exist in
+            :attr:`materials`
+        default : optional
+            Item to return if ``key`` isn't found
+
+        Returns
+        -------
+        object
+            A :class:`serpentTools.objects.DepletedMaterial` if
+            it is stored under ``key``. Otherwise return ``default``
+
+        """
+        return self.materials.get(key, default)
+
     def _read(self):
         """Read through the depletion file and store requested data."""
         keys = ['MAT', 'TOT'] if self.settings['processTotal'] else ['MAT']
@@ -181,7 +224,7 @@ class DepletionReader(DepPlotMixin, MaterialReader):
                     continue
                 self._addMetadata(chunk)
         if 'days' in self.metadata:
-            for mKey in self.materials:
+            for mKey in self:
                 self.materials[mKey].days = self.metadata['days']
 
     def _addMetadata(self, chunk):
@@ -219,7 +262,7 @@ class DepletionReader(DepPlotMixin, MaterialReader):
         if (self.settings['materialVariables']
                 and variable not in self.settings['materialVariables']):
             return
-        if name not in self.materials:
+        if name not in self:
             debug('Adding material {}...'.format(name))
             self.materials[name] = DepletedMaterial(name, self.metadata)
         if len(chunk) == 1:  # single line values, e.g. volume or burnup
@@ -249,12 +292,12 @@ class DepletionReader(DepPlotMixin, MaterialReader):
             error("No materials obtained from {}".format(self.filePath))
             return
 
-        for mKey, mat in self.materials.items():
+        for mKey, mat in self.items():
             assert isinstance(mat, DepletedMaterial), (
                 'Unexpected key {}: {} in materials dictionary'.format(
                     mKey, type(mat))
             )
-        debug('  found {} materials'.format(len(self.materials)))
+        debug('  found {} materials'.format(len(self)))
 
         if 'bu' in self.metadata:
             self.metadata['burnup'] = self.metadata.pop('bu')
@@ -311,7 +354,7 @@ class DepletionReader(DepPlotMixin, MaterialReader):
         commonMats = getKeyMatchingShapes(
             self.materials, other.materials, 'materials')
         similar = (
-            len(self.materials) == len(other.materials) == len(commonMats))
+            len(self) == len(other) == len(commonMats))
 
         for matName in sorted(commonMats):
             myMat = self[matName]
@@ -405,12 +448,13 @@ class DepletionReader(DepPlotMixin, MaterialReader):
 
         Raises
         ------
-        ImportError:
+        ImportError
             If :term:`scipy` is not installed
 
         See Also
         --------
         :func:`scipy.io.savemat`
+
         """
         if metadata is not None:
             warn("metadata argument is deprecated. All metadata written",
@@ -439,7 +483,7 @@ class DepletionReader(DepPlotMixin, MaterialReader):
         data = {k.upper() if reconvert else k: v
                 for k, v in self.metadata.items()}
 
-        for matName, material in self.materials.items():
+        for matName, material in self.items():
             for varName, varData in material.data.items():
                 data[converter(matName, varName)] = varData
 

--- a/serpentTools/parsers/detector.py
+++ b/serpentTools/parsers/detector.py
@@ -11,8 +11,6 @@ from serpentTools.parsers.base import BaseReader
 from serpentTools.messages import SerpentToolsException
 
 
-# After py2 removal, subclass this from collections.abc.Mapping
-# Gain full dictionary-like behavior by defining a few methods
 class DetectorReader(BaseReader):
     """
     Parser responsible for reading and working with detector files.
@@ -45,10 +43,36 @@ class DetectorReader(BaseReader):
         return len(self.detectors)
 
     def __contains__(self, key):
+        """Check if a detector ``key`` is stored"""
         return key in self.detectors
 
     def __iter__(self):
+        """Iterate over detector names"""
         return iter(self.detectors)
+
+    def items(self):
+        """Iterate over key, detector pairs"""
+        return self.detectors.items()
+
+    def get(self, key, default=None):
+        """Retrieve a detector from the dictionary if it exists
+
+        Parameters
+        ----------
+        key : str
+            Name of a detector that may or may not exist in
+            :attr:`detectors`
+        default : optional
+            Item to return if ``key`` isn't found
+
+        Returns
+        -------
+        object
+            A :class:`serpentTools.Detector` if
+            it is stored under ``key``. Otherwise return ``default``
+
+        """
+        return self.detectors.get(key, default)
 
     def iterDets(self):
         """Yield name, detector pairs by iterating over :attr:`detectors`."""
@@ -113,14 +137,13 @@ class DetectorReader(BaseReader):
 
     def _compare(self, other, lower, upper, sigma):
         """Compare two detector readers."""
-        similar = len(self.detectors) == len(other.detectors)
+        similar = len(self) == len(other)
 
         commonKeys = getKeyMatchingShapes(self.detectors, other.detectors,
                                           'detectors')
-        similar &= len(commonKeys) == len(self.detectors)
+        similar &= len(commonKeys) == len(self)
 
-        for detName in sorted(commonKeys):
-            myDetector = self[detName]
+        for detName, myDetector in self.items():
             otherDetector = other[detName]
             similar &= myDetector.compare(otherDetector, lower, upper, sigma)
         return similar
@@ -129,7 +152,7 @@ class DetectorReader(BaseReader):
         """Collect data from all detectors for exporting to matlab"""
         data = {}
 
-        for det in self.detectors.values():
+        for det in self.values():
             data.update(det._gather_matlab(reconvert))
 
         return data

--- a/serpentTools/parsers/detector.py
+++ b/serpentTools/parsers/detector.py
@@ -8,7 +8,7 @@ from serpentTools.utils.compare import getKeyMatchingShapes
 from serpentTools.engines import KeywordParser
 from serpentTools.detectors import detectorFactory
 from serpentTools.parsers.base import BaseReader
-from serpentTools.messages import SerpentToolsException
+from serpentTools.messages import SerpentToolsException, deprecated
 
 
 class DetectorReader(BaseReader):
@@ -74,8 +74,13 @@ class DetectorReader(BaseReader):
         """
         return self.detectors.get(key, default)
 
+    @deprecated("items")
     def iterDets(self):
-        """Yield name, detector pairs by iterating over :attr:`detectors`."""
+        """Yield name, detector pairs by iterating over :attr:`detectors`.
+
+        .. deprecated:: 0.9.3
+            Use :meth:`items`
+        """
         for key, det in self.detectors.items():
             yield key, det
 

--- a/serpentTools/parsers/results.py
+++ b/serpentTools/parsers/results.py
@@ -395,18 +395,19 @@ class ResultsReader(XSReader):
 
         Returns
         -------
-        :class:`~serpentTools.objects.HomogUniv`
+        serpentTools.objects.HomogUniv
             Requested universe
 
         Raises
         ------
-        KeyError:
+        KeyError
             If the requested universe could not be found
-        :class:`~serpentTools.SerpentToolsException`
+        ValueError
             If burnup, days and index are not given
+
         """
         if index is None and burnup is None and timeDays is None:
-            raise SerpentToolsException(
+            raise ValueError(
                 'Burnup, time or index are required inputs')
 
         searchKey = UnivTuple(univ, burnup, index, timeDays)

--- a/serpentTools/parsers/results.py
+++ b/serpentTools/parsers/results.py
@@ -208,6 +208,31 @@ class ResultsReader(XSReader):
         self.resdata = {}
         self.universes = {}
 
+    def __getitem__(self, key):
+        """Retrieve an item from :attr:`resdata` only
+
+        Universes data like group constants should be pulled
+        from universes directly with :meth:`getUniv`
+
+        Parameters
+        ----------
+        key : str
+            ``mixedCase`` variable name like ``"absKeff"`` that may
+            exist in :attr:`resdata`
+
+        Returns
+        -------
+        numpy.ndarray
+            Requested quantity
+
+        Raises
+        ------
+        KeyError
+            If ``key`` does not exist in :attr:`resdata`
+
+        """
+        return self.resdata[key]
+
     def _read(self):
         """Read through the results file and store requested data."""
 
@@ -468,6 +493,26 @@ class ResultsReader(XSReader):
         self._cleanMetadata()
         del (self._varTypeLookup, self._burnupKeys, self._keysVersion,
              self._counter, self._univlist)
+
+    def get(self, key, default=None):
+        """Retrieve an item from :attr:`resdata` or ``default``
+
+        Parameters
+        ----------
+        key : str
+            ``mixedCase`` variable name that may or may not
+            exist in :attr:`resdata`
+        default : optional
+            Object to be returned in ``key`` is not found
+
+        Returns
+        -------
+        object
+            :class:`numpy.ndarray` if ``key`` is found. Otherwise
+            ``default`` is returned
+
+        """
+        return self.resdata.get(key, default)
 
     def _compare(self, other, lower, upper, sigma):
         similar = self.compareMetadata(other)

--- a/serpentTools/samplers/detector.py
+++ b/serpentTools/samplers/detector.py
@@ -81,7 +81,7 @@ class DetectorSampler(Sampler):
     def _process(self):
         individualDetectors = defaultdict(list)
         for parser in self:
-            for detName, detector in parser.iterDets():
+            for detName, detector in parser.items():
                 individualDetectors[detName].append(detector)
         for name, detList in individualDetectors.items():
             self.detectors[name] = SampledDetector.fromDetectors(

--- a/tests/test_ResultsReader.py
+++ b/tests/test_ResultsReader.py
@@ -209,6 +209,15 @@ class TesterCommonResultsReader(TestCase):
         self.assertSetEqual(expectedKeys, actualKeys)
         assert_array_equal(self.reader.resdata['absKeff'], self.expectedKeff)
 
+        for key, value in self.reader.resdata.items():
+            assert self.reader[key] is value
+            assert self.reader.get(key) is value
+
+        with self.assertRaises(KeyError):
+            self.reader["invalid key"]
+
+        self.assertIs(self.reader.get("invalid key"), None)
+
     def test_burnup(self):
         """Verify the burnup vector is properly stored."""
         actualBurnDays = self.reader.resdata.get('burnDays', None)

--- a/tests/test_ResultsReader.py
+++ b/tests/test_ResultsReader.py
@@ -140,7 +140,7 @@ class TestGetUniv(TestCase):
 
     def test_allVarsNone(self):
         """Verify that the reader raises error when no time parameters are given""" # noqa
-        with self.assertRaises(SerpentToolsException):
+        with self.assertRaises(ValueError):
             self.reader.getUniv('0', burnup=None, index=None, timeDays=None)
 
     def test_noUnivState(self):

--- a/tests/test_depletion.py
+++ b/tests/test_depletion.py
@@ -111,11 +111,26 @@ class DepletionTester(_DepletionTestHelper):
 
     def test_getitem(self):
         """Verify the getitem approach to obtaining materials."""
+        self.assertEqual(len(self.reader), len(self.reader.materials))
+
         with self.assertRaises(KeyError):
             self.reader['this should not work']
-        for name, mat in self.reader.materials.items():
-            fromGetItem = self.reader[name]
-            self.assertIs(mat, fromGetItem, msg=mat)
+
+        self.assertIs(self.reader.get("this should not work"), None)
+
+        for name, mat in self.reader.items():
+            self.assertIn(name, self.reader.materials)
+            self.assertIn(name, self.reader)
+            self.assertIs(mat, self.reader[name], msg=mat)
+            self.assertIs(self.reader.get(name), mat)
+
+        for count, name in enumerate(self.reader, start=1):
+            self.assertIn(name, self.reader)
+
+        for count, name in enumerate(self.reader.keys(), start=1):
+            self.assertIn(name, self.reader)
+
+        self.assertEqual(count, len(self.reader.materials))
 
     @plotTest
     def test_plotFewIso(self):

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -25,8 +25,8 @@ class DetectorHelper(TestCase):
 
     def test_loadedDetectors(self):
         """Verify that all anticipated detectors are loaded."""
-        expectedNames = set(self.EXPECTED_DETECTORS.keys())
-        actualNames = set(self.reader.detectors.keys())
+        expectedNames = set(self.EXPECTED_DETECTORS)
+        actualNames = set(self.reader)
         self.assertSetEqual(
             expectedNames, actualNames,
             msg="Failure reading detectors from {}".format(self.FILE_PATH))

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -70,18 +70,16 @@ class DetectorHelper(TestCase):
 
     def test_iterDets(self):
         """Verify the iterDets method is functional."""
-        for name, det in self.reader.iterDets():
+        for name, det in self.reader.items():
             self.assertIn(name, self.reader.detectors, msg=name)
-            self.assertIs(det, self.reader.detectors[name], msg=name)
+            self.assertIn(name, self.reader, msg=name)
+            self.assertIs(self.reader.detectors[name], det, msg=name)
+            self.assertIs(self.reader[name], det, msg=name)
+            self.assertIs(self.reader.get(name), det, msg=name)
 
-    def test_getitem(self):
-        """Verify the getitem method for extracting detectors."""
-        for name, det in self.reader.detectors.items():
-            fromGetItem = self.reader[name]
-            self.assertIs(fromGetItem, det, msg=name)
         with self.assertRaises(KeyError):
-            self.reader['this should fail']
-
+            self.reader["this should fail"]
+        self.assertIs(self.reader.get("this should not fail"), None)
 
 class CartesianDetectorTester(DetectorHelper):
     """


### PR DESCRIPTION
The goal is to provide easier access into a lot of our data dictionaries and save users precious characters. This PR is fully backwards compatible :100: 

`ResultsReader` has new ``get`` and ``__getitem__`` methods that pull keys directly from the ``resdata`` dictionary. This allow users to do something like
```python
>>> r = serpentTools.read(resfile)
>>> r["absKeff"] is r.resdata["absKeff"]
True
>>> r.get("absKeff") is r.resdata("absKeff")
True
```
I chose to not add a look into the metadata because I felt like fetching information from the result section was the most common practice. And we have a special place for group constant data as well. No special iteration methods nor containment were added because we do store more and that could get confusing.

`DepletionReader` and `DetectorReader` can now be treated __mostly__ like a dictionary mapping strings to material or detector instances. They both now have `__iter__`, `get`, `__contains__`, `__len__`, `get`, `values`, `keys`, and `items` methods. This allows
```python
>>> detR = serpentTools.read(detfile)
>>> for name, det in detR.items():
...    assert det is detR.detectors[name]
...    assert name in detR
...    assert det is detR[name]
...    assert det is detR.get(name)
```
Similarly for the `DepletionReader`.

I have also marked the `DetectorReader.iterDets` method as deprecated as `items` handles the paired key-value iteration. This was a clutch to handle python 2/3 and should have been removed a while ago.