### PR TITLE
API/DEP Deprecate Depletion metadata for new attributes

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,10 +6,26 @@
 Changelog
 =========
 
+.. _v0.9.3:
+
+0.9.3
+=====
+
+
+.. _v0.9.3-dep:
+
+Pending Deprecations
+--------------------
+
+* :attr:`serpentTools.DepletionReader.metadata`. Prefer attributes
+  like :attr:`~serpentTools.DepletionReader.zais`
+* :attr:`serpentTools.samplers.DepletionSampler.metadata`. Prefer
+  attributes like :attr:`~serpentTools.samplers.DepletionSampler.zais`
+
 .. _v0.9.2:
 
-0.9.2
-=====
+:release-tag:`0.9.2`
+====================
 
 * Officially support installing under Python 3.8
 * Support for passing threshold values to hexagonal detector plots

--- a/serpentTools/parsers/base.py
+++ b/serpentTools/parsers/base.py
@@ -29,7 +29,6 @@ class BaseReader(ABC, BaseObject):
 
     def __init__(self, filePath, readerSettingsLevel):
         self.filePath = filePath
-        self.metadata = {}
         if isinstance(readerSettingsLevel, str):
             self.settings = rc.getReaderSettings(readerSettingsLevel)
         else:

--- a/serpentTools/parsers/base.py
+++ b/serpentTools/parsers/base.py
@@ -80,7 +80,7 @@ class MaterialReader(BaseReader):
     """Parent class for files that store materials."""
 
     def __init__(self, filePath, readerSettingsLevel):
-        BaseReader.__init__(self, filePath, readerSettingsLevel)
+        super().__init__(filePath, readerSettingsLevel)
         self.materials = {}
 
 
@@ -88,7 +88,7 @@ class XSReader(BaseReader):
     """Parent class for the branching and results reader"""
 
     def __init__(self, filePath, readerSettingsLevel):
-        BaseReader.__init__(self, filePath, ['xs', readerSettingsLevel])
+        super().__init__(filePath, ['xs', readerSettingsLevel])
         self.settings['variables'] = rc.expandVariables()
         self.settings.pop('variableGroups')
         self.settings.pop('variableExtras')

--- a/serpentTools/parsers/depletion.py
+++ b/serpentTools/parsers/depletion.py
@@ -160,6 +160,8 @@ class DepletionReader(DepPlotMixin, MaterialReader):
         ZZAAAI identifiers for isotopes
     metadata : dict of str to list
         Dictionary with zai and names
+
+        .. deprecated:: 0.9.3
     materials : dict of str to serpentTools.objects.Material
         Materials from the file. Keys will be the names as they appear
         in the file

--- a/serpentTools/parsers/results.py
+++ b/serpentTools/parsers/results.py
@@ -202,8 +202,7 @@ class ResultsReader(XSReader):
     """Metadata keys that will not be compared."""
 
     def __init__(self, filePath):
-        XSReader.__init__(self, filePath, 'results')
-
+        super().__init__(filePath, 'results')
         self.metadata = {}
         self.resdata = {}
         self.universes = {}

--- a/serpentTools/samplers/depletion.py
+++ b/serpentTools/samplers/depletion.py
@@ -56,6 +56,9 @@ class DepletionSampler(DepPlotMixin, Sampler):
     metadata: dict
         Dictionary with file-wide data names as keys and the
         corresponding data, e.g. ``'zai'``: [list of zai numbers]
+
+        .. deprecated:: 0.9.3
+            Use attributes like :attr:`days` directly
     metadataUncs: dict
         Dictionary containing uncertainties in day and burnup
         vectors

--- a/tests/compare/test_depletion.py
+++ b/tests/compare/test_depletion.py
@@ -83,12 +83,9 @@ class DepletionReaderComparisonTester(DepletionCompareHelper):
         """
         Verify the comparison fails early for dissimilar metadata shapes.
         """
-        newVecKey = 'badMetadataKey'
-        self.refReader.metadata[newVecKey] = [0, 1, 2, 3]
-        self.otherReader.metadata[newVecKey] = [0, 1, 2]
+        self.otherReader.names = self.refReader.names[1:]
         self.assertFalse(self.compare(100, 100, 100))
-        self.assertMsgInLogs('ERROR', newVecKey, partial=True)
-        self.refReader.metadata.pop(newVecKey)
+        self.assertMsgInLogs('ERROR', "names", partial=True)
 
     def test_diffMaterialDicts(self):
         """Verify the test fails if different materials are stored."""

--- a/tests/test_depletion.py
+++ b/tests/test_depletion.py
@@ -84,25 +84,28 @@ class DepletionTester(_DepletionTestHelper):
 
     def test_metadata(self):
         """Test the metadata storage for the reader."""
-        expectedMetadata = {
-            'zai':
-                [621490, 541350, 922350, 942390, 50100, 666, 0],
-            'names':
-                ['Sm149', 'Xe135', 'U235', 'Pu239', 'B10', 'lost', 'total'],
-            'burnup': [0.00000E+00, 1.93360E-02, 3.86721E-02, 1.16016E-01,
-                       1.93360E-01, 2.90041E-01, 3.86721E-01, 6.76762E-01,
-                       9.66802E-01, 1.45020E+00, 1.93360E+00, 2.90041E+00,
-                       3.86721E+00, 4.83401E+00],
-            'days': [0.00000E+00, 5.00000E-01, 1.00000E+00, 3.00000E+00,
-                     5.00000E+00, 7.50000E+00, 1.00000E+01, 1.75000E+01,
-                     2.50000E+01, 3.75000E+01, 5.00000E+01, 7.50000E+01,
-                     1.00000E+02, 1.25000E+02]
-        }
-        expectedKeys = set(expectedMetadata)
-        actualKeys = set(self.reader.metadata.keys())
-        self.assertSetEqual(expectedKeys, actualKeys)
-        for key, expectedValue in expectedMetadata.items():
-            assert_equal(self.reader.metadata[key], expectedValue)
+        self.assertListEqual(
+            self.reader.zais,
+            [621490, 541350, 922350, 942390, 50100, 666, 0],
+        )
+        self.assertListEqual(
+            self.reader.names,
+            ['Sm149', 'Xe135', 'U235', 'Pu239', 'B10', 'lost', 'total'],
+        )
+        assert_equal(
+            self.reader.burnup,
+            [0.00000E+00, 1.93360E-02, 3.86721E-02, 1.16016E-01,
+             1.93360E-01, 2.90041E-01, 3.86721E-01, 6.76762E-01,
+             9.66802E-01, 1.45020E+00, 1.93360E+00, 2.90041E+00,
+             3.86721E+00, 4.83401E+00],
+        )
+        assert_equal(
+            self.reader.days,
+            [0.00000E+00, 5.00000E-01, 1.00000E+00, 3.00000E+00,
+             5.00000E+00, 7.50000E+00, 1.00000E+01, 1.75000E+01,
+             2.50000E+01, 3.75000E+01, 5.00000E+01, 7.50000E+01,
+             1.00000E+02, 1.25000E+02],
+        )
 
     def test_ReadMaterials(self):
         """Verify the reader stored the correct materials."""
@@ -203,8 +206,7 @@ class DepletedMaterialTester(_DepletionTestHelper):
              1.49595E+09, 1.66322E+09, 1.80206E+09, 1.79453E+09, 1.79100E+09,
              1.80188E+09, 1.75346E+09, 1.60021E+09, 1.89771E+09],
         ])
-        self.assertListEqual(self.material.zai,
-                             self.reader.metadata['zai'])
+        self.assertListEqual(self.material.zai, self.reader.zais)
         assert_equal(self.material.adens, expectedAdens)
         assert_equal(self.material['ingTox'], expectedIngTox)
 
@@ -362,10 +364,32 @@ class DepMatlabExportHelper(MatlabTesterHelper):
                     err_msg="{} {}".format(materialName, variableName))
 
     def checkMetadata(self, loaded):
-        for key, data in self.reader.metadata.items():
-            expected = key.upper() if self.RECONVERT else key
-            assert expected in loaded, (
-                "Missing {} from metadata".format(expected))
+        if self.RECONVERT:
+            zais = loaded["ZAI"]
+            names = loaded["NAMES"]
+            days = loaded["DAYS"]
+            burnup = loaded["BURNUP"]
+        else:
+            zais = loaded["zai"]
+            names = loaded["names"]
+            days = loaded["days"]
+            burnup = loaded["burnup"]
+
+        # String array has extra spacing around shorter words
+        # so names like "Xe135" are fine, but we also get "lost "
+        # with a space
+        self.assertListEqual([x.strip() for x in names], self.reader.names)
+
+        # Numeric arraysrrays are written as 1xN matrices
+        # Can't do a straight comparison first
+        for actual, attr in [
+            [zais, "zais"],
+            [days, "days"],
+            [burnup, "burnup"],
+        ]:
+            expected = getattr(self.reader, attr)
+            self.assertEqual(actual.shape, (1, len(expected)), msg=attr)
+            assert_equal(actual[0], expected, err_msg=attr)
 
     def constructExpectedVarName(self, material, variable):
         """


### PR DESCRIPTION
The `metadata` dictionaries on `DepletionReader` and `DepletionSampler`  have been deprecated in favor of new attributes. These are more explicit and easier to access. The following example code serves to demonstrate the changes:
```python
>>> dep = serpentTools.read(depfile)
>>> dep.names is dep.metadata["names"]
True
>>> dep.zais is dep.metadata["zais"]
True
>>> dep.days is dep.metadata["days"]
True
>>> dep.burnup is dep.metadata["burnup"]
True
```

The metadata dictionary is never stored on the object, but is a property, generated at each call. Therefore any additions will not be permanent. However, the new attribute-based is a much better approach in my opinion. 

These data are still share with the depleted materials created during the read. This was done to keep this a back-compatible change if anyone is creating materials on their own.

There is one potential sticking point I would be happy to discuss. The reader has a `zais` attribute, while the materials have a `zai` attribute with the same data. I made the change to `zais` because these are really plural ZAI identifier**S** for each isotope, rather than a single isotope. I'm not sure how we want to reconcile the difference which would understandably be confusing. Changing `zai` :arrow_right: `zais` on the material objects would be a breaking change that I don't want to introduce in the next minor release. I support that change for 0.10.0 though.

Tests have been updated, separate of the API changes to make sure this was back-compatible. When introducing the properties in e896569 and a4c358b, the only change to the testing was one comparison test that added a key to the metadata dictionary. Since this is no longer permanent, the test is modified to compare directly against attributes.