### PR TITLE
API/DOC Rename index -> time in depletion toDataFrame; update docs

### DIFF
--- a/docs/examples/DepletionReader.rst
+++ b/docs/examples/DepletionReader.rst
@@ -259,6 +259,38 @@ with ``bglass`` followed by at least one integer.
     >>> bglass.data.keys()
     dict_keys(['adens'])
 
+Integration with ``pandas``
+---------------------------
+
+If you have the :mod:`pandas` package installed, you can use
+the :meth:`~serpentTools.objects.DepletedMaterial.toDataFrame` method
+to create tabulated data. The method will retrieve data for all isotopes
+unless the ``names`` or ``zai`` arguments are provided. For compactness,
+only a few isotopes will be retrieved here.
+
+.. code::
+
+    >>> fuel.toDataFrame("adens", names=["U235", "Pu239", "Xe135"]).head()
+    Isotopes U235 Pu239 Xe135
+    Time [d]      
+    0.0 0.000558 0.000000e+00 0.000000e+00
+    0.5 0.000558 6.374580e-09 2.435910e-09
+    1.0 0.000558 2.590310e-08 4.037960e-09
+    1.5 0.000558 5.728820e-08 4.620920e-09
+    2.0 0.000557 9.927160e-08 4.789480e-09
+
+Arguments can also be used to control the time values in the index and
+column structure::
+
+    >>> fuel.toDataFrame("adens", zai=[922350, 942390, 541350], time="burnup")
+    Isotope ZAI 922350 942390 541350
+    Burnup [MWd/kgU]
+    0.0 0.000558 0.000000e+00 0.000000e+00
+    0.5 0.000558 6.374580e-09 2.435910e-09
+    1.0 0.000558 2.590310e-08 4.037960e-09
+    1.5 0.000558 5.728820e-08 4.620920e-09
+    2.0 0.000557 9.927160e-08 4.789480e-09
+
 Conclusion
 ----------
 

--- a/examples/DepletionReader.ipynb
+++ b/examples/DepletionReader.ipynb
@@ -68,9 +68,9 @@
     {
      "data": {
       "text/plain": [
-       "{'fuel0': <serpentTools.objects.materials.DepletedMaterial at 0x7f400fcace80>,\n",
-       " 'bglass0': <serpentTools.objects.materials.DepletedMaterial at 0x7f400fcacdf0>,\n",
-       " 'total': <serpentTools.objects.materials.DepletedMaterial at 0x7f400fcacee0>}"
+       "{'fuel0': <serpentTools.objects.materials.DepletedMaterial at 0x7fc7b5265430>,\n",
+       " 'bglass0': <serpentTools.objects.materials.DepletedMaterial at 0x7fc7c47dbc70>,\n",
+       " 'total': <serpentTools.objects.materials.DepletedMaterial at 0x7fc7c47db5b0>}"
       ]
      },
      "execution_count": 3,
@@ -518,6 +518,196 @@
    "source": [
     "bglass = bgReader.materials['bglass0']\n",
     "bglass.data.keys()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Integration with ``pandas.DataFrame``\n",
+    "If you have the [`pandas`](https://pandas.pydata.org/) python package installed, you can use the `DepletedMaterial.toDataFrame` method to export depletion data to a tabular layout. The method will retrieve data for all isotopes unless ``names`` or ``zai`` are given. For compactness, only a few isotopes will be demonstrated here."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th>Isotopes</th>\n",
+       "      <th>U235</th>\n",
+       "      <th>Pu239</th>\n",
+       "      <th>Xe135</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Time [d]</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0.0</th>\n",
+       "      <td>0.000558</td>\n",
+       "      <td>0.000000e+00</td>\n",
+       "      <td>0.000000e+00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>0.5</th>\n",
+       "      <td>0.000558</td>\n",
+       "      <td>6.374580e-09</td>\n",
+       "      <td>2.435910e-09</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1.0</th>\n",
+       "      <td>0.000558</td>\n",
+       "      <td>2.590310e-08</td>\n",
+       "      <td>4.037960e-09</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1.5</th>\n",
+       "      <td>0.000558</td>\n",
+       "      <td>5.728820e-08</td>\n",
+       "      <td>4.620920e-09</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2.0</th>\n",
+       "      <td>0.000557</td>\n",
+       "      <td>9.927160e-08</td>\n",
+       "      <td>4.789480e-09</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "Isotopes      U235         Pu239         Xe135\n",
+       "Time [d]                                      \n",
+       "0.0       0.000558  0.000000e+00  0.000000e+00\n",
+       "0.5       0.000558  6.374580e-09  2.435910e-09\n",
+       "1.0       0.000558  2.590310e-08  4.037960e-09\n",
+       "1.5       0.000558  5.728820e-08  4.620920e-09\n",
+       "2.0       0.000557  9.927160e-08  4.789480e-09"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "fuel.toDataFrame(\"adens\", names=[\"U235\", \"Pu239\", \"Xe135\"]).head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Arguments can be used to control the time values in the index and column structure"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th>Isotope ZAI</th>\n",
+       "      <th>922350</th>\n",
+       "      <th>541350</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Burnup [MWd/kgU]</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0.000000</th>\n",
+       "      <td>0.000558</td>\n",
+       "      <td>0.000000e+00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>0.007027</th>\n",
+       "      <td>0.000558</td>\n",
+       "      <td>2.435910e-09</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>0.014441</th>\n",
+       "      <td>0.000558</td>\n",
+       "      <td>4.037960e-09</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>0.021880</th>\n",
+       "      <td>0.000558</td>\n",
+       "      <td>4.620920e-09</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>0.029725</th>\n",
+       "      <td>0.000557</td>\n",
+       "      <td>4.789480e-09</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "Isotope ZAI         922350        541350\n",
+       "Burnup [MWd/kgU]                        \n",
+       "0.000000          0.000558  0.000000e+00\n",
+       "0.007027          0.000558  2.435910e-09\n",
+       "0.014441          0.000558  4.037960e-09\n",
+       "0.021880          0.000558  4.620920e-09\n",
+       "0.029725          0.000557  4.789480e-09"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "fuel.toDataFrame(\"adens\", time=\"burnup\", zai=[922350, 541350]).head()"
    ]
   },
   {

--- a/serpentTools/objects/materials.py
+++ b/serpentTools/objects/materials.py
@@ -529,7 +529,7 @@ class DepletedMaterial(DepletedMaterialBase):
                         title=title, legend=legend)
         return ax
 
-    def toDataFrame(self, quantity, names=None, zai=None, index="days"):
+    def toDataFrame(self, quantity, names=None, zai=None, time="days", multiIndex=False):
         """Create a pandas DataFrame for a property of interest
 
         If ``names`` and ``zai`` are not provided, then the isotope
@@ -544,7 +544,7 @@ class DepletedMaterial(DepletedMaterialBase):
             Specific isotope names to obtain. Not compatible with ``zai``
         zai : sequence of int, optional
             Specific isotope zai to obtain. Not compatible with ``names``
-        index : {"days", "burnup", "step"}, optional
+        time : {"days", "burnup", "step"}, optional
             What array to use for the index or rows of the DataFrame.
             Defaults to using :attr:`days`, but ``"burnup"`` can be passed
             to use :attr:`burnup`, if it is present. The value of ``"step"``
@@ -567,19 +567,19 @@ class DepletedMaterial(DepletedMaterialBase):
         if names is not None and zai is not None:
             raise ValueError("Cannot pass both isotope names and zai")
 
-        if index == "days":
-            dfIndex = pandas.Index(self.days, name="Time [d]")
-        elif index == "burnup":
+        if time == "days":
+            timeIndex = pandas.Index(self.days, name="Time [d]")
+        elif time == "burnup":
             bu = self.burnup
             if bu is None:
                 raise AttributeError(
                     "Burnup not set on material {}".format(self.name))
-            dfIndex = pandas.Index(bu, name="Burnup [MWd/kgU]")
-        elif index == "step":
-            dfIndex = pandas.Index(range(len(self.days)), name="Step")
+            timeIndex = pandas.Index(bu, name="Burnup [MWd/kgU]")
+        elif time == "step":
+            timeIndex = pandas.Index(range(len(self.days)), name="Step")
         else:
             raise ValueError(
-                "Index must be days, burnup, or step, not {}".format(index))
+                "Index must be days, burnup, or step, not {}".format(time))
 
         data = self.data.get(quantity)
 
@@ -603,4 +603,4 @@ class DepletedMaterial(DepletedMaterialBase):
                 [self.names[x] for x in isoslice], name="Isotopes")
 
         return pandas.DataFrame(
-            data[isoslice].T.copy(), index=dfIndex, columns=columns)
+            data[isoslice].T.copy(), index=timeIndex, columns=columns)

--- a/tests/test_pt_depletion.py
+++ b/tests/test_pt_depletion.py
@@ -33,10 +33,10 @@ def test_toDataFrame(referenceMaterial, quantity):
         "days", quantity, names=["U235", "Xe135", "Pu239"]
     )
     namedBurnup = referenceMaterial.toDataFrame(
-        quantity, names=["U235", "Xe135", "Pu239"], index="burnup"
+        quantity, names=["U235", "Xe135", "Pu239"], time="burnup"
     )
     zaiSteps = referenceMaterial.toDataFrame(
-        quantity, zai=[922350, 541350, 942390], index="step"
+        quantity, zai=[922350, 541350, 942390], time="step"
     )
 
     assert numpy.array_equal(namedBurnup.values, reference.T)


### PR DESCRIPTION
The `index` argument that controls the data frame index is now ``time`` to conform with a lot of the other methods. The testing has been cleaned up a bit too, with more useful variable names. Finally, the documentation is updated to demonstrate this nice little method