### PR TITLE
[API][ENH] Update sensitivity.py

### DIFF
--- a/serpentTools/parsers/sensitivity.py
+++ b/serpentTools/parsers/sensitivity.py
@@ -5,7 +5,7 @@ from collections import OrderedDict
 from itertools import product
 
 from numpy import transpose, hstack
-from matplotlib.pyplot import gca
+from matplotlib.pyplot import gca, vlines
 
 from serpentTools.utils.plot import magicPlotDocDecorator, formatPlot
 from serpentTools.engines import KeywordParser
@@ -304,8 +304,8 @@ class SensitivityReader(BaseReader):
                                         "stored on reader")
 
     @magicPlotDocDecorator
-    def plot(self, resp, zai=None, pert=None, mat=None, sigma=3,
-             normalize=True, ax=None, labelFmt=None,
+    def plot(self, resp, zai=None, pert=None, mat=None, mevscale=False, egrid=None,
+             sigma=3, normalize=True, ax=None, labelFmt=None,
              title=None, logx=True, logy=False, loglog=False, xlabel=None,
              ylabel=None, legend=None, ncol=1):
         """
@@ -331,6 +331,10 @@ class SensitivityReader(BaseReader):
         mat: None or str or list of strings
             Plot sensitivities due to these materials. Passing ``None``
             will plot against all materials.
+        mevscale: string
+            Flag for plotting energy grid in MeV units. Default is ``False``.
+        egrid : numpy.array
+            Energy grid for sampling reaction rates ratios. Default is ``None``.
         {sigma}
         normalize: True
             Normalize plotted data per unit lethargy
@@ -389,7 +393,7 @@ class SensitivityReader(BaseReader):
 
         errors = resMat[..., 1] * values * sigma
 
-        energies = self.energies * 1E6
+        energies = self.energies * 1E6 if mevscale is False else self.energies
         for z, m, p in product(zais, mats, perts):
             iZ = self.zais[z]
             iM = self.materials[m]
@@ -401,8 +405,18 @@ class SensitivityReader(BaseReader):
             label = labelFmt.format(r=resp, z=z, m=m, p=p)
             ax.errorbar(energies, yVals, yErrs, label=label,
                         drawstyle='steps-post')
+            if egrid is not None:
+                ax.vlines(egrid, min(yVals), max(yVals), colors='k',
+                          linestyles='dashed')
 
-        xlabel = 'Energy [eV]' if xlabel is None else xlabel
+        if xlabel is None:
+            if mevscale is False:
+                xlabel = 'Energy [eV]'
+            else:
+                xlabel = 'Energy [MeV]'
+        else:
+            xlabel = xlabel
+
         ylabel = ylabel if ylabel is not None else (
             'Sensitivity {} {}'.format(
                 'per unit lethargy' if normalize else '',


### PR DESCRIPTION
I added the option for plotting the energy axis for sensitivity coefficients in MeV and the possibility to display the energy group boundaries passed by the user in case a reaction rate ratio response is defined over an energy grid .

Scope
=====
* Let the user decide to plot with respect to MeV or eV (new input `mevscale` boolean. Default is `False`)
* Provide the possibility to show the macro-group grid boundaries as vertical dashed black lines, in case a reaction rate is defined over some energy groups (e.g. a multi-group cross section), (new input `egrid` numpy.array. Default is `None`).

Example
=======
Please find attached a file that can be used for testing my modifications:
[IF3D_GPT_sens0.zip](https://github.com/CORE-GATECH-GROUP/serpent-tools/files/4585436/IF3D_GPT_sens0.zip)

`sens_filename = str(pwd.joinpath('IF3D_GPT_sens0.m'))`
`senscoeff = st.read(sens_filename)`
`G6 = np.array([1e-11, 7.48518E-04, 5.53084E-03, 2.47875E-02, 4.97871E-01,
               2.23130E+00, 20])`
`responses = ['keff', *['xsFissBin%g' % n for n in range(0, 6)],
             *['xsCaptBin%g' % n for n in range(0, 6)]]`
`for resp in responses:`
    `fig, ax = plt.subplots()`
    `senscoeff.plot(resp, 942390, pert=['mt 2 xs', 'mt 18 xs', 'mt 102 xs'],
                   ax=ax, labelFmt='{r}: {z} {p}', legend='right', mevscale=True,
                   egrid=G6)`

Disclaimer
=========
This is my first pull request to a repo that is not mine, hope I did not mess anything!
