### PR TITLE
DEV Mark .m files as vendored for github linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
-serpentTools/_version.py export-subst
 * text eol=auto
 * text eol=lf
 *.py diff=py
 *.png binary
+*.m linguist-vendored


### PR DESCRIPTION
Instructs the github language breakdown tool [linguist](https://github.com/github/linguist)
to not consider matlab files by marking them as vendored https://github.com/github/linguist#vendored-code

This has the effect of skipping these files when computing the language statistics for the package. 

![Current language statistics, marking this as a 90% MATLAB project](https://user-images.githubusercontent.com/19477741/82091034-aee1a000-96c4-11ea-8927-202c89f660c7.png)

Ultimately, this package will be marked as a python package on GitHub! :rocket: After committing this, we get 99.74 % python, and the rest Shell :snake: 