### PR TITLE
Update sensitivity.py

### DIFF
--- a/serpentTools/parsers/sensitivity.py
+++ b/serpentTools/parsers/sensitivity.py
@@ -5,7 +5,7 @@ from collections import OrderedDict
 from itertools import product
 
 from numpy import transpose, hstack
-from matplotlib.pyplot import gca
+from matplotlib.pyplot import gca, axvline
 
 from serpentTools.utils.plot import magicPlotDocDecorator, formatPlot
 from serpentTools.engines import KeywordParser
@@ -331,6 +331,10 @@ class SensitivityReader(BaseReader):
         mat: None or str or list of strings
             Plot sensitivities due to these materials. Passing ``None``
             will plot against all materials.
+        mevscale: bool, optional
+            Flag for plotting energy grid in MeV units. Default is ``False``.
+        egrid : numpy.array, optional
+            Energy grid for sampling reaction rates ratios. Default is ``None``.
         {sigma}
         normalize: True
             Normalize plotted data per unit lethargy
@@ -389,7 +393,7 @@ class SensitivityReader(BaseReader):
 
         errors = resMat[..., 1] * values * sigma
 
-        energies = self.energies * 1E6
+        energies = self.energies if mevscale else self.energies * 1E6
         for z, m, p in product(zais, mats, perts):
             iZ = self.zais[z]
             iM = self.materials[m]
@@ -401,6 +405,15 @@ class SensitivityReader(BaseReader):
             label = labelFmt.format(r=resp, z=z, m=m, p=p)
             ax.errorbar(energies, yVals, yErrs, label=label,
                         drawstyle='steps-post')
+
+        if egrid is not None:
+            for group in egrid:
+                ax.axvline(group, color='k', linestyle='dashed')
+
+        if xlabel is None:
+            xlabel = "Energy [MeV]" if mevscale else "Energy [eV]"
+        else:
+            xlabel = xlabel
 
         xlabel = 'Energy [eV]' if xlabel is None else xlabel
         ylabel = ylabel if ylabel is not None else (

--- a/serpentTools/parsers/sensitivity.py
+++ b/serpentTools/parsers/sensitivity.py
@@ -304,8 +304,8 @@ class SensitivityReader(BaseReader):
                                         "stored on reader")
 
     @magicPlotDocDecorator
-    def plot(self, resp, zai=None, pert=None, mat=None, sigma=3,
-             normalize=True, ax=None, labelFmt=None,
+    def plot(self, resp, zai=None, pert=None, mat=None, mevscale=False,
+             egrid=None, sigma=3, normalize=True, ax=None, labelFmt=None,
              title=None, logx=True, logy=False, loglog=False, xlabel=None,
              ylabel=None, legend=None, ncol=1):
         """
@@ -331,10 +331,12 @@ class SensitivityReader(BaseReader):
         mat: None or str or list of strings
             Plot sensitivities due to these materials. Passing ``None``
             will plot against all materials.
-        mevscale: bool, optional
-            Flag for plotting energy grid in MeV units. Default is ``False``.
+        mevscale : bool, optional
+            Flag for plotting energy grid in MeV units. If ``True``, the energy
+            axis is expressed in MeV. Default is ``False``.
         egrid : numpy.array, optional
-            Energy grid for sampling reaction rates ratios. Default is ``None``.
+            User-defined energy grid boundaries displayed on the sensitivities
+            as vblack, dashed vertical lines. Default is ``None``.
         {sigma}
         normalize: True
             Normalize plotted data per unit lethargy
@@ -412,8 +414,6 @@ class SensitivityReader(BaseReader):
 
         if xlabel is None:
             xlabel = "Energy [MeV]" if mevscale else "Energy [eV]"
-        else:
-            xlabel = xlabel
 
         xlabel = 'Energy [eV]' if xlabel is None else xlabel
         ylabel = ylabel if ylabel is not None else (


### PR DESCRIPTION
Disclaimer
=========
This is a new PR following [this one] (https://github.com/CORE-GATECH-GROUP/serpent-tools/pull/403), after rebasing to the master branch.

I added the option for plotting the energy axis for sensitivity coefficients in MeV and the possibility to display the energy group boundaries passed by the user in case a reaction rate ratio response is defined over an energy grid .

Scope
=====
* Let the user decide to plot with respect to MeV or eV (new input `mevscale` boolean. Default is `False`)
* Provide the possibility to show the macro-group grid boundaries as vertical dashed black lines, in case a reaction rate is defined over some energy groups (e.g. a multi-group cross section), (new input `egrid` numpy.array. Default is `None`).

Example
=======
Please find attached a file that can be used for testing my modifications:
[IF3D_GPT_sens0.zip](https://github.com/CORE-GATECH-GROUP/serpent-tools/files/4585436/IF3D_GPT_sens0.zip)

`sens_filename = str(pwd.joinpath('IF3D_GPT_sens0.m'))`
`senscoeff = st.read(sens_filename)`
`G6 = np.array([1e-11, 7.48518E-04, 5.53084E-03, 2.47875E-02, 4.97871E-01,
               2.23130E+00, 20])`
`responses = ['keff', *['xsFissBin%g' % n for n in range(0, 6)],
             *['xsCaptBin%g' % n for n in range(0, 6)]]`
`for resp in responses:`
    `fig, ax = plt.subplots()`
    `senscoeff.plot(resp, 942390, pert=['mt 2 xs', 'mt 18 xs', 'mt 102 xs'],
                   ax=ax, labelFmt='{r}: {z} {p}', legend='right', mevscale=True,
                   egrid=G6)`