### PR TITLE
API Provide serpentTools.next.Detector{File,Reader}

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -12,9 +12,13 @@ BUILDDIR      = _build
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
-.PHONY: help Makefile
+.PHONY: help Makefile clean
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+clean:
+	rm -rf $(BUILDDIR)
+	rm -rf generated develop/generated

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -192,7 +192,7 @@ autodoc_default_options = {
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3.5', None),
     'matplotlib': ('https://matplotlib.org', None),
-    'numpy': ('https://docs.scipy.org/doc/numpy/', None),
+    'numpy': ('https://numpy.org/doc/stable', None),
     'scipy': ('https://docs.scipy.org/doc/scipy/reference', None),
     'pandas': ('https://pandas.pydata.org/docs', None),
 }

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -69,6 +69,7 @@ version, with links to earlier releases.
    variableGroups
    command-line
    develop/index
+   next
    license
    contributors
    publications

--- a/docs/next.rst
+++ b/docs/next.rst
@@ -1,0 +1,37 @@
+.. _api_next:
+
+New Files and Readers
+=====================
+
+.. warning::
+
+    The contents of ``serpentTools.next`` are in development
+    and subject to change from the development branch up to
+    release in ``0.11.0``. Not all features included in the
+    current ``serpentTools`` API exist in ``serpentTools.next``
+
+The ``serpentTools.next`` module implements the new data model discussed
+in :pull:`400` and in :ref:`data-model`.
+
+.. currentmodule:: serpentTools.next
+
+Files
+-----
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+    :template: myclass.rst
+
+    DetectorFile
+    SerpentFile
+
+Readers
+-------
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+    :template: myclass.rst
+
+    DetectorReader

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,5 +4,5 @@ pandas==0.24.0
 jupyter==1.0.0
 coverage==4.5.1
 scipy==1.3.2
-pytest
+pytest>=4.2.0
 pytest-cov==2.7.1

--- a/serpentTools/next/__init__.py
+++ b/serpentTools/next/__init__.py
@@ -1,0 +1,2 @@
+from .base import SerpentFile
+from .detector import DetectorFile, DetectorReader

--- a/serpentTools/next/_engines.py
+++ b/serpentTools/next/_engines.py
@@ -1,0 +1,103 @@
+"""Classes for simple file processing
+
+Provided through the drewtils python project
+Distributed under an MIT License
+
+Copyright (c) Andrew Johnson, 2017-2020
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+"""
+
+import re
+
+
+class _TextProcessor(object):
+    """Parent class for text processors."""
+
+    def __init__(self, stream):
+        self.stream = stream
+        self.line = ""
+
+    def _step(self):
+        self.line = self.stream.readline()
+        return self.line
+
+    def _match(self, regexp):
+        return re.match(regexp, self.line)
+
+    def _search(self, regexp):
+        return re.search(regexp, self.line)
+
+    def seekToTop(self):
+        """Reset the file pointer to the start of the file."""
+        self.stream.seek(0)
+
+
+class KeywordParser(_TextProcessor):
+    r"""
+    Class for parsing a file for chunks separated by various keywords.
+
+    Parameters
+    ----------
+    stream : readable buffer
+        Stream to be processed.
+    keys : iterable of str
+        List of keywords/phrases that will indicate the start of a chunk
+    separators : iterable of str, optional
+        List of additional phrases that can separate two chunks.
+        If not given, will default to empty line ``'\n'``.
+    eof : str, optional
+        String to indicate the end of the file
+
+    Attributes
+    ----------
+    line : str
+        Most recently read line
+    stream : readable buffer
+        Stream that is currently processed
+
+    """
+
+    def __init__(self, stream, keys, separators=None, eof=""):
+        super().__init__(stream)
+        self._startMatch = re.compile("|".join([str(arg) for arg in keys]))
+        separators = set(keys).union(separators or {"\n"})
+        self._endMatch = re.compile("|".join([str(arg) for arg in separators]))
+        self._end = eof
+
+    def __iter__(self):
+        """Yield all chunks in the stream
+
+        Yields
+        ------
+        list of str
+            Successive chunks of text
+
+        """
+        chunk = []
+        while self._step() != self._end:
+            if self._match(self._endMatch):
+                if chunk:
+                    yield chunk
+                chunk = [self.line] if self._match(self._startMatch) else []
+            elif chunk:
+                chunk.append(self.line)
+        if chunk:
+            yield chunk

--- a/serpentTools/next/base.py
+++ b/serpentTools/next/base.py
@@ -32,7 +32,7 @@ class SerpentFile(ABC):
         ----------
         source : str or pathlib.Path or io.IOBase
             Source of Serpent output data. File names can be passed
-            as either strings or :class:`pathlib.Path`s. Otherwise,
+            as either strings or :class:`pathlib.Path`. Otherwise,
             source must be readable, e.g. support ``source.read`` and
             ``source.readline``
         sourcename : str, optional

--- a/serpentTools/next/base.py
+++ b/serpentTools/next/base.py
@@ -1,0 +1,115 @@
+import io
+import pathlib
+from abc import ABC, abstractclassmethod
+
+
+class SerpentFile(ABC):
+    """Most basic interface for a Serpent file
+
+    Parameters
+    ----------
+    filename : str, optional
+        Helpful identifier for the source of data
+
+    Attributes
+    ----------
+    filename : str or None
+        Name of the source of data
+
+    """
+
+    def __init__(self, filename=None):
+        self.filename = filename
+
+    @classmethod
+    def fromSerpent(
+        cls, source, sourcename=None, postcheck=True, strict=True, **kwargs
+    ):
+        """
+        Load data from a Serpent output file
+
+        Parameters
+        ----------
+        source : str or pathlib.Path or io.IOBase
+            Source of Serpent output data. File names can be passed
+            as either strings or :class:`pathlib.Path`s. Otherwise,
+            source must be readable, e.g. support ``source.read`` and
+            ``source.readline``
+        sourcename : str, optional
+            Alternative identifier for the source. If not provided
+            and ``source`` is a string or :class:`pathlib.Path`,
+            the name will reflect the name of the file
+        postcheck : bool, optional
+            Perform simple checks after the file has been processed.
+            Default is to perform the check
+        strict : bool, optional
+            If simple checks fail during post-check routines,
+            raise an error if ``True`` or a warning. Default is to
+            raise an error
+        kwargs :
+            Additional keyword arguments will be passed directly to
+            the concrete stream reader, implemented by each subclass.
+
+        Returns
+        -------
+        SerpentFile
+            Specific subclass corresponding to the file type
+
+        Raises
+        ------
+        serpentTools.SerpentToolsException
+            If ``postcheck``, a check fails, and ``strict``
+
+        Warns
+        -----
+        UserWarning
+            If ``postcheck``, a check fails, and not ``strict``
+
+        """
+        if isinstance(source, str):
+            with open(source, mode="r") as stream:
+                return cls._fromSerpentStream(
+                    stream, sourcename or source, postcheck, strict, **kwargs
+                )
+        elif isinstance(source, pathlib.Path):
+            with source.open(mode="r") as stream:
+                return cls._fromSerpentStream(
+                    stream,
+                    sourcename or str(source),
+                    postcheck,
+                    strict,
+                    **kwargs,
+                )
+        # Special case for binary data, e.g. zip files
+        elif isinstance(source, io.BufferedIOBase):
+            return cls._fromSerpentStream(
+                io.TextIOWrapper(source),
+                sourcename,
+                postcheck,
+                strict,
+                **kwargs,
+            )
+        elif not isinstance(source, io.IOBase):
+            raise TypeError(
+                "Source must be string or pathlib.Path for file names, or a "
+                "readable IO stream. Got {}".format(type(source))
+            )
+        return cls._fromSerpentStream(
+            source, sourcename, postcheck, strict, **kwargs
+        )
+
+    @abstractclassmethod
+    def _fromSerpentStream(
+        cls, source, sourcename, postcheck, strict, **kwargs
+    ):
+        """Process a stream of Serpent text data.
+
+        Source will be an :class:`io.TextIOBase`, which supports at
+        least ``source.read`` and ``source.readline``. Seeking
+        with ``source.seek`` might not be available in all
+        cases, but can be checked with ``source.seekable``
+
+        Other arguments correspond with their intent in
+        :meth:`fromSerpent`
+
+        """

--- a/serpentTools/next/detector.py
+++ b/serpentTools/next/detector.py
@@ -1,0 +1,374 @@
+import io
+import pathlib
+from collections.abc import Iterable
+from warnings import warn
+
+from serpentTools.messages import SerpentToolsException
+from serpentTools.detectors import Detector, detectorFactory
+from serpentTools.parsers.detector import cleanDetChunk
+
+from ._engines import KeywordParser
+from .base import SerpentFile
+
+
+__all__ = ["DetectorFile", "DetectorReader"]
+
+
+class DetectorFile(dict, SerpentFile):
+    """Dictionary-like storage of detectors
+
+    Inherits from :class:`dict`, but enforces that all
+    values are :class:`~serpentTools.Detector` or subclasses. Therefore
+    the following are allowed
+
+    .. code::
+
+        d.get(name, default=None)
+        for k, v in d.items():
+            pass
+        det = d[name]
+        det = d.pop(name)
+
+    Parameters
+    ----------
+    args : iterable of key-value pairs or dictionary, optional
+        Pre-defined iterable of detectors. Can either be an existing
+        dictionary of the form ``{name: detector}``, or an iterable
+        of the form ``[[name, detector], ...]``
+    filename : str, optional
+        Helpful identifier for the source of this data, e.g. file name
+    kwargs :
+        Additional way to pass detectors to the instance with
+        ```DetectorFile(..., xy=<Detector>, spectrum=<Detector>)``
+
+    Attributes
+    ----------
+    filename : str or None
+        Identifier for the source of this data, e.g. a file name.
+        A value of ``None`` indicates the filename was not passed
+
+    See Also
+    --------
+    :meth:`DetectorFile.fromSerpent`
+
+    """
+
+    def __init__(self, *args, filename=None, **kwargs):
+        dict.__init__(self)
+        SerpentFile.__init__(self, filename=filename)
+        self.update(*args, **kwargs)
+
+    def __setitem__(self, key, value):
+        """D[key] = :class:`~serpentTools.Detector`"""
+        if not isinstance(value, Detector):
+            raise TypeError(
+                "Values must be {}, not {}".format(Detector, type(value))
+            )
+        super().__setitem__(key, value)
+
+    def __repr__(self):
+        msg = "{}{}\n{}".format(
+            type(self),
+            " from {}".format(self.filename) if self.filename else "",
+            dict.__repr__(self),
+        )
+        return msg
+
+    def update(self, *args, **kwargs):
+        """Update with another mapping of detectors
+
+        Arguments can be another :class:`DetectorFile`,
+        dictionary of ``{key: <Detector>}``,
+        or iterable ``[[key, <Detector>]]`` much like the
+        formats expected by the constructor.
+        """
+        other = dict(*args, **kwargs)
+        for key, value in other.items():
+            if not isinstance(value, Detector):
+                raise TypeError(
+                    "Values must be {}, not {} for key {}".format(
+                        Detector, type(value), key
+                    )
+                )
+        super().update(other)
+
+    @classmethod
+    def fromSerpent(
+        cls, source, sourcename=None, postcheck=True, strict=True, names=None,
+    ):
+        """
+        Load data from a Serpent output file
+
+        Parameters
+        ----------
+        source : str or pathlib.Path or io.IOBase
+            Source of Serpent output data. File names can be passed
+            as either strings or :class:`pathlib.Path`s. Otherwise,
+            source must be readable, e.g. support ``source.read`` and
+            ``source.readline``
+        sourcename : str, optional
+            Alternative identifier for the source. If not provided
+            and ``source`` is a string or :class:`pathlib.Path`,
+            the name will reflect the name of the file
+        postcheck : bool, optional
+            Perform simple checks after the file has been processed.
+            Default is to perform the check
+        strict : bool, optional
+            If simple checks fail during post-check routines,
+            raise an error if ``True`` or a warning. Default is to
+            raise an error
+        names : str or iterable of str, optional
+            Names of detectors that, if found, will be processed.
+            Detectors not found in ``names`` will not be included
+            in the returned object
+
+        Returns
+        -------
+        SerpentFile
+            Specific subclass corresponding to the file type
+
+        Raises
+        ------
+        serpentTools.SerpentToolsException
+            If ``postcheck``, a check fails, and ``strict``
+
+        Warns
+        -----
+        UserWarning
+            If ``postcheck``, a check fails, and not ``strict``
+
+        """
+        return super().fromSerpent(
+            source,
+            sourcename=sourcename,
+            postcheck=postcheck,
+            strict=strict,
+            names=names,
+        )
+
+    @classmethod
+    def _fromSerpentStream(
+        cls, stream, sourcename, postcheck, strict, names=None
+    ):
+        return DetectorReader(names=names).readTextStream(
+            stream, sourcename=sourcename, postcheck=postcheck, strict=strict,
+        )
+
+
+class DetectorReader:
+    """Class for reading Serpent detector files
+
+    Creating one of these manually may not always
+    be necessary. However, it can be useful if repeated
+    files are to be read, as a fresh reader is created
+    for each call to :meth:`DetectorFile.fromSerpent`.
+
+    Parameters
+    ----------
+    names : str or iterable of str, optional
+        Initial names of detectors to add to :attr:`names`
+
+    Attributes
+    ----------
+    names : set of str
+        Names of detectors that, if found when reading,
+        should be processed. Any other detectors will not
+        be processed and stored
+
+    """
+
+    # Update this if new detector grids are introduced
+    _KNOWN_GRIDS = ("E", "X", "Y", "Z", "T", "COORD", "R", "PHI", "THETA")
+
+    def __init__(self, names=None):
+        self.names = set()
+        if names is not None:
+            if isinstance(names, str):
+                self.names.add(names)
+            elif isinstance(names, Iterable):
+                self.names.update(names)
+            else:
+                raise TypeError(
+                    "Names provided to {} must be string or iterable of string, "
+                    "not {}".format(type(self), type(names))
+                )
+
+    def read(self, source, sourcename=None, postcheck=True, strict=True):
+        """Process detectors from a Serpent output file
+
+        Parameters
+        ----------
+        source : str or pathlib.Path or io.IOBase
+            Filenames can be provided as strings or
+            :class:`pathlib.Path`s and will be opened accordingly.
+            Otherwise read directly from this argument
+        sourcename : str, optional
+            Additional descriptor of the data source. If not provided,
+            and ``source`` is a string or :class:`pathlib.Path`, use
+            the name of the file
+        postcheck : bool, optional
+            Check if any detectors have been found after reading.
+            Default: True
+        strict : bool, optional
+            Raise errors if no detectors are found during post-read
+            check. Otherwise warn if none are found. Default : True
+
+        Returns
+        -------
+        DetectorFile
+            Mapping of detector names and their corresponding instances.
+
+        Raises
+        ------
+        SerpentToolsException
+            If ``postcheck`` and ``strict`` and no detectors were found
+
+        Warns
+        -----
+        UserWarning
+            if ``postcheck`` and not ``strict`` and no detectors were found
+
+        """
+        if isinstance(source, str):
+            with open(source, mode="r") as stream:
+                return self.readTextStream(
+                    stream,
+                    sourcename or source,
+                    postcheck=postcheck,
+                    strict=strict,
+                )
+        elif isinstance(source, pathlib.Path):
+            with source.open(mode="r") as stream:
+                return self.readTextStream(
+                    stream,
+                    sourcename or str(source),
+                    postcheck=postcheck,
+                    strict=strict,
+                )
+        elif isinstance(source, io.BufferedIOBase):
+            return self.readTextStream(
+                io.TextIOWrapper(source),
+                sourcename,
+                postcheck=postcheck,
+                strict=strict,
+            )
+        elif not isinstance(source, io.TextIOBase):
+            raise TypeError(
+                "Source must be file name (str or pathlib.Path) or "
+                "readable stream of text data. Got {}".format(type(source))
+            )
+        return self.readTextStream(
+            source, sourcename, postcheck=postcheck, strict=strict
+        )
+
+    def readTextStream(
+        self, stream, sourcename=None, postcheck=True, strict=True
+    ):
+        """Process detectors from a stream of text data
+
+        Differs from :meth:`read` as this method only handles
+        readable :class:`io.TextIOBase` instances, like opened
+        files. :meth:`read` relies on this method for processing
+        of the file data, but handles more input types.
+
+        Parameters
+        ----------
+        source : io.TextIOBase
+            :meth:`~io.TextIOBase.readable` buffer of text data
+            corresponding to a Serpent output file.
+        sourcename : str, optional
+            Additional descriptor of the data source. If not provided,
+            and ``source`` is a string or :class:`pathlib.Path`, use
+            the name of the file
+        postcheck : bool, optional
+            Check if any detectors have been found after reading.
+            Default: True
+        strict : bool, optional
+            Raise errors if no detectors are found during post-read
+            check. Otherwise warn if none are found. Default : True
+
+        Returns
+        -------
+        DetectorFile
+            Mapping of detector names and their corresponding instances.
+
+        Raises
+        ------
+        SerpentToolsException
+            If ``postcheck`` and ``strict`` and no detectors were found
+
+        Warns
+        -----
+        UserWarning
+            if ``postcheck`` and not ``strict`` and no detectors were found
+
+        """
+        if not isinstance(stream, io.TextIOBase):
+            raise TypeError("Stream is not a source of text data")
+        elif not stream.readable():
+            raise AttributeError("Stream is not readable")
+
+        detectors = self._read(stream, sourcename)
+
+        if postcheck and not detectors:
+            msg = "No detectors found in {}, named {}".format(
+                repr(stream), sourcename
+            )
+            if self.names:
+                msg += ". Processing detectors with names: {}".format(
+                    ", ".join(self.names)
+                )
+            if strict:
+                raise SerpentToolsException(msg)
+            warn(msg)
+
+        return detectors
+
+    def _read(self, stream, name):
+        currentName = ""
+        grids = {}
+        bins = None
+        detectors = DetectorFile(filename=name)
+
+        for chunk in KeywordParser(stream, ["DET"], ["\n", "];"]):
+            name, data = self._clean(chunk)
+
+            # Determine if this is a new detector
+            if not currentName:
+                isNewDetector = False
+            elif not name.startswith(currentName):
+                isNewDetector = True
+            else:
+                isNewDetector = not any(
+                    name == "".join((currentName, g))
+                    for g in self._KNOWN_GRIDS
+                )
+
+            if isNewDetector:
+                if not self.names or currentName in self.names:
+                    detectors[currentName] = self._detectorFactory(
+                        currentName, bins, grids
+                    )
+                bins = data
+                grids = {}
+                currentName = name
+            elif bins is None:
+                currentName = name
+                bins = data
+            else:
+                gridName = name[len(currentName):]
+                grids[gridName] = data
+
+        if not self.names or currentName in self.names:
+            detectors[currentName] = self._detectorFactory(
+                currentName, bins, grids
+            )
+        return detectors
+
+    @staticmethod
+    def _detectorFactory(name, bins, grids):
+        return detectorFactory(name, bins, grids)
+
+    @staticmethod
+    def _clean(chunk):
+        return cleanDetChunk(chunk)

--- a/serpentTools/next/detector.py
+++ b/serpentTools/next/detector.py
@@ -362,7 +362,7 @@ class DetectorReader:
                 gridName = name[len(currentName):]
                 grids[gridName] = data
 
-        if not self.names or currentName in self.names:
+        if currentName and (not self.names or currentName in self.names):
             detectors[currentName] = self._detectorFactory(
                 currentName, bins, grids
             )

--- a/serpentTools/next/detector.py
+++ b/serpentTools/next/detector.py
@@ -150,9 +150,12 @@ class DetectorFile(dict, SerpentFile):
     def _fromSerpentStream(
         cls, stream, sourcename, postcheck, strict, names=None
     ):
-        return DetectorReader(names=names).readTextStream(
+        out = DetectorReader(names=names).readTextStream(
             stream, sourcename=sourcename, postcheck=postcheck, strict=strict,
         )
+        if type(out) is cls:
+            return out
+        return cls(out, filename=out.filename)
 
 
 class DetectorReader:

--- a/serpentTools/next/detector.py
+++ b/serpentTools/next/detector.py
@@ -103,7 +103,7 @@ class DetectorFile(dict, SerpentFile):
         ----------
         source : str or pathlib.Path or io.IOBase
             Source of Serpent output data. File names can be passed
-            as either strings or :class:`pathlib.Path`s. Otherwise,
+            as either strings or :class:`pathlib.Path`. Otherwise,
             source must be readable, e.g. support ``source.read`` and
             ``source.readline``
         sourcename : str, optional
@@ -203,7 +203,7 @@ class DetectorReader:
         ----------
         source : str or pathlib.Path or io.IOBase
             Filenames can be provided as strings or
-            :class:`pathlib.Path`s and will be opened accordingly.
+            :class:`pathlib.Path` and will be opened accordingly.
             Otherwise read directly from this argument
         sourcename : str, optional
             Additional descriptor of the data source. If not provided,

--- a/serpentTools/parsers/detector.py
+++ b/serpentTools/parsers/detector.py
@@ -119,7 +119,8 @@ class DetectorReader(BaseReader):
 
     def _processDet(self, name, bins, grids):
         """Add this detector with it's grid data to the reader."""
-        if self.settings['names'] and name not in self.settings['names']:
+        if not name or (
+                self.settings['names'] and name not in self.settings['names']):
             return
         if name in self.detectors:
             raise KeyError("Detector {} already stored on reader"

--- a/tests/test_next_detector.py
+++ b/tests/test_next_detector.py
@@ -1,4 +1,5 @@
 """Test for the new detector file"""
+import sys
 import pathlib
 import zipfile
 import io
@@ -75,6 +76,9 @@ def test_new_det(previousBWR):
     compareDetReader(fromstream, previousBWR)
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 6), reason="Can't write zip files with <3.6"
+)
 def test_from_zip(previousBWR, zippedStream):
     newfile = serpentTools.next.DetectorFile.fromSerpent(zippedStream)
     compareDetReader(previousBWR, newfile)

--- a/tests/test_next_detector.py
+++ b/tests/test_next_detector.py
@@ -1,0 +1,113 @@
+"""Test for the new detector file"""
+import pathlib
+import zipfile
+import io
+
+import pytest
+import serpentTools
+from serpentTools.data import getFile
+import serpentTools.next
+
+BWR_FILE = getFile("bwr_det0.m")
+HEX_FILE = getFile("hexplot_det0.m")
+
+
+@pytest.fixture(scope="module")
+def previousBWR():
+    return serpentTools.read(BWR_FILE)
+
+
+@pytest.fixture
+def zippedStream(tmp_path):
+    d = tmp_path / "next_detector"
+    d.mkdir()
+    filename = d / "bwr.zip"
+    zipname = "bwr_det0.m"
+
+    # Create the file in a zipped archive
+    with zipfile.ZipFile(filename, mode="w") as z:
+        with z.open(zipname, mode="w") as zfile, open(
+            BWR_FILE, mode="rb"
+        ) as sfile:
+            zfile.write(sfile.read())
+
+    # Yield the stream of binary zip data to be reader
+    with zipfile.ZipFile(filename, mode="r") as z:
+        with z.open(zipname, mode="r") as zstream:
+            yield zstream
+
+    # Clean up after the test
+    filename.unlink()
+    d.rmdir()
+
+
+def compareDetector(actual, expected):
+    assert type(actual) is type(expected)
+    assert actual.indexes == expected.indexes
+    assert actual.bins == pytest.approx(expected.bins)
+    assert actual.tallies == pytest.approx(expected.tallies)
+    assert actual.errors == pytest.approx(expected.errors)
+
+    assert set(actual.grids) == set(expected.grids)
+
+    for gridK, grid in expected.grids.items():
+        assert actual.grids[gridK] == pytest.approx(grid)
+
+
+def compareDetReader(actual, expected):
+    assert set(actual) == set(expected)
+
+    for key, detector in expected.items():
+        compareDetector(actual[key], detector)
+
+
+def test_new_det(previousBWR):
+    fromstr = serpentTools.next.DetectorFile.fromSerpent(BWR_FILE)
+    compareDetReader(fromstr, previousBWR)
+
+    frompath = serpentTools.next.DetectorFile.fromSerpent(
+        pathlib.Path(BWR_FILE)
+    )
+    compareDetReader(frompath, previousBWR)
+
+    with open(BWR_FILE, mode="r") as stream:
+        fromstream = serpentTools.next.DetectorFile.fromSerpent(stream)
+    compareDetReader(fromstream, previousBWR)
+
+
+def test_from_zip(previousBWR, zippedStream):
+    newfile = serpentTools.next.DetectorFile.fromSerpent(zippedStream)
+    compareDetReader(previousBWR, newfile)
+
+
+@pytest.fixture(scope="module")
+def previousHex():
+    return serpentTools.read(HEX_FILE)
+
+
+def test_filtered(previousHex):
+    reader = serpentTools.next.DetectorReader()
+    full = reader.read(HEX_FILE)
+    compareDetReader(full, previousHex)
+
+    for name, detector in previousHex.items():
+        reader.names.clear()
+        reader.names.add(name)
+        single = reader.read(HEX_FILE)
+        assert len(single) == 1
+        found, fromFilter = single.popitem()
+        assert found == name
+        compareDetector(fromFilter, detector)
+
+
+def test_postcheck():
+    fakestream = io.StringIO()
+    reader = serpentTools.next.DetectorReader()
+
+    with pytest.raises(serpentTools.SerpentToolsException):
+        reader.read(fakestream, postcheck=True, strict=True)
+
+    reader.read(fakestream, postcheck=False)
+
+    with pytest.warns(UserWarning):
+        reader.read(fakestream, postcheck=True, strict=False)


### PR DESCRIPTION
This PR introduces the first of the new readers and files discussed in #400, as well as the `serpentTools.next` sub-module. I wanted to add these piecemeal (e.g. one file type at a time) because then we can let any additional inheritance and subclasses arise naturally. For example, maybe we want to have a base `SerpentReader` that handles the `read` and `readTextStream` methods. Maybe the readers will be very different from each other and any subclassing might not make sense. More for a discussion later.

## `DetectorFile` 
The new class responsible for storing detectors is `serpentTools.next.DetectorFile`, and it is the first concrete `serpentTools.next.SerpentFile` class. It is also a subclass of `dict`, where the values should always be `Detector` instances. Some enforcement is done through `__setitem__` and `update`, but thanks to a lot of python features, this might not always be the case.

The `DetectorFile` can be created in a few different ways, with the most likely construction being done through `DetectorFile.fromSerpent`. This class method, provided by the base `SerpentFile` class, can handle a good number of inputs. Filepaths can be provided as strings or as `pathlib.Path` instances. Alternatively, io streams can be passed directly (e.g. a file opened outside the method or binary zip file) so long as they can be coerced to a [`io.TextIOBase`](https://docs.python.org/3/library/io.html?highlight=textiobase#io.TextIOBase). Zip files and other `io.BufferedIOBase` instances are converted using `io.TextIOWrapper` so that regular expressions and other routines that expect strings (rather than bytes) are handled transparently.

This allows the following workflow: 
1. Zip files, including potentially many detector files 
2. Extract a `DetectorFile` from this zip file without un-packing the archive with
```python
import zipfile
with zipfile.ZipFile("archive.zip", mode="r") as zipp:
    with zipp.open("bwr_det0.m", mode="r") as myf:
        bwr = DetectorFile.fromSerpent(myf)
```

The reading is handled by the new ...

## `DetectorReader`
`serpentTools.next.DetectorReader` is a re-usable class that facilitates reading Serpent detector files. I imagine the majority of cases will not require creating one of these manually, but it can be useful in some instances. The method `DetectorFile.fromSerpent` creates one of these every call, so creating a reader might be beneficial here. 

The reading routine is identical to what we currently have on our `serpentTools.DetectorReader`. The filtering is done with a `set` of strings stored on the reader, which the user can configure at construction and/or during the life of the reader, e.g.
```python
r = DetectorReader(names={"xymesh"})
r.names.add("spectrum")  # store the spectrum detector
r.names.remove("xymesh")  # don't store xy mesh
r.names.clear()  # empty set -> store everything
```
The default again is to store all detectors. Names can also be passed via `fromSerpent` with `DetectorFile.fromSerpent(source, names=["xymesh"])` and will be converted to a set.

## Design decisions

I tried to put as much of the auxiliary reading routines on the reader through "protected" static method, e.g. `DetectorReader._detectorFactory` is responsible for creating a detector based on the tallies and grids found in the file. This was to keep everything pretty contained on the reader, even though the two such methods `_detectorFactory` and `_clean` import from existing utilities. In the future, we should add that code directly on the reader rather than 
```python
def detectorFactory(...):
    # create a detector

class DetectorReader:
    ...
    @staticmethod
    def _detectorFactory(...):
        return detectorFactory(...)
```
This helps ensure that the detectors we create in this `next` module are consistent with those in the current API.

My biggest gripe, which may be a non-issue, is that the `DetectorFile.fromSerpent` and `DetectorReader.read` methods always return a `DetectorFile`, regardless of subclassing. What this means is a subclass of `DetectorFile` would not create it's own subclass calling `fromSerpent`, unless the method was over-written. As a better example,
```python
class A(DetectorFile):
    pass
class B(DetectorFile):
    @classmethod
    def fromSerpent(cls, *args, **kwargs):
        out = super().fromSerpent(*args, **kwargs)
        # coerce out -> cls to be of right type
        return cls(out, filename=out.filename)

a = A.fromSerpent(source)
b = B.fromSerpent(source)
isisinstance(a, A)
False
isinstance(b, B)
True
```
Similarly, subclasses of `DetectorReader` will always return a `DetectorFile` from the read methods. This is less of an issue, but it does make things a little bit less flexible. I tried a few fixes for the `DetectorFile` "issue", but I haven't found one that I like. I guess we could check if the type of what is returned from `DetectorReader.read` is `cls`, and then make adjustments there.

## To-do

This is a draft PR mainly to start a conversation with the development team and potential users. As such, the new classes are not formally documented nor tested. After deciding on the API, I will add documentation and testing before merging this PR. 

- [x] Testing
- [x] Documentation