### PR TITLE
BUG Capture full precision of scalars in ResultsReader

### DIFF
--- a/serpentTools/parsers/depletion.py
+++ b/serpentTools/parsers/depletion.py
@@ -262,7 +262,7 @@ class DepletionReader(DepPlotMixin, MaterialReader):
                 if varName == 'NAMES':
                     values = [item[1:item.find(" ")] for item in cleaned]
                 else:
-                    values = str2vec(cleaned, int, list)
+                    values = [int(v) for v in cleaned]
             else:
                 line = self._cleanSingleLine(chunk)
                 values = str2vec(line)

--- a/serpentTools/parsers/microxs.py
+++ b/serpentTools/parsers/microxs.py
@@ -128,8 +128,7 @@ class MicroXSReader(BaseReader):
         if 'E' in currVar.split('_')[-1]:  # e.g., NFY_902270_1E
             sclVal = SCALAR_REGEX.search(chunk[0])
             # energy must be stored on the reader
-            self._energyFY = float(str2vec(
-                chunk[0][sclVal.span()[0] + 1:sclVal.span()[1] - 2]))
+            self._energyFY = float(sclVal.groups()[1])
             return  # thermal/epi/fast
         for tline in chunk:
             if '[' in tline or ']' in tline:
@@ -152,7 +151,7 @@ class MicroXSReader(BaseReader):
         # obtain the universe id
         univ = currVar.split('_')[-1]
         search = VEC_REGEX.search(chunk0)  # group flux values
-        vals = str2vec(chunk0[search.span()[0] + 1:search.span()[1] - 2])
+        vals = str2vec(search.groups()[1])
         self.fluxRatio[univ], self.fluxUnc[univ] = splitValsUncs(vals)
 
     def _storeMicroXS(self, chunk):

--- a/serpentTools/parsers/microxs.py
+++ b/serpentTools/parsers/microxs.py
@@ -135,8 +135,9 @@ class MicroXSReader(BaseReader):
             if '[' in tline or ']' in tline:
                 continue
             tline = tline[:tline.find('%')]
-            if len(tline.split()) == 3:
-                val1, val2, val3 = str2vec(tline, out=list)
+            items = tline.split()
+            if len(items) == 3:
+                val1, val2, val3 = (float(i) for i in items)
                 fissProd.append(val1)
                 indYield.append(val2)
                 cumYield.append(val3)

--- a/serpentTools/parsers/results.py
+++ b/serpentTools/parsers/results.py
@@ -133,8 +133,8 @@ def varTypeFactory(key):
             return lambda x: (typeFunc(x), None)
     # Perform array conversion, return expected values and uncertainties
     if UNIV_K_RE.search(key) is not None:
-        return lambda x: str2vec(x, out=tuple)
-    return lambda x: splitValsUncs(x)
+        return lambda s: tuple(float(i) for i in s.split())
+    return splitValsUncs
 
 
 __all__ = ['ResultsReader', ]

--- a/serpentTools/parsers/results.py
+++ b/serpentTools/parsers/results.py
@@ -427,13 +427,13 @@ class ResultsReader(XSReader):
         varType, varVals = [], []
         if strMatch is not None:
             varType = 'string'
-            varVals = tline[strMatch.span()[0] + 1:strMatch.span()[1] - 1]
+            varVals = strMatch.groups()[1]
         elif vecMatch is not None:
             varType = 'vector'
-            varVals = tline[vecMatch.span()[0] + 1:vecMatch.span()[1] - 2]
+            varVals = vecMatch.groups()[1].strip()
         elif sclMatch is not None:
             varType = 'scalar'
-            varVals = tline[sclMatch.span()[0] + 1:sclMatch.span()[1] - 2]
+            varVals = sclMatch.groups()[1]
         return varType, varVals
 
     def getUniv(self, univ, burnup=None, index=None, timeDays=None):

--- a/serpentTools/parsers/sensitivity.py
+++ b/serpentTools/parsers/sensitivity.py
@@ -4,7 +4,7 @@ Class to read Sensitivity file
 from collections import OrderedDict
 from itertools import product
 
-from numpy import transpose, hstack
+from numpy import transpose, hstack, array
 from matplotlib.pyplot import gca, axvline
 
 from serpentTools.utils.plot import magicPlotDocDecorator, formatPlot
@@ -219,7 +219,7 @@ class SensitivityReader(BaseReader):
                                         "in energy chunk {}".format(chunk[:3]))
         splitLine = line.split()
         varName = splitLine[0].split('_')[1:]
-        varValues = str2vec(splitLine[3:-1])
+        varValues = array(splitLine[3:-1], dtype=float)
         if varName[0] == 'E':
             self.energies = varValues
         elif varName == ['LETHARGY', 'WIDTHS']:

--- a/serpentTools/utils/core.py
+++ b/serpentTools/utils/core.py
@@ -9,9 +9,9 @@ from numpy import array, ndarray, fromiter
 
 # Regular expressions
 
-STR_REGEX = compile(r'\'.+\'')  # string
-VEC_REGEX = compile(r'(?<==.)\[.+?\]')  # vector
-SCALAR_REGEX = compile(r'=.+;')  # scalar
+STR_REGEX = compile(r"([A-Z_]+).*'(.*)'")
+VEC_REGEX = compile(r"([A-Z_]+).*=\s+\[\s*([0-9-\+\.Ee ]+)\]")
+SCALAR_REGEX = compile(r"([A-Z_]+).*=\s+([0-9-\+Ee\.]+)")
 FIRST_WORD_REGEX = compile(r'^\w+')  # first word in the line
 
 

--- a/serpentTools/utils/core.py
+++ b/serpentTools/utils/core.py
@@ -15,62 +15,37 @@ SCALAR_REGEX = compile(r'=.+;')  # scalar
 FIRST_WORD_REGEX = compile(r'^\w+')  # first word in the line
 
 
-def str2vec(iterable, dtype=float, out=array):
+def str2vec(s, dtype=float):
     """
-    Convert a string or other iterable to vector.
+    Convert a string to a numpy array
 
     Parameters
     ----------
-    iterable: str or iterable
+    s : str
         If a string containing spaces, will be split using
         ```iterable.split()``. If no spaces are found, the
         outgoing type is filled with a single string, e.g.
         a list with a single string as the first and only
         entry. This is returned directly, avoiding conversion
-        with ``dtype``.
-        Every item in this split list, or original
-        iterable, will be iterated over and converted accoring
-        to the other arguments.
-    dtype: type
+        with ``dtype``. Every item in this split list will be iterated
+        over and converted according to the other arguments.
+    dtype : type
         Convert each value in ``iterable`` to this data type.
-    out: type
-        Return data type. Will be passed the iterable of
-        converted items of data dtype ``dtype``.
 
     Returns
     -------
-    vector
-        Iterable of all values of ``iterable``, or split variant,
-        converted to type ``dtype``.
+    numpy.ndarray
+        Vector of all the elements converted to ``dtype``
 
     Examples
     --------
-    ::
 
-        >>> v = "1 2 3 4"
-        >>> str2vec(v)
-        array([1., 2., 3., 4.,])
-
-        >>> str2vec(v, int, list)
-        [1, 2, 3, 4]
-
-        >>> x = [1, 2, 3, 4]
-        >>> str2vec(x)
-        array([1., 2., 3., 4.,])
-
-        >>> str2vec("ADF")
-        array(['ADF', dtype='<U3')
+    >>> v = "1 2 3 4"
+    >>> str2vec(v)
+    array([1., 2., 3., 4.,])
 
     """
-    if isinstance(iterable, str):
-        if ' ' in iterable:
-            iterable = iterable.split()
-        else:
-            return out([iterable])
-    cmap = map(dtype, iterable)
-    if out is array:
-        return fromiter(cmap, dtype)
-    return out(cmap)
+    return array(s.split(), dtype=dtype)
 
 
 def splitValsUncs(iterable, copy=False):

--- a/tests/test_pt_results.py
+++ b/tests/test_pt_results.py
@@ -1,0 +1,28 @@
+"""pytest tests for reading the result file"""
+
+import pytest
+import serpentTools.data
+from serpentTools.settings import rc
+
+
+@pytest.fixture(scope="module")
+def read_2_1_29():
+    with rc:
+        rc["serpentVersion"] = "2.1.29"
+        yield
+
+
+@pytest.fixture
+def fullPwrFile(read_2_1_29):
+    return serpentTools.data.readDataFile("pwr_res.m")
+
+
+def test_scalars(fullPwrFile):
+    """Ensure that the full precision of scalars are captured
+
+    Related: GH issue #411
+    """
+    assert fullPwrFile["miscMemsize"] == pytest.approx([6.59, 6.59], abs=0, rel=0)
+    assert fullPwrFile["availMem"] == pytest.approx([15935.20, 15935.20], abs=0, rel=0)
+    assert fullPwrFile["totCpuTime"] == pytest.approx([0.282078, 0.494889], abs=0, rel=0)
+

--- a/tests/test_pt_utils.py
+++ b/tests/test_pt_utils.py
@@ -1,0 +1,15 @@
+"""Tests for using utility features"""
+
+import pytest
+from numpy import random
+
+import serpentTools.utils as sutils
+
+
+@pytest.mark.parametrize("N", [1, 5, 10])
+def test_str2vec(N):
+    """Compare the string to vector conversion on a random vector"""
+    r = random.random(N)
+    s = " ".join(map(str, r))
+    v = sutils.str2vec(s)
+    assert v == pytest.approx(r, abs=0, rel=0)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -44,48 +44,6 @@ class VariableConverterTester(TestCase):
             self.assertEqual(expected, actual, msg=serpentStyle)
 
 
-class VectorConverterTester(TestCase):
-    """Class for testing the str2vec function"""
-
-    @classmethod
-    def setUpClass(cls):
-        cls.testCases = ("0 1 2 3", [0, 1, 2, 3], (0, 1, 2, 3), arange(4))
-
-    def test_str2Arrays(self):
-        """Verify that the str2vec converts to arrays."""
-        expected = arange(4)
-        for case in self.testCases:
-            actual = str2vec(case)
-            assert_array_equal(expected, actual, err_msg=case)
-
-    def test_listOfInts(self):
-        """Verify that a list of ints can be produced with str2vec."""
-        expected = [0, 1, 2, 3]
-        self._runConversionTest(int, expected, list)
-
-    def test_vecOfStr(self):
-        """Verify a single word can be converted with str2vec"""
-        key = 'ADF'
-        expected = array('ADF')
-        actual = str2vec(key)
-        assert_array_equal(expected, actual)
-
-    def _runConversionTest(self, valType, expected, outType=None):
-        if outType is None:
-            outType = array
-            compareType = ndarray
-        else:
-            compareType = outType
-        for case in self.testCases:
-            actual = str2vec(case, dtype=valType, out=outType)
-            self.assertIsInstance(actual, compareType, msg=case)
-            ofRightType = [isinstance(xx, valType) for xx in actual]
-            self.assertTrue(all(ofRightType),
-                            msg="{} -> {}, {}".format(case, actual,
-                                                      type(actual)))
-            self.assertEqual(expected, actual, msg=case)
-
-
 class SplitValsTester(TestCase):
     """Class that tests splitValsUncs."""
 


### PR DESCRIPTION
Closes #411 by using more complicated but powerful regular expressions to match 1) the Serpent variable name and 2) the desired string data from the result file. This removes a lot of the logic involving taking the span of the matched string, which led to the bug in the first place.

I also went down a small rabbit whole with the `str2vec` function, and decided to make it arguably less functional (no longer supporting arbitrary output type like list, tuple) but so much cleaner. The function is a single line now, rather than using a lot of conditional checks, which is great for a function that is called so so many times throughout the project. In fact, if we wanted to be real clever, we would just remove the function since it just does `numpy.array(s.split(), dtype=dtype)` where the `dtype` argument defaults to float. Neither here nor there.

This was motivated by the regular expressions not capturing some of the trailing / leading spaces, which caused `str2vec` to not call `iterable.split`, producing tons of arrays of strings which just broke a bunch of stuff down the road.

This PR is back compatible, but some people might see small changes in values (like memory size of 6.5**9** vs. 6.5) but that's what we're trying to fix here
