### PR TITLE
[BUG] Try using the whole string if getting PlotGrid fails using only the first letter. (issue #415)

### DIFF
--- a/serpentTools/detectors.py
+++ b/serpentTools/detectors.py
@@ -463,7 +463,11 @@ class Detector(NamedObject):
         return slices
 
     def _getPlotGrid(self, qty):
+        # Try with the first letter only
         grids = self.grids.get(qty[0].upper())
+        if grids is None:
+            # The phi-grid has three letters!
+            grids = self.grids.get(qty.upper())
         if grids is not None:
             return hstack((grids[:, 0], grids[-1, 1]))
         nItems = self.tallies.shape[self.indexes.index(qty)]


### PR DESCRIPTION
This is for issue #415.

After this PR, phi-axis can be read for plotting.




