### PR TITLE
DOC Update publications: main paper and AIAA NTP

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,7 +54,7 @@ citing with
 * Andrew Johnson, Dan Kotlyar, Stefano Terlizzi, and Gavin Ridley,
   "`serpentTools: A Python Package for Expediting Analysis with
   Serpent <https://doi.org/10.1080/00295639.2020.1723992>`_,"
-  *Nuc. Sci. Eng*, (in press) (2020).
+  *Nuc. Sci. Eng*, 2020, 194, 1016-1024
 
 Also, let us know if you publish work using this package! We try and
 keep an up-to-date list of works using serpentTools [2]_, and would be

--- a/docs/publications.rst
+++ b/docs/publications.rst
@@ -34,6 +34,12 @@ of metallic fuel sodium fast reactor*." `Annals of Nuclear Energy (2019)
 Conference
 ==========
 
+Victor Petitgenet, Christopher D. Roper, Matthew Krecicki, Andrew J. Yatsko,
+Dan Kotlyar, Dimitri N. Mavris, and David Shalat, "*A Coupled Approach
+to the Design Space Exploration of Nuclear Thermal Propulsion Systems*,"
+in proceedings of American Institute of Aeronautics and Astronautics,
+Virtual, 2020 https://doi.org/10.2514/6.2020-3846
+
 A. Johnson and D. Kotlyar, "*Application of a Custom Depletion Framework
 to the Prediction of Neutron Flux Distribution Through Depletion*,"
 in proceedings of PHYSOR 2020: Transition to a Scalable Nuclear


### PR DESCRIPTION
[Our primary journal paper](https://doi.org/10.1080/00295639.2020.1723992) has been properly published in a [special issue of NSE](https://www.tandfonline.com/toc/unse20/194/11) alongside other exception papers from M&C 2019. The main change to the reference is we now have proper volume, issue, and page numbers, rather than being in-pres

This PR also adds a conference paper by @DanKotlyar and @MattKrecicki :rocket: 