### PR TITLE
DOC Update publications, add USNC-Tech sponsored development

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -61,7 +61,7 @@ citing with
 * Andrew Johnson, Dan Kotlyar, Stefano Terlizzi, and Gavin Ridley,
   "`serpentTools: A Python Package for Expediting Analysis with
   Serpent <https://doi.org/10.1080/00295639.2020.1723992>`_,"
-  *Nuc. Sci. Eng*, (in press) (2020).
+  *Nuc. Sci. Eng*, (2020).
 
 Also, let us know if you publish work using this package! We try and
 keep an up-to-date list of works using serpentTools [2]_, and would be

--- a/README.rst
+++ b/README.rst
@@ -44,6 +44,13 @@ If you have issues installing the project, find a bug, or want to add a feature,
 the `GitHub issue page <https://github.com/CORE-GATECH-GROUP/serpent-tools/issues>`_
 is the best place to do that.
 
+Support
+=======
+
+The development of ``serpentTools`` is supported by the following organizations:
+
+* `USNC-Tech <https://usnc.com/space>`_
+
 References
 ==========
 

--- a/README.rst
+++ b/README.rst
@@ -71,4 +71,4 @@ happy to include more.
     development and applications in 2013." Ann. Nucl. Energy, `82 (2015) 142-150
     <http://www.sciencedirect.com/science/article/pii/S0306454914004095>`_
 
-.. [2] https://github.com/CORE-GATECH-GROUP/serpent-tools/wiki/Publications-using-serpentTools
+.. [2] https://serpent-tools.readthedocs.io/en/latest/publications.html

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -53,6 +53,13 @@ version, with links to earlier releases.
 
  .. _works using serpentTools: https://github.com/CORE-GATECH-GROUP/serpent-tools/wiki/Publications-using-serpentTools
 
+Support
+=======
+
+The development of ``serpentTools`` is supported by the following organizations:
+
+* `USNC-Tech <https://usnc.com/space>`_
+
 .. toctree::
    :maxdepth: 1
    :caption: Contents:

--- a/docs/publications.rst
+++ b/docs/publications.rst
@@ -12,7 +12,7 @@ Overview
 
 Andrew Johnson, Dan Kotlyar, Stefano Terlizzi, and Gavin Ridley,
 *"serpentTools: A Python Package for Expediting Analysis with Serpent*."
-`Nuclear Science and Engineering (in press) (2020)
+`Nuclear Science and Engineering (2020)
 <https://doi.org/10.1080/00295639.2020.1723992>`_
 
 Journal

--- a/docs/publications.rst
+++ b/docs/publications.rst
@@ -18,6 +18,18 @@ Andrew Johnson, Dan Kotlyar, Stefano Terlizzi, and Gavin Ridley,
 Journal
 =======
 
+A. Johnson and D. Kotlyar, "*Hybrid depletion framework using mixed-fidelity
+transport solutions and substeps*." `Annals of Nuclear Energy (2021)
+<https://doi.org/10.1016/j.anucene.2020.108120>`_
+
+J. Carter and R. Borrelli, "*Integral molten salt reactor temperature
+sensitivities using Serpent target motion sampling*." `Nuclear Engineering
+and Design (2020) <https://doi.org/10.1016/j.nucengdes.2020.110863>`_
+
+V. Mishra et al., "*Estimating gamma and neutron radiation fluxes around
+BWR quivers for nuclear safeguards verification purposes*." `Journal of Instrumentation
+(2020) <https://doi.org/10.1088/1748-0221/15/12/P12023>`_
+
 M. Krecicki and D. Kotlyar, "*Low enriched nuclear thermal propulsion
 neutronic, thermal hydraulic, and system design space analysis*."
 `Nuclear Engineering and Design (2020) <https://doi.org/10.1016/j.nucengdes.2020.110605>`_


### PR DESCRIPTION
Added three publications to `docs/publications.rst`

- A. Johnson and D. Kotlyar, "*Hybrid depletion framework using mixed-fidelity transport solutions and substeps*." [Annals of Nuclear Energy (2021)](https://doi.org/10.1016/j.anucene.2020.108120)
- J. Carter and R. Borrelli, "*Integral molten salt reactor temperature sensitivities using Serpent target motion sampling*." [Nuclear Engineering and Design (2020)](https://doi.org/10.1016/j.nucengdes.2020.110863)
- V. Mishra et al., "*Estimating gamma and neutron radiation fluxes around BWR quivers for nuclear safeguards verification purposes*." [Journal of Instrumentation (2020)](https://doi.org/10.1088/1748-0221/15/12/P12023)

Added a message to readme + docs/readme indicating that [USNC-Tech](https://usnc.com/space) is sponsoring development of this project.

Will cherry-pick these onto `master` after merging