### PR TITLE
DEV Support py39

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
         installer: [setup,sdist]
 
     name: 'Python ${{ matrix.python-version }} installer=${{ matrix.installer }}'

--- a/setup.py
+++ b/setup.py
@@ -36,12 +36,13 @@ classifiers = [
     'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',
+    'Programming Language :: Python :: 3.9',
 ]
 
 with open('./requirements.txt') as req:
     installRequires = req.read()
 
-pythonRequires = ">=3.5,<3.9"
+pythonRequires = ">=3.5"
 
 version = "0.9.3"
 


### PR DESCRIPTION
Closes #443 by removing the upper limit on python version. Github actions tests now include python 3.9