### PR TITLE
Minor tweaks before 0.9.4 release candidates

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -192,7 +192,7 @@ autodoc_default_options = {
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3.5', None),
     'matplotlib': ('https://matplotlib.org', None),
-    'numpy': ('https://docs.scipy.org/doc/numpy/', None),
+    'numpy': ('https://numpy.org/doc/stable/', None),
     'scipy': ('https://docs.scipy.org/doc/scipy/reference', None),
     'pandas': ('https://pandas.pydata.org/docs', None),
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 numpy>=1.16.0
-matplotlib>=2.2.3,<=3.3.4
+matplotlib>=2.2.3,!=3.3.4
 pyyaml>=5.1.1

--- a/serpentTools/parsers/sensitivity.py
+++ b/serpentTools/parsers/sensitivity.py
@@ -391,7 +391,7 @@ class SensitivityReader(BaseReader):
         {ylabel}
         {legend}
         {ncol}
-        {kwargs} :method:`matplotlib.pyplot.Axes.errorbar`
+        {kwargs} :meth:`matplotlib.pyplot.Axes.errorbar`
 
             .. versionadded: 0.9.4
 


### PR DESCRIPTION
- Change `:method:` directive to `:meth:` - closes #448 
- Update path to numpy objects file for intershinx
- Mark matplotlib 3.3.4 as incompatible with serpent-tools due to issues with yerr and errorbar