### PR TITLE
REL Release candidate 0.9.4rc0

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,6 +14,21 @@ Changelog
     existing structures. For more information, see
     :ref:`data-model`
 
+.. _v0.9.4:
+
+:release-tag:`0.9.4rc0`
+====================
+
+* Support for Serpent 2.1.32 via :ref:`settings`. 2.1.31 is still
+  default - :pull:`447`
+* Support for installing under python 3.9 - :pull:`444`
+* Various ``plot`` methods now support passing keword arguments to underlying
+  matplotlib plot routines
+
+  * :meth:`serpentTools.objects.HomogUniv.plot` - :pull:`432`
+  * :meth:`serpentTools.SensitivityReader.plot` - :pull:`434`
+  * :meth:`serpentTools.ResultsReader.plot` - :pull:`446`
+
 .. _v0.9.3:
 
 :release-tag:`0.9.3`

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -52,7 +52,7 @@ master_doc = 'index'
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 
-version = "0.9.3"
+version = "0.9.4rc0"
 
 # General information about the project.
 project = 'serpentTools'

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -214,7 +214,7 @@ Version of Serpent::
 
   Default: 2.1.31
   Type: str
-  Options: [2.1.29, 2.1.30, 2.1.31]
+  Options: [2.1.29, 2.1.30, 2.1.31, 2.1.32]
 
 .. _verbosity:
 

--- a/serpentTools/__init__.py
+++ b/serpentTools/__init__.py
@@ -7,4 +7,4 @@ from serpentTools.samplers import *
 from serpentTools.seed import *
 from serpentTools.xs import *
 
-__version__ = "0.9.3"
+__version__ = "0.9.4rc0"

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ with open('./requirements.txt') as req:
 
 pythonRequires = ">=3.5"
 
-version = "0.9.3"
+version = "0.9.4rc0"
 
 setupArgs = {
     'name': 'serpentTools',


### PR DESCRIPTION
This will be the first release candidate for [0.9.4](https://github.com/CORE-GATECH-GROUP/serpent-tools/milestone/17)

After this, the develop branch will be used for __all__ development going forward. I don't like having master and develop this far diverged. We don't move so fast between releases that we need the two separate branches

Once this is merged I will make a new tag and release on pypi. Users can then install with pip using either
```
pip install --pre serpentTools
```
or this specific version as
```
pip install serpentTools==0.9.4rc0
```