### PR TITLE
REL Release 0.9.4

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -16,14 +16,11 @@ Changelog
 
 .. _v0.9.4:
 
-:release-tag:`0.9.4rc1`
-=======================
+:release-tag:`0.9.4`
+====================
 
 * Normalize spectrum by maximum value or not at all - :pull:`457`
 * Support for reading ``pspec`` fields in xsplot files - :pull:`456`
-
-:release-tag:`0.9.4rc0`
-=======================
 
 * Support for Serpent 2.1.32 via :ref:`settings`. 2.1.31 is still
   default - :pull:`447`
@@ -34,6 +31,8 @@ Changelog
   * :meth:`serpentTools.objects.HomogUniv.plot` - :pull:`432`
   * :meth:`serpentTools.SensitivityReader.plot` - :pull:`434`
   * :meth:`serpentTools.ResultsReader.plot` - :pull:`446`
+
+Supported by releases :release-tag:`0.9.4rc0` and :release-tag:`0.9.4rc1`
 
 .. _v0.9.3:
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -52,7 +52,7 @@ master_doc = 'index'
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 
-version = "0.9.4rc1"
+version = "0.9.4"
 
 # General information about the project.
 project = 'serpentTools'

--- a/serpentTools/__init__.py
+++ b/serpentTools/__init__.py
@@ -7,4 +7,4 @@ from serpentTools.samplers import *
 from serpentTools.seed import *
 from serpentTools.xs import *
 
-__version__ = "0.9.4rc1"
+__version__ = "0.9.4"

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ with open('./requirements.txt') as req:
 
 pythonRequires = ">=3.5"
 
-version = "0.9.4rc1"
+version = "0.9.4"
 
 setupArgs = {
     'name': 'serpentTools',


### PR DESCRIPTION
After this, a new release will be created on github and a new tag corresponding to version `0.9.4`. The version will be pushed to pypi (hopefully) this week