### PR TITLE
API Allow pathlib.Path arguments to readers

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,15 +25,15 @@ Welcome to serpentTools's documentation!
        :alt: Nuclear Science and Engineering 10.1080/00295639.2020.1723992
 
 A suite of parsers designed to make interacting with
-:term:`SERPENT` [serpent]_ output files simple and flawless. 
+:term:`SERPENT` [serpent]_ output files simple and flawless.
 
 The :term:`SERPENT` Monte Carlo code
 is developed by VTT Technical Research Centre of Finland, Ltd.
 More information, including distribution and licensing of :term:`SERPENT` can be
 found at `<http://montecarlo.vtt.fi>`_
 
-The Annals of Nuclear Energy article should be cited for all work
-using :term:`SERPENT`. 
+The Nuclear Science and Engineering article should be cited for all work
+using :term:`SERPENT`.
 
 .. admonition:: Preferred citation for attribution
     :class: tip
@@ -41,13 +41,13 @@ using :term:`SERPENT`.
     Andrew Johnson, Dan Kotlyar, Stefano Terlizzi, and Gavin Ridley,
     "`serpentTools: A Python Package for Expediting Analysis with
     Serpent <https://doi.org/10.1080/00295639.2020.1723992>`_,"
-    *Nuc. Sci. Eng*, (in press) (2020).
+    *Nuc. Sci. Eng*, **194** (11), pp. 1016-1024 (2020).
 
 Also, let us know if you publish work using this package! We try and
 keep an up-to-date list of `works using serpentTools`_, and would be
 happy to include more.
 
-If you want to refer to a specific version, follow the `Zenodo DOI 
+If you want to refer to a specific version, follow the `Zenodo DOI
 <https://doi.org/10.5281/zenodo.1301035>`_. This will resolve to the latest
 version, with links to earlier releases.
 

--- a/serpentTools/parsers/__init__.py
+++ b/serpentTools/parsers/__init__.py
@@ -65,7 +65,7 @@ def inferReader(filePath):
 
     Parameters
     ----------
-    filePath: str
+    filePath: str or path-like
         File to be read.
 
     Raises
@@ -73,6 +73,7 @@ def inferReader(filePath):
     SerpentToolsException
         If a reader cannot be inferred
     """
+    filePath = str(filePath)
     for reg, reader in REGEXES.items():
         match = re.match(reg, filePath)
         if match and match.group() == filePath:

--- a/serpentTools/parsers/base.py
+++ b/serpentTools/parsers/base.py
@@ -21,13 +21,14 @@ class BaseReader(ABC, BaseObject):
 
     Parameters
     ----------
-    filePath: str
+    filePath: str or path-like
         path pointing towards the file to be read
     readerSettingsLevel: str or list
         type of reader. Determines which settings to obtain
     """
 
     def __init__(self, filePath, readerSettingsLevel):
+        filePath = str(filePath)
         self.filePath = filePath
         if isinstance(readerSettingsLevel, str):
             self.settings = rc.getReaderSettings(readerSettingsLevel)


### PR DESCRIPTION
This PR makes a small change to allow `Path` objects to be passed to either `serpentTools.read(...)` or to the reader classes themselves. I'm not sure if there are other places that accept file paths -- if so, let me know and I can update those as well.

I've also updated the citation information in the docs, which I noticed was out of date.
