### PR TITLE
BUG SensitivityReader.plot uses absolute value for yerr

### DIFF
--- a/serpentTools/parsers/sensitivity.py
+++ b/serpentTools/parsers/sensitivity.py
@@ -4,7 +4,7 @@ Class to read Sensitivity file
 from collections import OrderedDict
 from itertools import product
 
-from numpy import transpose, hstack
+from numpy import transpose, hstack, fabs
 from matplotlib.pyplot import gca
 
 from serpentTools.utils.plot import magicPlotDocDecorator, formatPlot
@@ -450,7 +450,7 @@ class SensitivityReader(BaseReader):
             yVals = values[iM, iZ, iP]
             yVals = hstack((yVals, yVals[-1]))
             yErrs = errors[iM, iZ, iP]
-            yErrs = hstack((yErrs, yErrs[-1]))
+            yErrs = fabs(hstack((yErrs, yErrs[-1])))
             label = labelFmt.format(r=resp, z=z, m=m, p=p)
             ax.errorbar(energies, yVals, yErrs, label=label, **kwargs)
 


### PR DESCRIPTION
Avoids error in `matplotlib>=3.6` where yerr must have positive values.

Closes #469 

For bug fixes and enhancements, link to the corresponding issue.

Make sure you have read over the developer guide to ease
the review process. These include:

- [x] PR fits the [project scope](http://serpent-tools.readthedocs.io/en/latest/develop/contributing.html#project-scope)
- [x] Code to be committed is [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) and matches the [code style](http://serpent-tools.readthedocs.io/en/latest/develop/codestyle.html#code-style) of the project
- [x] New and/or changed features are [well documented](http://serpent-tools.readthedocs.io/en/latest/develop/documentation.html#documentation) and have adequate testing
- [x] For first-time contributors, you have included your attribution in [`docs/contributors.rst`](https://github.com/CORE-GATECH-GROUP/serpent-tools/blob/develop/docs/contributors.rst)