### PR TITLE
ENH ResultsReader supports Serpent 2.2.0

### DIFF
--- a/serpentTools/parsers/results.py
+++ b/serpentTools/parsers/results.py
@@ -48,12 +48,13 @@ MapStrVersions = {
         'varsUnc': ['MICRO_NG', 'MICRO_E', 'MACRO_NG', 'MACRO_E'],
     },
 }
-MapStrVersions['2.1.30'] = MapStrVersions['2.1.29']
-MapStrVersions['2.1.31'] = MapStrVersions['2.1.29']
-MapStrVersions['2.1.32'] = MapStrVersions['2.1.29']
 """
 Assigns search strings for different Serpent versions
 """
+MapStrVersions['2.1.30'] = MapStrVersions['2.1.29']
+MapStrVersions['2.1.31'] = MapStrVersions['2.1.29']
+MapStrVersions['2.1.32'] = MapStrVersions['2.1.29']
+MapStrVersions['2.2.0'] = MapStrVersions['2.1.32']
 
 METADATA_CONV = {
     int: {

--- a/serpentTools/settings.py
+++ b/serpentTools/settings.py
@@ -106,7 +106,7 @@ defaultSettings = {
     },
     'serpentVersion': {
         'default': '2.1.31',
-        'options': ['2.1.29', '2.1.30', '2.1.31', '2.1.32'],
+        'options': ['2.1.29', '2.1.30', '2.1.31', '2.1.32', "2.2.0"],
         # When adding new version of Serpent, add / update
         # MapStrVersions with variables that indicate the start of specific
         # data blocks / time parameters like burnup

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -2,10 +2,13 @@ import re
 import os
 from os.path import join as pjoin
 from tempfile import TemporaryDirectory
+from pathlib import Path
 
 import numpy
 import pytest
 import serpentTools
+
+from . import LoggerMixin
 
 
 @pytest.fixture
@@ -55,8 +58,8 @@ def fake2132File(tdir):
     newfile = pjoin(tdir, "InnerAssembly_2132_res.m")
     with open(newfile, "w") as ostream, open(basefile, "r") as istream:
         for line in istream:
-            if "2.1.31" in line:
-                ostream.write(line.replace("2.1.31", "2.1.32"))
+            if "2.1.30" in line:
+                ostream.write(line.replace("2.1.30", "2.1.32"))
             else:
                 ostream.write(line)
             if line.startswith("BURN_STEP"):
@@ -90,3 +93,33 @@ def test_2132_filterburnup(fake2132File):
     assert "burnDays" in reader.resdata
     assert "absKeff" in reader.resdata
     assert "pop" not in reader.metadata
+
+
+@pytest.fixture
+def fake220File(tmp_path: Path) -> str:
+    fname = "InnerAssembly_res.m"
+    originalFile = serpentTools.data.getFile(fname)
+    newFile = tmp_path / fname
+
+    with open(originalFile) as orig, newFile.open("w") as wstream:
+        for line in orig:
+            if "2.1.30" not in line:
+                wstream.write(line)
+            else:
+                wstream.write(line.replace("2.1.30", "2.2.0"))
+    yield str(newFile)
+
+
+@pytest.fixture
+def logInterceptor() -> LoggerMixin:
+    logger = LoggerMixin()
+    logger.attach()
+    yield logger
+    logger.detach()
+
+
+def test_nowarns_220(fake220File: str, logInterceptor: LoggerMixin):
+    with serpentTools.settings.rc as rc:
+        rc["serpentVersion"] = "2.2.0"
+        serpentTools.read(fake220File, "results")
+    assert not logInterceptor.handler.logMessages

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -164,3 +164,8 @@ class ConfigLoaderTester(TestCaseWithLogCapture):
         self._writeTestRemoveConfFile(badSettings, self.files['nested'],
                                       self.configSettings, False)
         self.assertMsgInLogs("ERROR", "bad setting", partial=True)
+
+
+def test_supports_2_2():
+    with settings.rc as rc:
+        rc["serpentVersion"] = "2.2.0"


### PR DESCRIPTION
Closes #467

For bug fixes and enhancements, link to the corresponding issue.

Make sure you have read over the developer guide to ease
the review process. These include:

- [x] PR fits the [project scope](http://serpent-tools.readthedocs.io/en/latest/develop/contributing.html#project-scope)
- [x] Code to be committed is [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) and matches the [code style](http://serpent-tools.readthedocs.io/en/latest/develop/codestyle.html#code-style) of the project
- [x] New and/or changed features are [well documented](http://serpent-tools.readthedocs.io/en/latest/develop/documentation.html#documentation) and have adequate testing
- [x] For first-time contributors, you have included your attribution in [`docs/contributors.rst`](https://github.com/CORE-GATECH-GROUP/serpent-tools/blob/develop/docs/contributors.rst)

Include a thorough and concise overview of the changes, and why this PR is overall beneficial to the project.

Once the PR has been created and is nearing closure, make sure that serious changes, including deprecations and incompatible changes are documented in [the changelog](https://github.com/CORE-GATECH-GROUP/serpent-tools/blob/develop/docs/changelog.rst)
