### PR TITLE
[ENH] Sensitivity DataFrame

### DIFF
--- a/docs/contributors.rst
+++ b/docs/contributors.rst
@@ -13,3 +13,4 @@ Here are all the wonderful people that helped make this project happen
 * `Paul Romano <https://github.com/paulromano>`_
 * `Anton Travleev <https://github.com/travleev>`_
 * `@nicolaborate <https://github.com/nicoloabrate>`_ 
+* `Federico Grimaldi <https://github.com/GrimFe>`_ 

--- a/serpentTools/parsers/sensitivity.py
+++ b/serpentTools/parsers/sensitivity.py
@@ -456,6 +456,39 @@ class SensitivityReader(BaseReader):
                            "{}".format(', '.join(missing)))
         return requested
 
+    def toDataFrame(self, columns=["MAT", "ZAI", "PERT", "ENE", "S", "rel_unc", "RESP"]):
+        """
+        Create a pandas DataFrame for the sensitivities
+
+
+        Parameters
+        ----------
+        columns : sequence of str, optional
+            Names for the columns of the output dataframe.
+            Default is ``["MAT", "ZAI", "PERT", "ENE", "S", "rel_unc", "RESP"]``
+
+        Returns
+        -------
+        pandas.DataFrame
+            2D tabulated representation of the sensitivity. Columns reflect
+            materials, zais, perts, energies, sensitivity, relative uncertainty
+            and response
+
+        """
+        import pandas as pd
+        out = []
+        size = self.nMat * self.nZai * self.nPert * self.nEne
+        idx = pd.MultiIndex.from_product([self.materials.keys(),
+                                          self.zais,
+                                          self.perts,
+                                          self.energies[1:]])
+        for k, v in self.sensitivities.items():
+            out.append(pd.DataFrame(v.reshape(size, 2),
+                                    index=idx
+                                    ).reset_index().assign(Response=k))
+        out = pd.concat(out, ignore_index=True)
+        out.columns = columns
+        return out
 
 def reshapePermuteSensMat(vec, newShape):
     """


### PR DESCRIPTION
Please add the appropriate tag to the beginning of the title of your PR:

The `toDataFrame` method was added to the `SensitivityReader` class.
This allows for easy energy dependent sensitivity manipulation in a pandas context and follows what was implemented for the `DepletedMaterial` class.
