### PR TITLE
[ENH] Test against python 3.10 and python 3.11

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -32,7 +32,10 @@ jobs:
           python-version: ${{ matrix.python-version }}
       -
         name: Prep environment
-        run: sudo apt-get install libopenblas-dev
+        # pip install scipy for py3.11 hasn't worked well
+        # we don't need a lot of specific versions here, so
+        # just grab _a_ scipy from the package manager
+        run: sudo apt-get install python3-scipy
 
       -
         name: install

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, 3.10, 3.11]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     name: 'Python ${{ matrix.python-version }}'
 

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: [3.8, 3.9, 3.10, 3.11]
 
     name: 'Python ${{ matrix.python-version }}'
 

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -30,6 +30,9 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+      -
+        name: Prep environment
+        run: sudo apt-get install libopenblas-dev
 
       -
         name: install

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -32,10 +32,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       -
         name: Prep environment
-        # pip install scipy for py3.11 hasn't worked well
-        # we don't need a lot of specific versions here, so
-        # just grab _a_ scipy from the package manager
-        run: sudo apt-get install python3-scipy
+        run: sudo apt-get install libopenblas-dev
 
       -
         name: install

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -42,7 +42,7 @@ jobs:
       -
         name: unit tests
         shell: bash
-        run: pytest --cov=serpentTools --cov-report= -v
+        run: pytest -v
 
       -
         name: artifacts
@@ -52,9 +52,3 @@ jobs:
             name: test-images-${{ matrix.python-version }}
             path: |
                 tests/plots/result_images/*png
-
-      -
-        name: after
-        shell: bash
-        run: |
-          coverage report

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -37,9 +37,7 @@ jobs:
       -
         name: install
         shell: bash
-        run: |
-          pip install "numpy>=1.16.0" scipy "pandas>=1,<2"
-          pip install ".[extras,test,ci]"
+        run: pip install ".[extras,test,ci]"
 
       -
         name: unit tests

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -37,7 +37,7 @@ jobs:
       -
         name: install
         shell: bash
-        run: pip install ".[extras,test,ci]"
+        run: pip3 install ".[extras,test,ci]"
 
       -
         name: unit tests

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -37,7 +37,9 @@ jobs:
       -
         name: install
         shell: bash
-        run: pip install ".[extras,test,ci]"
+        run: |
+          pip install "numpy>=1.16.0" scipy "pandas>=1,<2"
+          pip install ".[extras,test,ci]"
 
       -
         name: unit tests

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -30,19 +30,16 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      -
-        name: Prep environment
-        run: sudo apt-get install libopenblas-dev
 
       -
         name: install
         shell: bash
-        run: pip3 install ".[extras,test,ci]"
+        run: pip install ".[extras,test,ci]"
 
       -
         name: unit tests
         shell: bash
-        run: pytest -v
+        run: pytest --cov=serpentTools --cov-report= -v
 
       -
         name: artifacts
@@ -52,3 +49,9 @@ jobs:
             name: test-images-${{ matrix.python-version }}
             path: |
                 tests/plots/result_images/*png
+
+      -
+        name: after
+        shell: bash
+        run: |
+          coverage report

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=61.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
 
 [project.optional-dependencies]
 extras = ["pandas>1", "scipy"]
-test = ["pytest>=6", "pytest-cov", "coverage"]
+test = ["pytest>=6"]
 ci = ["jupyter"]
 
 [tool.setuptools]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0", "wheel"]
+requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -38,7 +38,7 @@ dependencies = [
 
 [project.optional-dependencies]
 extras = ["pandas>1", "scipy"]
-test = ["pytest>=6"]
+test = ["pytest>=6", "pytest-cov", "coverage"]
 ci = ["jupyter"]
 
 [tool.setuptools]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,14 @@ dependencies = [
 "Bug Tracker" = "https://github.com/CORE-GATECH-GROUP/serpent-tools/issues"
 
 [project.optional-dependencies]
-extras = ["pandas>1", "scipy"]
+extras = [
+    "pandas>1",
+    # Add conditional to still get scipy
+    # but we need a version with wheels to avoid building from
+    # scratch in CI
+    "scipy;python_version<3.11",
+    "scipy>=1.9.2;python_version==3.11",
+]
 test = ["pytest>=6"]
 ci = ["jupyter"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,14 +37,7 @@ dependencies = [
 "Bug Tracker" = "https://github.com/CORE-GATECH-GROUP/serpent-tools/issues"
 
 [project.optional-dependencies]
-extras = [
-    "pandas>1",
-    # Add conditional to still get scipy
-    # but we need a version with wheels to avoid building from
-    # scratch in CI
-    "scipy;python_version<3.11",
-    "scipy>=1.9.2;python_version==3.11",
-]
+extras = ["pandas>1", "scipy"]
 test = ["pytest>=6"]
 ci = ["jupyter"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ maintainers = [
 ]
 description = "A suite of parsers designed to make interacting with Serpent output files simple, scriptable, and flawless"
 readme = "README.rst"
-requires-python = ">=3.8,<=3.11"
+requires-python = ">=3.8,<3.12"
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Education",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ maintainers = [
 ]
 description = "A suite of parsers designed to make interacting with Serpent output files simple, scriptable, and flawless"
 readme = "README.rst"
-requires-python = ">=3.8,<3.10"
+requires-python = ">=3.8,<=3.11"
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Education",
@@ -21,6 +21,8 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
 ]
 license = {file = "LICENSE"}
 dependencies = [


### PR DESCRIPTION
Closes #482 by testing against python 3.10 and python 3.11 in our CI test suite

- [x] PR fits the [project scope](http://serpent-tools.readthedocs.io/en/latest/develop/contributing.html#project-scope)
- [x] Code to be committed is [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) and matches the [code style](http://serpent-tools.readthedocs.io/en/latest/develop/codestyle.html#code-style) of the project
- [x] New and/or changed features are [well documented](http://serpent-tools.readthedocs.io/en/latest/develop/documentation.html#documentation) and have adequate testing
- [x] For first-time contributors, you have included your attribution in [`docs/contributors.rst`](https://github.com/CORE-GATECH-GROUP/serpent-tools/blob/develop/docs/contributors.rst)
