### PR TITLE
ENH: Reinstate ci testing for jupyter notebooks

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -36,6 +36,10 @@ jobs:
         shell: bash
         run: pip install ".[extras,test,ci]"
 
+      - name: debug python install
+        working-directory: /tmp
+        run: python -c "import serpentTools"
+
       -
         name: unit tests
         shell: bash

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -42,6 +42,11 @@ jobs:
         run: pytest --cov=serpentTools --cov-report= -v
 
       -
+        name: notebooks
+        shell: bash
+        run: cd examples && jupyter execute *ipynb
+
+      -
         name: artifacts
         uses: actions/upload-artifact@v3
         if: failure()  # only if the previous step failed

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -44,7 +44,14 @@ jobs:
       -
         name: notebooks
         shell: bash
-        run: cd examples && jupyter execute *ipynb
+        # Workaround to prepend repository to python path
+        # to resolve an issue importing serpenttools after
+        # installing. Should be removed with a src-layout
+        # https://github.com/CORE-GATECH-GROUP/serpent-tools/issues/499
+        run: |
+          export PYTHONPATH=${GITHUB_WORKSPACE}:${PYTHONPATH}
+          cd examples
+          jupyter execute *ipynb
 
       -
         name: artifacts

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -36,10 +36,6 @@ jobs:
         shell: bash
         run: pip install ".[extras,test,ci]"
 
-      - name: debug python install
-        working-directory: /tmp
-        run: python -c "import serpentTools"
-
       -
         name: unit tests
         shell: bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,6 @@ serpentTools = ["variables.yaml"]
 
 [tool.setuptools.packages.find]
 where = ["serpentTools"]
-include = ["serpentTools*"]
 
 [tool.pytest.ini_options]
 markers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ serpentTools = ["variables.yaml"]
 
 [tool.setuptools.packages.find]
 where = ["serpentTools"]
+include = ["serpentTools*"]
 
 [tool.pytest.ini_options]
 markers = [


### PR DESCRIPTION
Closes #484 when CI pass

- [x] PR fits the [project scope](http://serpent-tools.readthedocs.io/en/latest/develop/contributing.html#project-scope)
- [x] Code to be committed is [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) and matches the [code style](http://serpent-tools.readthedocs.io/en/latest/develop/codestyle.html#code-style) of the project
- [x] New and/or changed features are [well documented](http://serpent-tools.readthedocs.io/en/latest/develop/documentation.html#documentation) and have adequate testing
- [x] For first-time contributors, you have included your attribution in [`docs/contributors.rst`](https://github.com/CORE-GATECH-GROUP/serpent-tools/blob/develop/docs/contributors.rst)
