### PR TITLE
[DEV] Dynamic package version based on git history

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -72,7 +72,7 @@ del devTeamLink
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "english"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -52,7 +52,9 @@ master_doc = 'index'
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 
-version = "0.9.5"
+from importlib.metadata import version
+release = version("serpentTools")
+version = release
 
 # General information about the project.
 project = 'serpentTools'

--- a/docs/develop/git.rst
+++ b/docs/develop/git.rst
@@ -52,15 +52,8 @@ of a painless release.
 Updating the package version
 ----------------------------
 
-Before and after a release, the project version number should be updated in the
-following places:
-
-1. ``setup.py``
-2. ``serpentTools/__init__.py``
-3. ``docs/conf.py``
-
-The new version should be indicative of the changes introduced between this release
-and the previous release.
+Package version is pulled using ``setuptools-scm`` based on git tags. Therefore nothing
+is needed to be changed in order to change the version. Only the creation of new tags.
 
 Generating distributions
 ------------------------

--- a/docs/develop/git.rst
+++ b/docs/develop/git.rst
@@ -6,20 +6,10 @@ Version Control
 
 ``serpentTools`` uses :term:`git` for version control. All the source
 code can be found at https://github.com/CORE-GATECH-GROUP/serpent-tools.
-Two main branches are provided: ``master`` and ``develop``, and the
-`git flow <https://nvie.com/posts/a-successful-git-branching-model/>`_ branching
-model is followed.
-The ``master`` branch should be considered stable and updated coincident with
-each release.
-The ``develop`` branch is updated with more frequency as features are introduced.
-This is the main branch of the project, and features should be introduced off
-of this branch.
 
 ``serpentTools`` follows the `semantic versioning <https://semver.org/>`_
-system, where the version number as found in ``setup.py``,
-``serpentTools/__init__.py``, and ``docs/conf.py`` has the following form:
-``major.minor.patch``, e.g. ``0.8.0`` or ``1.1.20``. Each of the numbers
-should be incremented prior to new releases with the following designation:
+system, where the released versions have the following form
+``{major}.{minor}.{patch}``, where
 
 1. Changes that are not backwards compatible should be denoted by
    incrementing the major number.
@@ -28,10 +18,23 @@ should be incremented prior to new releases with the following designation:
 3. Changes that are largely internal and not recognizable by end-users should
    be denoted by incrementing the patch number
 
-.. note::
+Prior to a release, there may be pre-releases made signified with a "release candidate"
+label. These can be identified with a trailing ``.rc.{N}`` e.g., ``0.10.0.rc.5`` would be
+the fifth release candidate for version ``0.10.0``.
 
-    Until a stable 1.0.0 release, the positions are essentially shifted,
-    e.g. the version is ``0.major.minor``
+For developers and users who are using the "bleeding edge" version straight from source
+between releases, the version string may be more complex. As this is being written,
+the version string is ``0.9.6.dev14+g0d7b6d6.d20230811``. The most recent release
+from the time of this writing was ``0.9.5``, so the first part ``0.9.6.dev`` means
+we are ahead of version ``0.9.5``, and does not mean the next version **must** be
+``0.9.6``.
+
+The ``.dev14+g0d7b6b6`` indicates we are currently ``14`` commits ahead of the last
+tag, and the content following the ``+g`` is the SHA-1 hash of the most recent
+commit.
+
+Finally, if we have any uncommitted changes, the version string will conclude with
+an indicator of the installed date. Which in this case is August 11th, 2023.
 
 .. _dev-release:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,11 @@
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=61.0", "setuptools_scm[toml]>=6.2"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "serpentTools"
-version = "0.9.5"
+# Let setuptools-scm pick up version data
+dynamic = ["version"]
 maintainers = [
     {name="Dan Kotlyar"},
     {name="Drew Johnson"},
@@ -50,6 +51,10 @@ serpentTools = ["variables.yaml"]
 
 [tool.setuptools.packages.find]
 where = ["serpentTools"]
+
+# This is okay to be empty, but we need a section here
+# in order to trigger it's usage when setting version data
+[tool.setuptools_scm]
 
 [tool.pytest.ini_options]
 markers = [

--- a/serpentTools/__init__.py
+++ b/serpentTools/__init__.py
@@ -1,4 +1,12 @@
 # flake8: noqa
+from importlib.metadata import version, PackageNotFoundError
+try:
+    __version__ = version(__package__)
+except PackageNotFoundError:
+    __version__ = "ERROR"
+
+del PackageNotFoundError, version
+
 from serpentTools.detectors import *
 from serpentTools.parsers import *
 from serpentTools.messages import *
@@ -6,5 +14,3 @@ from serpentTools.data import *
 from serpentTools.samplers import *
 from serpentTools.seed import *
 from serpentTools.xs import *
-
-__version__ = "0.9.5"


### PR DESCRIPTION
Chose to use `setuptools-scm` because it's pretty snazzy and doesn't require lots of config files like versioneer does. Or use to require.

Version information is pulled from `git tags` with the following logic. If you are exactly on a tag, e.g., a release, the version is the tag. Otherwise, information is added to the version to signal you are so many commits ahead of the last release, and sometimes the day on which you installed the package. So, right now, I have `0.9.6.dev15+g4379676` because
1. I am not the most recent tag `0.9.5`
2. I am 15 commits ahead of the tag
3. My last commit was 4379676

Sometimes, if you have uncommitted changes, there will be a trailing date marker like `.d20230811`.

- [x] PR fits the [project scope](http://serpent-tools.readthedocs.io/en/latest/develop/contributing.html#project-scope)
- [x] Code to be committed is [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) and matches the [code style](http://serpent-tools.readthedocs.io/en/latest/develop/codestyle.html#code-style) of the project
- [x] New and/or changed features are [well documented](http://serpent-tools.readthedocs.io/en/latest/develop/documentation.html#documentation) and have adequate testing
- [x] For first-time contributors, you have included your attribution in [`docs/contributors.rst`](https://github.com/CORE-GATECH-GROUP/serpent-tools/blob/develop/docs/contributors.rst)

Closes #488 