### PR TITLE
[REL] Prepare for 0.9.6 release

### DIFF
--- a/docs/develop/checklist.rst
+++ b/docs/develop/checklist.rst
@@ -61,7 +61,7 @@ in the package. These are converted to be used in our main documentation, and se
 as a handy way for new users to discover the features provided with ``serpentTools``.
 In order to ensure that these are valid notebooks as changes are introduced, our :term:`CI`
 converts these to python scripts and runs them using 
-`the test notebooks script <https://github.com/CORE-GATECH-GROUP/serpent-tools/blob/develop/scripts/travis/testNotebooks.sh>`_. 
+``jupyter execute``.
 It is beneficial to run this script during major changes to the API, as well as correcting any
 errors or deprecated/removed features.
 

--- a/docs/develop/checklist.rst
+++ b/docs/develop/checklist.rst
@@ -81,7 +81,7 @@ the lint that would be introduced with
 
 .. code::
 
-    $ git diff --unified=0 develop | flake8 --diff
+    $ git diff --unified=0 main | flake8 --diff
 
-Here, ``develop`` is the intended target branch into which these changes
+Here, ``main`` is the intended target branch into which these changes
 will be merged.

--- a/docs/develop/contributing.rst
+++ b/docs/develop/contributing.rst
@@ -63,7 +63,7 @@ Pull Requests
 =============
 
 Pull requests are how we review, approve, and incorporate changes into
-the ``master`` branch. If you have code you want to
+the ``main`` branch. If you have code you want to
 contribute, please look at the content in the :ref:`dev-guide`
 for things like :ref:`pr-checklist`, :ref:`code-style`, and more.
 
@@ -73,14 +73,9 @@ and make a request!
 Someone of the core development team will review the changes according
 to the criteria above and make changes and/or approve for merging!
 
-The ``develop`` branch is the primary branch for this project.
+The ``main`` branch is the primary branch for this project.
 All pull requests, except for bugs on public releases, should be compared against this branch.
 When a pull request is approved and has passed the required checks, it should be 
-`squashed and merged <https://github.com/blog/2141-squash-your-commits>`_ into the develop branch.
-Squashing a branch converts a series of commits into a single commit onto the main branch,
-creating a tidy git history.
-
-For pull requests into ``master``, as in releases, these should simply be merged without squashing.
-When viewing the ``git log`` on the ``master`` or ``develop`` branches, one is presented only with
-approved and closed pull requests, not incremental commits that led to a PR being closed.
-
+`squashed and merged <https://github.com/blog/2141-squash-your-commits>`_ into the
+``main`` branch.  Squashing a branch converts a series of commits into a single commit
+onto the main branch, creating a tidy git history.

--- a/docs/develop/git.rst
+++ b/docs/develop/git.rst
@@ -6,14 +6,6 @@ Version Control
 
 ``serpentTools`` uses :term:`git` for version control. All the source
 code can be found at https://github.com/CORE-GATECH-GROUP/serpent-tools.
-Two main branches are provided: ``master`` and ``develop``, and the
-`git flow <https://nvie.com/posts/a-successful-git-branching-model/>`_ branching
-model is followed.
-The ``master`` branch should be considered stable and updated coincident with
-each release.
-The ``develop`` branch is updated with more frequency as features are introduced.
-This is the main branch of the project, and features should be introduced off
-of this branch.
 
 ``serpentTools`` follows the `semantic versioning <https://semver.org/>`_
 system, where the version number as found in ``setup.py``,

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,10 +8,6 @@ Welcome to serpentTools's documentation!
 
 .. only:: html
 
-    .. image:: https://travis-ci.org/CORE-GATECH-GROUP/serpent-tools.svg?branch=develop
-        :target: https://travis-ci.org/CORE-GATECH-GROUP/serpent-tools
-        :alt: Build status - develop
-
     .. image:: https://readthedocs.org/projects/serpent-tools/badge/?version=latest
         :target: http://serpent-tools.readthedocs.io/en/latest/?badge=latest
         :alt: Documentation Status


### PR DESCRIPTION
Want to get support for newer python versions out the door in a smaller release. Then, larger features like those requested in issues can be picked up

- [x] PR fits the [project scope](http://serpent-tools.readthedocs.io/en/latest/develop/contributing.html#project-scope)
- [x] Code to be committed is [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) and matches the [code style](http://serpent-tools.readthedocs.io/en/latest/develop/codestyle.html#code-style) of the project
- [x] New and/or changed features are [well documented](http://serpent-tools.readthedocs.io/en/latest/develop/documentation.html#documentation) and have adequate testing
- [x] For first-time contributors, you have included your attribution in [`docs/contributors.rst`](https://github.com/CORE-GATECH-GROUP/serpent-tools/blob/develop/docs/contributors.rst)
