### PR TITLE
ENH: Support passing depletion reader settings at construction

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,13 @@
 Changelog
 =========
 
+.. _v0.11.0:
+
+0.11.0
+======
+
+* Depletion reader settings can be provided at construction - :pull:`516`
+
 .. _v0.10.1:
 
 :release-tag:`0.10.1`

--- a/src/serpentTools/parsers/depletion.py
+++ b/src/serpentTools/parsers/depletion.py
@@ -154,6 +154,11 @@ class DepletionReader(DepPlotMixin, MaterialReader):
         But ``["fuel.*"]`` is a pattern that will match and collect any
         material that begins with ``fuel``. If not provided,
         pulls from ``depletion.materials`` setting.
+    materialVariables : list of string, optional
+        Names of variables to pull for each processed material. List can
+        contain zero or more entries like ``"ADENS"``, ``"MDENS"``, and
+        ``"INH_TOX"``. If not provided, pulls from
+        ``depletion.materialVariables`` setting.
     metadataKeys : list of string, optional
         Metadata fields to pull from the file. List can contain
         zero or more of the following strings: ``"ZAI"``, ``"NAMES"``,
@@ -195,7 +200,12 @@ class DepletionReader(DepPlotMixin, MaterialReader):
         corresponding data, e.g. ``'zai'``: [list of zai numbers]"""
 
     def __init__(
-        self, filePath, materials=None, metadataKeys=None, processTotal=None
+        self,
+        filePath,
+        materials=None,
+        materialVariables=None,
+        metadataKeys=None,
+        processTotal=None,
     ):
         MaterialReader.__init__(self, filePath, "depletion")
         if metadataKeys is not None:
@@ -204,6 +214,8 @@ class DepletionReader(DepPlotMixin, MaterialReader):
             self.settings["materials"] = materials
         if processTotal is not None:
             self.settings["processTotal"] = processTotal
+        if materialVariables is not None:
+            self.settings["materialVariables"] = materialVariables
         patterns = self.settings["materials"] or [".*"]
         # match all materials if nothing given
         self._matPatterns = [re.compile(mat) for mat in patterns]

--- a/src/serpentTools/parsers/depletion.py
+++ b/src/serpentTools/parsers/depletion.py
@@ -159,6 +159,9 @@ class DepletionReader(DepPlotMixin, MaterialReader):
         zero or more of the following strings: ``"ZAI"``, ``"NAMES"``,
         ``"DAYS",`` and ``"BU"`` (case sensitive). If not provided,
         pulls from ``depletion.metadataKeys`` setting
+    processTotal : bool, optional
+        Flag to process the ``TOTAL`` data section or not. If not given,
+        pulls from the ``depletion.processTotal`` setting.
 
     Attributes
     ----------
@@ -191,12 +194,16 @@ class DepletionReader(DepPlotMixin, MaterialReader):
         Dictionary with file-wide data names as keys and the
         corresponding data, e.g. ``'zai'``: [list of zai numbers]"""
 
-    def __init__(self, filePath, materials=None, metadataKeys=None):
+    def __init__(
+        self, filePath, materials=None, metadataKeys=None, processTotal=None
+    ):
         MaterialReader.__init__(self, filePath, "depletion")
         if metadataKeys is not None:
             self.settings["metadataKeys"] = metadataKeys
         if materials is not None:
             self.settings["materials"] = materials
+        if processTotal is not None:
+            self.settings["processTotal"] = processTotal
         patterns = self.settings["materials"] or [".*"]
         # match all materials if nothing given
         self._matPatterns = [re.compile(mat) for mat in patterns]

--- a/src/serpentTools/parsers/depletion.py
+++ b/src/serpentTools/parsers/depletion.py
@@ -147,6 +147,13 @@ class DepletionReader(DepPlotMixin, MaterialReader):
     ----------
     filePath: str
         path to the depletion file
+    materials : list of string, optional
+        Names and patterns to use when determining if a material found
+        in the file should be processed or not. ``["fuel"]`` will
+        result in only the material exactly named ``fuel`` to be processed.
+        But ``["fuel.*"]`` is a pattern that will match and collect any
+        material that begins with ``fuel``. If not provided,
+        pulls from ``depletion.materials`` setting.
     metadataKeys : list of string, optional
         Metadata fields to pull from the file. List can contain
         zero or more of the following strings: ``"ZAI"``, ``"NAMES"``,
@@ -184,10 +191,12 @@ class DepletionReader(DepPlotMixin, MaterialReader):
         Dictionary with file-wide data names as keys and the
         corresponding data, e.g. ``'zai'``: [list of zai numbers]"""
 
-    def __init__(self, filePath, metadataKeys=None):
+    def __init__(self, filePath, materials=None, metadataKeys=None):
         MaterialReader.__init__(self, filePath, "depletion")
         if metadataKeys is not None:
             self.settings["metadataKeys"] = metadataKeys
+        if materials is not None:
+            self.settings["materials"] = materials
         patterns = self.settings["materials"] or [".*"]
         # match all materials if nothing given
         self._matPatterns = [re.compile(mat) for mat in patterns]

--- a/src/serpentTools/parsers/depletion.py
+++ b/src/serpentTools/parsers/depletion.py
@@ -147,6 +147,11 @@ class DepletionReader(DepPlotMixin, MaterialReader):
     ----------
     filePath: str
         path to the depletion file
+    metadataKeys : list of string, optional
+        Metadata fields to pull from the file. List can contain
+        zero or more of the following strings: ``"ZAI"``, ``"NAMES"``,
+        ``"DAYS",`` and ``"BU"`` (case sensitive). If not provided,
+        pulls from ``depletion.metadataKeys`` setting
 
     Attributes
     ----------
@@ -170,6 +175,7 @@ class DepletionReader(DepPlotMixin, MaterialReader):
         of this reader
 
     """
+
     docAttrs = """materials: dict
         Dictionary with material names as keys and the corresponding
         :py:class:`~serpentTools.objects.materials.DepletedMaterial` class
@@ -178,9 +184,11 @@ class DepletionReader(DepPlotMixin, MaterialReader):
         Dictionary with file-wide data names as keys and the
         corresponding data, e.g. ``'zai'``: [list of zai numbers]"""
 
-    def __init__(self, filePath):
-        MaterialReader.__init__(self, filePath, 'depletion')
-        patterns = self.settings['materials'] or ['.*']
+    def __init__(self, filePath, metadataKeys=None):
+        MaterialReader.__init__(self, filePath, "depletion")
+        if metadataKeys is not None:
+            self.settings["metadataKeys"] = metadataKeys
+        patterns = self.settings["materials"] or [".*"]
         # match all materials if nothing given
         self._matPatterns = [re.compile(mat) for mat in patterns]
         DepPlotMixin.__init__(self)

--- a/src/serpentTools/parsers/depletion.py
+++ b/src/serpentTools/parsers/depletion.py
@@ -154,19 +154,30 @@ class DepletionReader(DepPlotMixin, MaterialReader):
         But ``["fuel.*"]`` is a pattern that will match and collect any
         material that begins with ``fuel``. If not provided,
         pulls from ``depletion.materials`` setting.
+
+        .. versionadded:: 0.11.0
+
     materialVariables : list of string, optional
         Names of variables to pull for each processed material. List can
         contain zero or more entries like ``"ADENS"``, ``"MDENS"``, and
         ``"INH_TOX"``. If not provided, pulls from
         ``depletion.materialVariables`` setting.
+
+        .. versionadded:: 0.11.0
+
     metadataKeys : list of string, optional
         Metadata fields to pull from the file. List can contain
         zero or more of the following strings: ``"ZAI"``, ``"NAMES"``,
         ``"DAYS",`` and ``"BU"`` (case sensitive). If not provided,
         pulls from ``depletion.metadataKeys`` setting
+
+        .. versionadded:: 0.11.0
+
     processTotal : bool, optional
         Flag to process the ``TOTAL`` data section or not. If not given,
         pulls from the ``depletion.processTotal`` setting.
+
+        .. versionadded:: 0.11.0
 
     Attributes
     ----------

--- a/tests/test_depletion.py
+++ b/tests/test_depletion.py
@@ -441,19 +441,24 @@ def test_defaultSettings():
     """Test behavior of settings if no additional arguments given"""
     r = DepletionReader(DEP_FILE_PATH)
     assert r.settings["metadataKeys"] == ["ZAI", "NAMES", "DAYS", "BU"]
+    assert r.settings["materials"] == []
 
 
 def test_simpleOverloadSettings():
     """Test overwritting some settings and the behavior"""
     base = DepletionReader(DEP_FILE_PATH)
     base.read()
-    alt = DepletionReader(DEP_FILE_PATH, metadataKeys=["ZAI"])
+    alt = DepletionReader(
+        DEP_FILE_PATH,
+        materials=["f.*"],
+        metadataKeys=["ZAI"],
+    )
     alt.read()
     assert set(alt.metadata) == {
         "zai",
     }
     assert alt.zais == base.zais
-    assert set(alt.materials) == set(base.materials)
+    assert set(alt.materials) == {"fuel", "total"}
     assert alt.days is None
     assert alt.burnup is None
     assert alt.names is None

--- a/tests/test_depletion.py
+++ b/tests/test_depletion.py
@@ -442,6 +442,7 @@ def test_defaultSettings():
     r = DepletionReader(DEP_FILE_PATH)
     assert r.settings["metadataKeys"] == ["ZAI", "NAMES", "DAYS", "BU"]
     assert r.settings["materials"] == []
+    assert r.settings["processTotal"]
 
 
 def test_simpleOverloadSettings():
@@ -452,13 +453,17 @@ def test_simpleOverloadSettings():
         DEP_FILE_PATH,
         materials=["f.*"],
         metadataKeys=["ZAI"],
+        processTotal=False,
     )
+    assert not alt.settings["processTotal"]
     alt.read()
     assert set(alt.metadata) == {
         "zai",
     }
     assert alt.zais == base.zais
-    assert set(alt.materials) == {"fuel", "total"}
+    assert set(alt.materials) == {
+        "fuel",
+    }
     assert alt.days is None
     assert alt.burnup is None
     assert alt.names is None

--- a/tests/test_depletion.py
+++ b/tests/test_depletion.py
@@ -2,11 +2,11 @@
 
 from unittest import TestCase
 from os import remove
+from io import BytesIO
 
 from numpy import array
 from numpy.testing import assert_equal
 
-from io import BytesIO
 from serpentTools.data import getFile
 from serpentTools.settings import rc
 from serpentTools.parsers.depletion import (

--- a/tests/test_depletion.py
+++ b/tests/test_depletion.py
@@ -1,4 +1,5 @@
 """Test the depletion file."""
+
 from unittest import TestCase
 from os import remove
 
@@ -434,3 +435,25 @@ class DepMatlabExportNoConverter(DepMatlabExportHelper):
 
 
 del DepMatlabExportHelper
+
+
+def test_defaultSettings():
+    """Test behavior of settings if no additional arguments given"""
+    r = DepletionReader(DEP_FILE_PATH)
+    assert r.settings["metadataKeys"] == ["ZAI", "NAMES", "DAYS", "BU"]
+
+
+def test_simpleOverloadSettings():
+    """Test overwritting some settings and the behavior"""
+    base = DepletionReader(DEP_FILE_PATH)
+    base.read()
+    alt = DepletionReader(DEP_FILE_PATH, metadataKeys=["ZAI"])
+    alt.read()
+    assert set(alt.metadata) == {
+        "zai",
+    }
+    assert alt.zais == base.zais
+    assert set(alt.materials) == set(base.materials)
+    assert alt.days is None
+    assert alt.burnup is None
+    assert alt.names is None

--- a/tests/test_depletion.py
+++ b/tests/test_depletion.py
@@ -6,6 +6,7 @@ from io import BytesIO
 
 from numpy import array
 from numpy.testing import assert_equal
+import pytest
 
 from serpentTools.data import getFile
 from serpentTools.settings import rc
@@ -443,6 +444,7 @@ def test_defaultSettings():
     assert r.settings["metadataKeys"] == ["ZAI", "NAMES", "DAYS", "BU"]
     assert r.settings["materials"] == []
     assert r.settings["processTotal"]
+    assert r.settings["materialVariables"] == []
 
 
 def test_simpleOverloadSettings():
@@ -452,6 +454,7 @@ def test_simpleOverloadSettings():
     alt = DepletionReader(
         DEP_FILE_PATH,
         materials=["f.*"],
+        materialVariables=["ADENS", "INH_TOX"],
         metadataKeys=["ZAI"],
         processTotal=False,
     )
@@ -464,6 +467,10 @@ def test_simpleOverloadSettings():
     assert set(alt.materials) == {
         "fuel",
     }
+    fuel = alt["fuel"]
+    assert set(fuel.data) == {"adens", "inhTox"}
+    assert fuel["adens"] == pytest.approx(base["fuel"]["adens"])
+    assert fuel["inhTox"] == pytest.approx(base["fuel"]["inhTox"])
     assert alt.days is None
     assert alt.burnup is None
     assert alt.names is None


### PR DESCRIPTION
Not really a deprecation **yet** but this is my first step into #339. The depletion reader can be fully configured at construction like
```python
r = DepletionReader(
    "case_dep.m",
    materials=["f.*"],
    materialVariables=["ADENS", "INH_TOX"],
    metadataKeys=["NAMES", "DAYS"]],
    processTotal=False,
)
r.read()
```
All of the arguments are optional, defaulting to `None`. If not given, the values in the `rc` global settings object is used.

Starting small because I want to get buy in from @DanKotlyar and other users before applying this approach to all the readers.

Current plan roll out (to be re-posted into #339) is
1. next release : each reader can be fully configured at construction. `rc` unchanged
2. +1 major release : setting any value in the `rc` object raises a deprecation warning. transition tests away from using `rc` in favor of direct construction
3. +3 major releases : remove the `rc` object from the code base

This should give enough time for users to update their applications to move away from the `rc` object

Make sure you have read over the developer guide to ease
the review process. These include:

- [x] PR fits the [project scope](http://serpent-tools.readthedocs.io/en/latest/develop/contributing.html#project-scope)
- [x] Code to be committed is [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) and matches the [code style](http://serpent-tools.readthedocs.io/en/latest/develop/codestyle.html#code-style) of the project
- [x] New and/or changed features are [well documented](http://serpent-tools.readthedocs.io/en/latest/develop/documentation.html#documentation) and have adequate testing
- [x] For first-time contributors, you have included your attribution in [`docs/contributors.rst`](https://github.com/CORE-GATECH-GROUP/serpent-tools/blob/develop/docs/contributors.rst)

## TODO
- [x] Add something to the changelog (0.11.0?)
- [x] Add a `versionadded` tag in the docstrings for these parameters