### PR TITLE
ENH: Support providing detector names at construction

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,6 +13,8 @@ Changelog
 
 * Depletion reader settings can be provided at construction - :pull:`516`
 * Support ``numpy`` 2.0 - :pull:`524`
+* Names of detectors to read can be provided at construction of the detector
+  reader - :pull:`519`
 
 .. _v0.10.1:
 

--- a/src/serpentTools/parsers/detector.py
+++ b/src/serpentTools/parsers/detector.py
@@ -19,6 +19,9 @@ class DetectorReader(BaseReader):
     ----------
     filePath : str
         path to the depletion file
+    names : list of string, optional
+        Names of any detectors to process. If not given, fall back
+        to the ``detector.names``.
 
     Attributes
     ----------
@@ -31,9 +34,11 @@ class DetectorReader(BaseReader):
     # Update this if new detector grids are introduced
     _KNOWN_GRIDS = ("E", "X", "Y", "Z", "T", "COORD", "R", "PHI", "THETA")
 
-    def __init__(self, filePath):
-        BaseReader.__init__(self, filePath, 'detector')
+    def __init__(self, filePath, names=None):
+        BaseReader.__init__(self, filePath, "detector")
         self.detectors = {}
+        if names is not None:
+            self.settings["names"] = names
 
     def __getitem__(self, name):
         """Retrieve a detector from :attr:`detectors`"""

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -7,7 +7,7 @@ from collections import OrderedDict
 
 from numpy import arange, array
 from numpy.testing import assert_equal
-from serpentTools.parsers import read
+from serpentTools.parsers import read, DetectorReader
 from serpentTools.data import getFile
 from serpentTools.detectors import (
     CartesianDetector, HexagonalDetector, CylindricalDetector)
@@ -336,3 +336,18 @@ class TimeBinnedDetectorTester(TestCase):
         assert_equal(self.timeDet.tallies, expTallies)
         assert_equal(self.timeDet.errors, expErrors)
         assert_equal(self.timeDet.grids['T'], expTimeGrid)
+
+
+def test_defaultSettings():
+     fp = getFile("ref_det0.m")
+     reader = DetectorReader(fp)
+     assert reader.settings["names"] == []
+
+
+def test_filteredInitSettings():
+    fp = getFile("bwr_det0.m")
+    reader = DetectorReader(fp, names=["spectrum"])
+    assert reader.settings["names"] == ["spectrum"]
+    reader.read()
+    assert len(reader) == 1
+    assert "spectrum" in reader


### PR DESCRIPTION
Names of detectors can be provided when building a `DetectorReader`

Related to #339
