### PR TITLE
ENH Support numpy 2

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,6 +12,7 @@ Changelog
 ======
 
 * Depletion reader settings can be provided at construction - :pull:`516`
+* Support ``numpy`` 2.0 - :pull:`524`
 
 .. _v0.10.1:
 

--- a/src/serpentTools/parsers/depmatrix.py
+++ b/src/serpentTools/parsers/depmatrix.py
@@ -3,7 +3,7 @@ Improved processing of depletion matrix files
 """
 import re
 
-from numpy import empty, empty_like, longfloat, zeros
+from numpy import empty, empty_like, longdouble, zeros
 
 from serpentTools.parsers.base import BaseReader, SparseReaderMixin
 from serpentTools.messages import SerpentToolsException
@@ -98,7 +98,7 @@ class DepmtxReader(BaseReader, SparseReaderMixin):
             match = self._getMatch(line, NDENS_REGEX, 'n0 vector')
             line = _parseIsoBlock(stream, tempN0, match, line, NDENS_REGEX)
             numIso = len(tempN0)
-            self.n0 = empty(numIso, dtype=longfloat)
+            self.n0 = empty(numIso, dtype=longdouble)
             for index in range(numIso):
                 self.n0[index] = tempN0.pop(index)
 
@@ -120,13 +120,13 @@ class DepmtxReader(BaseReader, SparseReaderMixin):
             _parseIsoBlock(stream, self.n1, match, line, NDENS_REGEX)
 
     def __processDenseMatrix(self, stream, matrixSize):
-        self.depmtx = zeros(matrixSize, dtype=longfloat)
+        self.depmtx = zeros(matrixSize, dtype=longdouble)
         line = stream.readline()
         match = self._getMatch(line, DEPMTX_REGEX, 'depletion matrix')
         while match:
             row, col = [int(xx) - 1 for xx in match.groups()[:2]]
-            value = longfloat(match.groups()[2])
-            self.depmtx[row, col] = longfloat(value)
+            value = longdouble(match.groups()[2])
+            self.depmtx[row, col] = longdouble(value)
             line = stream.readline()
             match = DEPMTX_REGEX.search(line)
         return line
@@ -136,11 +136,11 @@ class DepmtxReader(BaseReader, SparseReaderMixin):
         from serpentTools.parsers.base import CSCStreamProcessor
 
         cscProcessor = CSCStreamProcessor(
-            stream, DEPMTX_REGEX, longfloat)
+            stream, DEPMTX_REGEX, longdouble)
         line = cscProcessor.process()
         self.depmtx = csc_matrix(
             (cscProcessor.data[:, 0], cscProcessor.indices,
-             cscProcessor.indptr), dtype=longfloat, shape=matrixSize)
+             cscProcessor.indptr), dtype=longdouble, shape=matrixSize)
 
         return line
 

--- a/src/serpentTools/utils/compare.py
+++ b/src/serpentTools/utils/compare.py
@@ -3,10 +3,9 @@ Comparison utilities
 """
 from collections.abc import Iterable
 
-from numpy.core.defchararray import equal as charEqual
 from numpy import (
     fabs, zeros_like, ndarray, array, greater, multiply, subtract,
-    equal, asarray,
+    equal, asarray, char
 )
 
 from serpentTools.messages import (
@@ -190,8 +189,8 @@ def directCompare(obj0, obj1, lower, upper):
 def _directCompareIdentical(obj0, obj1):
     """Compare arrays that should be identical"""
     # special case for strings
-    if obj0.dtype.name[:3] == 'str':
-        compArray = charEqual(obj0, obj1)
+    if obj0.dtype.name.startswith("str"):
+        compArray = char.equal(obj0, obj1)
     else:
         compArray = equal(obj0, obj1)
     if compArray.all():

--- a/tests/test_depmtx.py
+++ b/tests/test_depmtx.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 
-from numpy import array, longfloat, subtract, matrix
+from numpy import array, longdouble, subtract, matrix
 from numpy.testing import assert_array_equal
 
 from serpentTools.data import getFile
@@ -92,7 +92,7 @@ class DepmtxTestHelper(TestCase):
         2.108367055387284252194156353166E-07,
         9.841801952371811001202615665146E-12,
         8.052266563002563381135156316475E-16,
-    ], dtype=longfloat)
+    ], dtype=longdouble)
     REF_ZAI = array([
         -1, 10010, 10020, 10030, 20030, 20040, 30060, 30070, 40090, 50100,
         50110, 60120, 70140, 70150, 80160, 80170, 561380, 561400, 581380,
@@ -179,7 +179,7 @@ class DepmtxTestHelper(TestCase):
         2.108922382983142802931309477132E-07,
         9.823435767284427578223342980928E-12,
         8.030354784613487489140522453118E-16,
-    ], dtype=longfloat)
+    ], dtype=longdouble)
 
     # Values for comparing depletion matrix
     # Taking the first and last N_MTX values
@@ -236,7 +236,7 @@ class DepmtxTestHelper(TestCase):
         2.166500765256806589294628619590E-14,
         8.673595631793918327440743302798E-12,
         -3.205752291225075667717126458572E-09,
-    ], dtype=longfloat)
+    ], dtype=longdouble)
 
     def test_vectors_deltaT(self):
         """Verify the isotopics are stored correctly."""

--- a/tests/test_engines.py
+++ b/tests/test_engines.py
@@ -12,7 +12,7 @@ from io import StringIO
 
 import re
 from numpy.testing import assert_array_equal, assert_allclose
-from numpy import longfloat, array, dtype
+from numpy import longdouble, array, dtype
 
 from serpentTools.parsers.base import CSCStreamProcessor
 
@@ -90,9 +90,9 @@ class FloatProcessor(object):
     datatype = float
 
 
-class LongFloatProcessor(object):
+class longdoubleProcessor(object):
     """Class that stores data as long floats."""
-    datatype = longfloat
+    datatype = longdouble
 
 
 class CaseOneStringFloatTester(
@@ -102,10 +102,10 @@ class CaseOneStringFloatTester(
     """
 
 
-class CaseOneStringLongfloatTester(
-        CSCStreamTester, CaseOneStringBasedProcessor, LongFloatProcessor):
+class CaseOneStringlongdoubleTester(
+        CSCStreamTester, CaseOneStringBasedProcessor, longdoubleProcessor):
     """
-    Class that reads the first case with string-regex and stores longfloats.
+    Class that reads the first case with string-regex and stores longdoubles.
     """
 
 
@@ -116,10 +116,10 @@ class CaseTwoStringFloatTester(
     """
 
 
-class CaseTwoStringLongfloatTester(
-        CSCStreamTester, CaseTwoStringBasedProcessor, LongFloatProcessor):
+class CaseTwoStringlongdoubleTester(
+        CSCStreamTester, CaseTwoStringBasedProcessor, longdoubleProcessor):
     """
-    Class that reads the second case with string-regex and stores longfloats.
+    Class that reads the second case with string-regex and stores longdoubles.
     """
 
 
@@ -130,10 +130,10 @@ class CaseOneRegexFloatTester(
     """
 
 
-class CaseOneRegexLongfloatTester(
-        CSCStreamTester, CaseOneRegexBasedProcessor, LongFloatProcessor):
+class CaseOneRegexlongdoubleTester(
+        CSCStreamTester, CaseOneRegexBasedProcessor, longdoubleProcessor):
     """
-    Class that reads the first case with compiled regex and stores longfloats.
+    Class that reads the first case with compiled regex and stores longdoubles.
     """
 
 
@@ -144,10 +144,10 @@ class CaseTwoRegexFloatTester(
     """
 
 
-class CaseTwoRegexLongfloatTester(
-        CSCStreamTester, CaseTwoRegexBasedProcessor, LongFloatProcessor):
+class CaseTwoRegexlongdoubleTester(
+        CSCStreamTester, CaseTwoRegexBasedProcessor, longdoubleProcessor):
     """
-    Class that reads the second case with compiled regex and stores longfloats.
+    Class that reads the second case with compiled regex and stores longdoubles.
     """
 
 


### PR DESCRIPTION
Fixes #515 

Uses longdouble over longfloat which was removed in numpy 2.0

Also transition from `numpy.core.defchararray` to `numpy.char` for the few string array comparisons we do. Eventually we'll want to use `numpy.string` to get future updates - https://numpy.org/doc/stable/reference/routines.char.html#module-numpy.char

> This submodule (`numpy.char`) is considered legacy and will no longer receive updates. This could also mean it will be removed in future NumPy versions. The string operations in this module, as well as the [numpy.char.chararray](https://numpy.org/doc/stable/reference/generated/numpy.char.chararray.html#numpy.char.chararray) class, are planned to be deprecated in the future. Use [numpy.strings](https://numpy.org/doc/stable/reference/routines.strings.html#module-numpy.strings) instead.

Make sure you have read over the developer guide to ease
the review process. These include:

- [x] PR fits the [project scope](http://serpent-tools.readthedocs.io/en/latest/develop/contributing.html#project-scope)
- [x] Code to be committed is [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) and matches the [code style](http://serpent-tools.readthedocs.io/en/latest/develop/codestyle.html#code-style) of the project
- [x] New and/or changed features are [well documented](http://serpent-tools.readthedocs.io/en/latest/develop/documentation.html#documentation) and have adequate testing
- [x] For first-time contributors, you have included your attribution in [`docs/contributors.rst`](https://github.com/CORE-GATECH-GROUP/serpent-tools/blob/develop/docs/contributors.rst)