### PR TITLE
[CI] Bump deprecated github action for uploading artifacts

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -54,7 +54,7 @@ jobs:
 
       -
         name: artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()  # only if the previous step failed
         with:
             name: test-images-${{ matrix.python-version }}

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -32,7 +32,7 @@ This is a bug fix release to fix installing the package.
 Users should experience no changes. Developer should note
 that the package has moved from a "flat-layout" to a "src-layout",
 where the code the the package has moved from ``serpentTools``
-to ``src/serpentTools``Commit
+to ``src/serpentTools``
 
 * Move from "flat-layout" to "src-layout" - :pull:`506`
 


### PR DESCRIPTION
See https://github.com/CORE-GATECH-GROUP/serpent-tools/actions/runs/13149550841/job/36694430297


- [x] PR fits the [project scope](http://serpent-tools.readthedocs.io/en/latest/develop/contributing.html#project-scope)
- [x] Code to be committed is [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) and matches the [code style](http://serpent-tools.readthedocs.io/en/latest/develop/codestyle.html#code-style) of the project
- [x] New and/or changed features are [well documented](http://serpent-tools.readthedocs.io/en/latest/develop/documentation.html#documentation) and have adequate testing
- [x] For first-time contributors, you have included your attribution in [`docs/contributors.rst`](https://github.com/CORE-GATECH-GROUP/serpent-tools/blob/develop/docs/contributors.rst)

Include a thorough and concise overview of the changes, and why this PR is overall beneficial to the project.

Once the PR has been created and is nearing closure, make sure that serious changes, including deprecations and incompatible changes are documented in [the changelog](https://github.com/CORE-GATECH-GROUP/serpent-tools/blob/develop/docs/changelog.rst)
