### PR TITLE
BUG Remove distutils

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
 "Bug Tracker" = "https://github.com/CORE-GATECH-GROUP/serpent-tools/issues"
 
 [project.optional-dependencies]
-extras = ["pandas>1", "scipy"]
+extras = ["pandas>1", "scipy>1.0"]
 test = ["pytest>=8", "pytest-cov", "coverage"]
 ci = ["jupyter"]
 

--- a/src/serpentTools/io/base.py
+++ b/src/serpentTools/io/base.py
@@ -3,7 +3,6 @@ Classes for converting readers and containers to other data types
 """
 
 from abc import ABC, abstractmethod
-from serpentTools.utils import checkScipy
 
 __all__ = [
     'MatlabConverter',
@@ -65,11 +64,6 @@ class MatlabConverter(BaseConverter):
             raise NotImplementedError(
                 "Gathering method not implemented for {}."
                 .format(container.__class__.__name__))
-
-    def checkImports(self):
-        """Ensure that :term:`scipy` >= 1.0 is installed."""
-        if not checkScipy('1.0'):
-            raise ImportError("scipy >= 1.0 required")
 
     def convert(self, reconvert, append=True, format='5', longNames=True,
                 compress=True, oned='row'):

--- a/src/serpentTools/parsers/base.py
+++ b/src/serpentTools/parsers/base.py
@@ -13,7 +13,13 @@ from numpy import array
 from serpentTools.messages import info
 from serpentTools.settings import rc
 from serpentTools.objects.base import BaseObject
-from serpentTools.utils import checkScipy
+
+try:
+    import scipy
+
+    _HAS_SCIPY = True
+except ImportError:
+    _HAS_SCIPY = False
 
 
 class BaseReader(ABC, BaseObject):
@@ -135,10 +141,9 @@ class SparseReaderMixin(object):
     """
 
     def __init__(self, sparse):
-        HAS_SCIPY = checkScipy()
         if sparse is None:
-            self.__sparse = HAS_SCIPY
-        elif sparse is True and not HAS_SCIPY:
+            self.__sparse = _HAS_SCIPY
+        elif sparse and not _HAS_SCIPY:
             raise ImportError(
                 "scipy not installed and required for sparse support")
         else:

--- a/src/serpentTools/utils/__init__.py
+++ b/src/serpentTools/utils/__init__.py
@@ -1,20 +1,8 @@
 """
 Commonly used functions and utilities
 """
-from distutils.version import StrictVersion
-
 from serpentTools.utils.core import *  # noqa
 from serpentTools.utils.docstrings import *  # noqa
 from serpentTools.utils.compare import *  # noqa
 from serpentTools.utils.plot import *  # noqa
 
-
-def checkScipy(version=None):
-    """Return ``True`` if the given version of :term:`scipy` is installed"""
-    try:
-        import scipy
-    except ImportError:
-        return False
-    if version is None:
-        return True
-    return StrictVersion(scipy.__version__) >= StrictVersion(version)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -10,7 +10,6 @@ from numpy.testing import assert_allclose
 from serpentTools.messages import (
     DictHandler, __logger__, removeHandler, addHandler,
 )
-from serpentTools.utils import checkScipy
 
 
 def computeMeansErrors(*arrays):
@@ -249,7 +248,12 @@ class TestCaseWithLogCapture(TestCase, LoggerMixin):
                          msg=failMsg.format(matchType, msg, level))
 
 
-HAS_SCIPY = checkScipy('1.0')
+try:
+    import scipy
+
+    HAS_SCIPY = True
+except ImportError:
+    HAS_SCIPY = False
 
 
 class MatlabTesterHelper(TestCase):


### PR DESCRIPTION
Really only needed to guard against scipy < 1.0 which has been out since 2017

Closes #527 