### PR TITLE
fix: skip extra header lines in depmtx reader (Serpent 2.2.3+)

### DIFF
--- a/src/serpentTools/parsers/depmatrix.py
+++ b/src/serpentTools/parsers/depmatrix.py
@@ -94,7 +94,12 @@ class DepmtxReader(BaseReader, SparseReaderMixin):
             self.deltaT = float(line.split()[-1][:-1])
 
             # process initial isotopics
+            # Serpent 2.2.3+ with ``set depmtx 1`` emits extra scalar lines
+            # (e.g. ``flx = 2;``, ``N0 = zeros(n, 1);``) between the time
+            # header and the first isotope entry. Advance past them.
             line = stream.readline()
+            while line and not NDENS_REGEX.search(line):
+                line = stream.readline()
             match = self._getMatch(line, NDENS_REGEX, 'n0 vector')
             line = _parseIsoBlock(stream, tempN0, match, line, NDENS_REGEX)
             numIso = len(tempN0)

--- a/tests/test_depmtx.py
+++ b/tests/test_depmtx.py
@@ -324,3 +324,30 @@ class SparseReadDepmtxFuncTester(ReadDepmtxFuncTesterBase, DenseTesterMixin):
 
 
 del DepmtxTestHelper, DepmtxReaderTesterBase, ReadDepmtxFuncTesterBase
+
+
+def test_depmtx_extra_header_lines(tmp_path):
+    """Serpent 2.2.3 with ``set depmtx 1`` emits extra scalar/declaration
+    lines (e.g. ``flx = 2;``, ``N0 = zeros(n, 1);``) immediately after the
+    time header and before the N0 isotope data.  The reader must skip these
+    and still parse the file correctly.  Regression test for issue #533.
+    """
+    ref_text = open(TEST_FILE).read()
+    # Insert extra lines after the first line (t = ...)
+    first_line, rest = ref_text.split('\n', 1)
+    extra = 'flx =  2;\nN0 = zeros(74, 1);\n'
+    modified_text = first_line + '\n' + extra + rest
+
+    modified_file = tmp_path / "depmtx_extra.m"
+    modified_file.write_text(modified_text)
+
+    reader_ref = DepmtxReader(TEST_FILE, sparse=False)
+    reader_ref.read()
+
+    reader_mod = DepmtxReader(str(modified_file), sparse=False)
+    reader_mod.read()
+
+    assert_array_equal(reader_mod.n0, reader_ref.n0)
+    assert_array_equal(reader_mod.n1, reader_ref.n1)
+    assert_array_equal(reader_mod.zai, reader_ref.zai)
+    assert reader_mod.deltaT == reader_ref.deltaT


### PR DESCRIPTION
## Summary

Serpent 2.2.3 with `set depmtx 1` writes additional scalar and matrix declaration lines between the time header and the N0 isotope data, for example:

```
t = 4.32E4;
flx =  2;             ← new in Serpent 2.2.3
N0 = zeros(74, 1);    ← new in Serpent 2.2.3
N0(  1, 1) =  1.17E-07; % lost
...
```

The current reader immediately tries to match the line after `t = ...` as an N0 entry and raises:

```
SerpentToolsException: Depmtx reader failed to match n0 vector from ...:
flx =  2;
```

## Fix

In `DepmtxReader._read`, advance past any lines that do not match `NDENS_REGEX` before starting to parse the N0 block. The change is backward-compatible: files without extra lines are parsed identically.

## Test

Added `test_depmtx_extra_header_lines` which prepends `flx` and `N0 = zeros` declarations to the existing `depmtx_ref.m` fixture and verifies the parsed arrays exactly match the unmodified reference reader.

Fixes #533

Signed-off-by: Mike German <mike@stepsventures.com>