### PR TITLE
fix: NumPy 2.0 compatibility for scalar metadata / fission-yield conversion

### DIFF
--- a/src/serpentTools/parsers/microxs.py
+++ b/src/serpentTools/parsers/microxs.py
@@ -124,12 +124,12 @@ class MicroXSReader(BaseReader):
         fissProd, indYield, cumYield = [], [], []
         currVar = FIRST_WORD_REGEX.search(chunk[0]).group()  # NFY_902270_1
         # Obtain the parent ID: AAZZZ0/1, e.g., 922350
-        parentFY = int(str2vec(currVar.split('_')[-2]))
+        parentFY = int(str2vec(currVar.split('_')[-2]).item())
         if 'E' in currVar.split('_')[-1]:  # e.g., NFY_902270_1E
             sclVal = SCALAR_REGEX.search(chunk[0])
             # energy must be stored on the reader
             self._energyFY = float(str2vec(
-                chunk[0][sclVal.span()[0] + 1:sclVal.span()[1] - 2]))
+                chunk[0][sclVal.span()[0] + 1:sclVal.span()[1] - 2]).item())
             return  # thermal/epi/fast
         for tline in chunk:
             if '[' in tline or ']' in tline:
@@ -245,8 +245,8 @@ class MicroXSReader(BaseReader):
         IndYield = self.nfy[(parent, energy)]['indYield']
         CumYield = self.nfy[(parent, energy)]['cumYield']
         if daughter in FP:
-            return (float(IndYield[FP == daughter]),
-                    float(CumYield[FP == daughter]))
+            return (float(IndYield[FP == daughter].item()),
+                    float(CumYield[FP == daughter].item()))
         raise SerpentToolsException(
             "There is no fission product {0} for parent {1} at energy {2} in "
             "{3}".format(daughter, parent, energy, self.filePath))

--- a/src/serpentTools/parsers/results.py
+++ b/src/serpentTools/parsers/results.py
@@ -3,7 +3,7 @@ from collections import OrderedDict
 from numbers import Real
 import re
 
-from numpy import array, empty, asarray
+from numpy import array, empty, asarray, ndarray
 from cycler import cycler
 from matplotlib import rcParams
 from matplotlib.pyplot import gca
@@ -714,7 +714,13 @@ class ResultsReader(XSReader):
         for converter, keys in METADATA_CONV.items():
             for key in keys:
                 if key in origKeys:
-                    mdata[key] = converter(mdata[key])
+                    value = mdata[key]
+                    # Serpent scalar metadata is parsed into size-1 arrays.
+                    # NumPy 2.0 removed implicit scalar conversion of non
+                    # 0-d arrays, so unwrap size-1 arrays before converting.
+                    if isinstance(value, ndarray) and value.size == 1:
+                        value = value.item()
+                    mdata[key] = converter(value)
                     origKeys.remove(key)
 
     @magicPlotDocDecorator


### PR DESCRIPTION
## Problem

CI is red on current runners across all supported Python versions. The bulk of the failures (≈53 of 58 per job) are a single root cause:

```
TypeError: only 0-dimensional arrays can be converted to Python scalars
```

The last green `main` run predates the NumPy 2.0 rollout on `ubuntu-latest`; any run today hits this. It reproduces on a clean `main` checkout with NumPy 2.5.1 / Python 3.13, so it is independent of any feature branch — it blocks every open PR's CI.

## Root cause

NumPy 2.0 removed implicit conversion of non 0-d arrays to Python scalars. Serpent scalar metadata (and single fission-yield lookups) are parsed into **size-1 arrays**, so `int(...)` / `float(...)` on them now raises. Affected sites:

- `ResultsReader._cleanMetadata` — hit by nearly every test that reads a `_res.m` file
- `MicroXSReader` fission-yield parsing (parent id, energy, and the `getFY` lookup)

## Fix

Unwrap size-1 arrays with `.item()` before converting. Behavior is unchanged on older NumPy, where `int()`/`float()` on a size-1 array already returned the scalar.

## Testing

Full suite on `main` + this fix (Python 3.13, NumPy 2.5.1, with `scipy`/`pandas` installed):

- Before: `36 failed, 29 errors`
- After: `346 passed`, **zero** scalar-conversion errors

## Not covered here

A handful of `matplotlib` image-comparison tests still fail on current runners due to baseline-PNG drift against newer matplotlib. That is a separate, pre-existing issue (unrelated to NumPy) and is intentionally left out of this PR — filed separately for maintainer triage.